### PR TITLE
add feature flag for using O_DIRECT on writes. closes #111.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 default = []
 bench = ["clap", "num_cpus", "log", "rand", "rayon", "zstd", "env_logger"]
 stress = ["docopt", "chan-signal", "rayon", "rand", "zstd"]
+o_direct_writer = []
+
+# [profile.release]
+# debug = 2
 
 [[bin]]
 name = "bench"

--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -84,8 +84,6 @@ fn main() {
     let total = Arc::new(AtomicUsize::new(0));
     let shutdown = Arc::new(AtomicBool::new(false));
 
-    let nonce: String = thread_rng().gen_ascii_chars().take(10).collect();
-    let path = format!("sled_stress_{}", nonce);
     let config = sled::Config::default()
         .io_bufs(2)
         .io_buf_size(8_000_000)
@@ -94,8 +92,8 @@ fn main() {
         .cache_bits(6)
         .cache_capacity(1_000_000)
         .flush_every_ms(Some(100))
-        .snapshot_after_ops(1000000)
-        .path(Some(path));
+        .snapshot_after_ops(1000000);
+
     let tree = Arc::new(config.tree());
 
     let mut threads = vec![];

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,7 +129,7 @@ macro_rules! builder {
 impl ConfigInner {
     builder!(
         (io_bufs, get_io_bufs, set_io_bufs, usize, "number of io buffers"),
-        (io_buf_size, get_io_buf_size, set_io_buf_size, usize, "size of each io flush buffer"),
+        (io_buf_size, get_io_buf_size, set_io_buf_size, usize, "size of each io flush buffer. MUST be multiple of 512!"),
         (blink_fanout, get_blink_fanout, set_blink_fanout, usize, "b-link node fanout, minimum of 2"),
         (page_consolidation_threshold, get_page_consolidation_threshold, set_page_consolidation_threshold, usize, "page consolidation threshold"),
         (path, get_path, set_path, String, "path for the main storage file"),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,6 +26,8 @@ pub struct Metrics {
     pub read: Histo,
     pub tree_loops: AtomicUsize,
     pub log_loops: AtomicUsize,
+    pub written_bytes: AtomicUsize,
+    pub written_padding: AtomicUsize,
 }
 
 impl Metrics {
@@ -35,6 +37,14 @@ impl Metrics {
 
     pub fn log_looped(&self) {
         self.log_loops.fetch_add(1, Relaxed);
+    }
+
+    pub fn written(&self, bytes: usize) {
+        self.written_bytes.fetch_add(bytes, Relaxed);
+    }
+
+    pub fn padded(&self, bytes: usize) {
+        self.written_padding.fetch_add(bytes, Relaxed);
     }
 
     pub fn print_profile(&self) {
@@ -121,5 +131,7 @@ impl Metrics {
             f("reserve", &self.reserve),
         ]);
         println!("log contention loops: {}", self.log_loops.load(Acquire));
+        println!("total bytes written: {}", self.written_bytes.load(Acquire));
+        println!("pad bytes written: {}", self.written_padding.load(Acquire));
     }
 }


### PR DESCRIPTION
O_DIRECT skips the OS pagecache entirely, basically doing DMA. It makes it so the OS does not cache any data in memory about files, as it normally does. This is sometimes useful if the data on disk is different from what the application actually uses (compression, serialization, etc...) and there's a userspace cache already (like what we have). A downside is you can get WORSE performance if you mix O_DIRECT and non-O_DIRECT work, and you have to align all operations to the device's specified alignment (usually 512, but sometimes not!)

This work basically gives us a quick switch to flip when we want to give it a spin!

Note that it's not correct yet, since the 512 hardcoded alignment could be different sometimes, so we need to check that dynamically in the future.