### PR TITLE
Porting to crossbeam-epoch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ version = "0.3"
 # features = ["max_level_off"]
 
 [dependencies]
-coco = "0.2"
+crossbeam-epoch = "0.1"
 bincode = "0.8"
 serde = "1.0"
 serde_derive = "1.0"

--- a/lib/neon-sled/native/src/lib.rs
+++ b/lib/neon-sled/native/src/lib.rs
@@ -9,7 +9,7 @@ use neon::js::Value;
 
 fn extract_arg(call: &mut Call, idx: i32) -> Result<String, ()> {
     let args = &call.arguments;
-    let handle = args.get(call.scope, idx).ok_or(())?;
+    let handle = args.get(call.guard, idx).ok_or(())?;
     Ok((*handle).to_string(call.scope).map_err(|_| ())?.value())
 }
 
@@ -21,7 +21,7 @@ fn create_db(mut call: Call) -> JsResult<JsString> {
 
     let ptr = Box::into_raw(Box::new(t));
     let ptr_string = format!("{}", ptr as usize);
-    Ok(JsString::new(call.scope, &*ptr_string).unwrap())
+    Ok(JsString::new(call.guard, &*ptr_string).unwrap())
 }
 
 fn cast_string_to_ptr<'a>(ptr_str: String) -> &'a sled::Tree {
@@ -51,9 +51,9 @@ fn set(mut call: Call) -> JsResult<JsString> {
     let from_db = t.get(&*k)
         .and_then(|from_db| {
             let str = unsafe { std::str::from_utf8_unchecked(&*from_db) };
-            JsString::new(call.scope, str)
+            JsString::new(call.guard, str)
         })
-        .unwrap_or_else(|| JsString::new(call.scope, "").unwrap());
+        .unwrap_or_else(|| JsString::new(call.guard, "").unwrap());
 
     Ok(from_db)
 }
@@ -70,9 +70,9 @@ fn get(mut call: Call) -> JsResult<JsString> {
     let from_db = t.get(&*k)
         .map( |from_db| {
             let str = unsafe { std::str::from_utf8_unchecked(&*from_db) };
-            JsString::new(call.scope, str).unwrap()
+            JsString::new(call.guard, str).unwrap()
         })
-        .unwrap_or_else(|| JsString::new(call.scope, "").unwrap());
+        .unwrap_or_else(|| JsString::new(call.guard, "").unwrap());
 
     Ok(from_db)
 }

--- a/src/ds/stack.rs
+++ b/src/ds/stack.rs
@@ -127,7 +127,10 @@ impl<T: Send + 'static> Stack<T> {
                         &guard,
                     ) {
                         Ok(_) => unsafe {
-                            guard.defer(move || head.into_owned());
+                            guard.defer(move || {
+                                let head: *mut Node<T> = Box::into_raw(head.into_owned().into());
+                                drop(Vec::from_raw_parts(head, 0, 1));
+                            });
                             return Some(ptr::read(&h.inner));
                         },
                         Err(h) => head = h.current,

--- a/src/io/log/segment_accountant.rs
+++ b/src/io/log/segment_accountant.rs
@@ -67,7 +67,7 @@ use std::fs::File;
 use std::sync::{Arc, Mutex};
 use std::mem;
 
-use coco::epoch::{Owned, pin};
+use epoch::{Owned, pin};
 
 use super::*;
 
@@ -607,14 +607,13 @@ impl SegmentAccountant {
         } else {
             self.ensure_safe_free_distance();
 
-            pin(|scope| {
-                let pd = Owned::new(SegmentDropper(lid, self.free.clone()));
-                let ptr = pd.into_ptr(scope);
-                unsafe {
-                    scope.defer_drop(ptr);
-                    scope.flush();
-                }
-            });
+            let guard = pin();
+            let pd = Owned::new(SegmentDropper(lid, self.free.clone()));
+            let ptr = pd.into_shared(&guard);
+            unsafe {
+                guard.defer(move || ptr.into_owned());
+                guard.flush();
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
-extern crate coco;
+extern crate crossbeam_epoch as epoch;
 extern crate bincode;
 extern crate historian;
 #[macro_use]
@@ -93,7 +93,7 @@ type Key = Vec<u8>;
 type KeyRef<'a> = &'a [u8];
 type Value = Vec<u8>;
 
-type HPtr<'s, P> = coco::epoch::Ptr<'s, ds::stack::Node<io::CacheEntry<P>>>;
+type HPtr<'g, P> = epoch::Shared<'g, ds::stack::Node<io::CacheEntry<P>>>;
 
 lazy_static! {
     /// A metric collector for all sled instances running in this

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use coco::epoch::{Scope, pin};
+use epoch::{Guard, pin};
 
 
 impl<'a> IntoIterator for &'a Tree {
@@ -38,42 +38,41 @@ impl Tree {
             debug!("recovered root {} while starting tree", root_id);
             root_id
         } else {
-            pin(|scope| {
-                let (root_id, root_cas_key) = pages.allocate(scope);
-                debug!("allocated pid {} for root of new tree", root_id);
+            let guard = pin();
+            let (root_id, root_cas_key) = pages.allocate(&guard);
+            debug!("allocated pid {} for root of new tree", root_id);
 
-                let (leaf_id, leaf_cas_key) = pages.allocate(scope);
-                trace!("allocated pid {} for leaf in new", leaf_id);
+            let (leaf_id, leaf_cas_key) = pages.allocate(&guard);
+            trace!("allocated pid {} for leaf in new", leaf_id);
 
-                let leaf = Frag::Base(
-                    Node {
-                        id: leaf_id,
-                        data: Data::Leaf(vec![]),
-                        next: None,
-                        lo: Bound::Inc(vec![]),
-                        hi: Bound::Inf,
-                    },
-                    false,
-                );
+            let leaf = Frag::Base(
+                Node {
+                    id: leaf_id,
+                    data: Data::Leaf(vec![]),
+                    next: None,
+                    lo: Bound::Inc(vec![]),
+                    hi: Bound::Inf,
+                },
+                false,
+            );
 
-                let mut root_index_vec = vec![];
-                root_index_vec.push((vec![], leaf_id));
+            let mut root_index_vec = vec![];
+            root_index_vec.push((vec![], leaf_id));
 
-                let root = Frag::Base(
-                    Node {
-                        id: root_id,
-                        data: Data::Index(root_index_vec),
-                        next: None,
-                        lo: Bound::Inc(vec![]),
-                        hi: Bound::Inf,
-                    },
-                    true,
-                );
+            let root = Frag::Base(
+                Node {
+                    id: root_id,
+                    data: Data::Index(root_index_vec),
+                    next: None,
+                    lo: Bound::Inc(vec![]),
+                    hi: Bound::Inf,
+                },
+                true,
+            );
 
-                pages.replace(root_id, root_cas_key, root, scope).unwrap();
-                pages.replace(leaf_id, leaf_cas_key, leaf, scope).unwrap();
-                root_id
-            })
+            pages.replace(root_id, root_cas_key, root, &guard).unwrap();
+            pages.replace(leaf_id, leaf_cas_key, leaf, &guard).unwrap();
+            root_id
         };
 
         Tree {
@@ -86,11 +85,10 @@ impl Tree {
     /// Retrieve a value from the `Tree` if it exists.
     pub fn get(&self, key: &[u8]) -> Option<Value> {
         let start = clock();
-        pin(|scope| {
-            let (_, ret) = self.get_internal(key, scope);
-            M.tree_get.measure(clock() - start);
-            ret
-        })
+        let guard = pin();
+        let (_, ret) = self.get_internal(key, &guard);
+        M.tree_get.measure(clock() - start);
+        ret
     }
 
     /// Compare and swap. Capable of unique creation, conditional modification,
@@ -136,8 +134,9 @@ impl Tree {
         let frag = new.map(|n| Frag::Set(key.clone(), n)).unwrap_or_else(|| {
             Frag::Del(key.clone())
         });
-        pin(|scope| loop {
-            let (mut path, cur) = self.get_internal(&*key, scope);
+        let guard = pin();
+        loop {
+            let (mut path, cur) = self.get_internal(&*key, &guard);
             if old != cur {
                 M.tree_cas.measure(clock() - start);
                 return Err(cur);
@@ -145,14 +144,14 @@ impl Tree {
 
             let &mut (ref node, ref cas_key) = path.last_mut().unwrap();
             if self.pages
-                .link(node.id, cas_key.clone(), frag.clone(), scope)
+                .link(node.id, cas_key.clone(), frag.clone(), &guard)
                 .is_ok()
             {
                 M.tree_cas.measure(clock() - start);
                 return Ok(());
             }
             M.tree_looped();
-        })
+        }
     }
 
     /// Set a key to a new value.
@@ -163,33 +162,32 @@ impl Tree {
         let start = clock();
         // println!("starting set of {:?} -> {:?}", key, value);
         let frag = Frag::Set(key.clone(), value);
-        pin(|scope| {
-            loop {
-                let mut path = self.path_for_key(&*key, scope);
-                let (mut last_node, last_cas_key) = path.pop().unwrap();
-                // println!("last before: {:?}", last);
-                if let Ok(new_cas_key) = self.pages.link(
-                    last_node.id,
-                    last_cas_key,
-                    frag.clone(),
-                    scope,
-                )
-                {
-                    last_node.apply(&frag);
-                    // println!("last after: {:?}", last);
-                    let should_split = last_node.should_split(self.fanout());
-                    path.push((last_node.clone(), new_cas_key));
-                    // success
-                    if should_split {
-                        // println!("need to split {:?}", last_node.id);
-                        self.recursive_split(&path, scope);
-                    }
-                    M.tree_set.measure(clock() - start);
-                    return;
+        let guard = pin();
+        loop {
+            let mut path = self.path_for_key(&*key, &guard);
+            let (mut last_node, last_cas_key) = path.pop().unwrap();
+            // println!("last before: {:?}", last);
+            if let Ok(new_cas_key) = self.pages.link(
+                last_node.id,
+                last_cas_key,
+                frag.clone(),
+                &guard,
+            )
+            {
+                last_node.apply(&frag);
+                // println!("last after: {:?}", last);
+                let should_split = last_node.should_split(self.fanout());
+                path.push((last_node.clone(), new_cas_key));
+                // success
+                if should_split {
+                    // println!("need to split {:?}", last_node.id);
+                    self.recursive_split(&path, &guard);
                 }
-                M.tree_looped();
+                M.tree_set.measure(clock() - start);
+                return;
             }
-        })
+            M.tree_looped();
+        }
         // println!("done set of {:?}", key);
     }
 
@@ -209,41 +207,40 @@ impl Tree {
             return None;
         }
         let start = clock();
-        pin(|scope| {
-            let mut ret: Option<Value>;
-            loop {
-                let mut path = self.path_for_key(&*key, scope);
-                let (leaf_node, leaf_cas_key) = path.pop().unwrap();
-                match leaf_node.data {
-                    Data::Leaf(ref items) => {
-                        let search = items.binary_search_by(
-                            |&(ref k, ref _v)| (**k).cmp(key),
-                        );
-                        if let Ok(idx) = search {
-                            ret = Some(items[idx].1.clone());
-                        } else {
-                            ret = None;
-                            break;
-                        }
+        let guard = pin();
+        let mut ret: Option<Value>;
+        loop {
+            let mut path = self.path_for_key(&*key, &guard);
+            let (leaf_node, leaf_cas_key) = path.pop().unwrap();
+            match leaf_node.data {
+                Data::Leaf(ref items) => {
+                    let search = items.binary_search_by(
+                        |&(ref k, ref _v)| (**k).cmp(key),
+                    );
+                    if let Ok(idx) = search {
+                        ret = Some(items[idx].1.clone());
+                    } else {
+                        ret = None;
+                        break;
                     }
-                    _ => panic!("last node in path is not leaf"),
                 }
-
-                let frag = Frag::Del(key.to_vec());
-                if self.pages
-                    .link(leaf_node.id, leaf_cas_key, frag, scope)
-                    .is_ok()
-                {
-                    // success
-                    break;
-                } else {
-                    // failure, retry
-                }
-                M.tree_looped();
+                _ => panic!("last node in path is not leaf"),
             }
-            M.tree_del.measure(clock() - start);
-            ret
-        })
+
+            let frag = Frag::Del(key.to_vec());
+            if self.pages
+                .link(leaf_node.id, leaf_cas_key, frag, &guard)
+                .is_ok()
+            {
+                // success
+                break;
+            } else {
+                // failure, retry
+            }
+            M.tree_looped();
+        }
+        M.tree_del.measure(clock() - start);
+        ret
     }
 
     /// Iterate over tuples of keys and values, starting at the provided key.
@@ -262,15 +259,14 @@ impl Tree {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn scan(&self, key: &[u8]) -> Iter {
-        pin(|scope| {
-            let (path, _) = self.get_internal(key, scope);
-            let &(ref last_node, ref _last_cas_key) = path.last().unwrap();
-            Iter {
-                id: last_node.id,
-                inner: &self.pages,
-                last_key: Bound::Non(key.to_vec()),
-            }
-        })
+        let guard = pin();
+        let (path, _) = self.get_internal(key, &guard);
+        let &(ref last_node, ref _last_cas_key) = path.last().unwrap();
+        Iter {
+            id: last_node.id,
+            inner: &self.pages,
+            last_key: Bound::Non(key.to_vec()),
+        }
     }
 
     /// Iterate over the tuples of keys and values in this tree.
@@ -290,21 +286,20 @@ impl Tree {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn iter(&self) -> Iter {
-        pin(|scope| {
-            let (path, _) = self.get_internal(b"", scope);
-            let &(ref last_node, ref _last_cas_key) = path.last().unwrap();
-            Iter {
-                id: last_node.id,
-                inner: &self.pages,
-                last_key: Bound::Non(vec![]),
-            }
-        })
+        let guard = pin();
+        let (path, _) = self.get_internal(b"", &guard);
+        let &(ref last_node, ref _last_cas_key) = path.last().unwrap();
+        Iter {
+            id: last_node.id,
+            inner: &self.pages,
+            last_key: Bound::Non(vec![]),
+        }
     }
 
-    fn recursive_split<'s>(
+    fn recursive_split<'g>(
         &self,
-        path: &[(Node, HPtr<'s, Frag>)],
-        scope: &'s Scope,
+        path: &[(Node, HPtr<'g, Frag>)],
+        guard: &'g Guard,
     ) {
         // to split, we pop the path, see if it's in need of split, recurse up
         // two-phase: (in prep for lock-free, not necessary for single threaded)
@@ -339,7 +334,7 @@ impl Tree {
                 if let Ok(parent_split) = self.child_split(
                     &node,
                     cas_key,
-                    scope,
+                    guard,
                 )
                 {
                     // now try to parent split
@@ -350,7 +345,7 @@ impl Tree {
                         parent_node.clone(),
                         parent_cas_key.clone(),
                         parent_split.clone(),
-                        scope,
+                        guard,
                     );
 
                     if let Ok(res) = res {
@@ -372,27 +367,27 @@ impl Tree {
             if let Ok(parent_split) = self.child_split(
                 &root_node,
                 root_cas_key,
-                scope,
+                guard,
             )
             {
                 self.root_hoist(
                     root_node.id,
                     parent_split.to,
                     parent_split.at.inner().unwrap(),
-                    scope,
+                    guard,
                 );
             }
         }
         // println!("after:\n{:?}\n", self);
     }
 
-    fn child_split<'s>(
+    fn child_split<'g>(
         &self,
         node: &Node,
-        node_cas_key: HPtr<'s, Frag>,
-        scope: &'s Scope,
+        node_cas_key: HPtr<'g, Frag>,
+        guard: &'g Guard,
     ) -> Result<ParentSplit, ()> {
-        let (new_pid, new_cas_key) = self.pages.allocate(scope);
+        let (new_pid, new_cas_key) = self.pages.allocate(guard);
         trace!("allocated pid {} in child_split", new_pid);
 
         // split the node in half
@@ -410,12 +405,12 @@ impl Tree {
 
         // install the new right side
         self.pages
-            .replace(new_pid, new_cas_key, Frag::Base(rhs, false), scope)
+            .replace(new_pid, new_cas_key, Frag::Base(rhs, false), guard)
             .expect("failed to initialize child split");
 
         // try to install a child split on the left side
         if self.pages
-            .link(node.id, node_cas_key, child_split, scope)
+            .link(node.id, node_cas_key, child_split, guard)
             .is_err()
         {
             // if we failed, don't follow through with the parent split
@@ -427,19 +422,19 @@ impl Tree {
         Ok(parent_split)
     }
 
-    fn parent_split<'s>(
+    fn parent_split<'g>(
         &self,
         parent_node: Node,
-        parent_cas_key: HPtr<'s, Frag>,
+        parent_cas_key: HPtr<'g, Frag>,
         parent_split: ParentSplit,
-        scope: &'s Scope,
-    ) -> Result<HPtr<'s, Frag>, Option<HPtr<'s, Frag>>> {
+        guard: &'g Guard,
+    ) -> Result<HPtr<'g, Frag>, Option<HPtr<'g, Frag>>> {
         // install parent split
         let res = self.pages.link(
             parent_node.id,
             parent_cas_key,
             Frag::ParentSplit(parent_split.clone()),
-            scope,
+            guard,
         );
 
         if res.is_err() {
@@ -449,15 +444,15 @@ impl Tree {
         res
     }
 
-    fn root_hoist<'s>(
+    fn root_hoist<'g>(
         &self,
         from: PageID,
         to: PageID,
         at: Key,
-        scope: &'s Scope,
+        guard: &'g Guard,
     ) {
         // hoist new root, pointing to lhs & rhs
-        let (new_root_pid, new_root_cas_key) = self.pages.allocate(scope);
+        let (new_root_pid, new_root_cas_key) = self.pages.allocate(guard);
         debug!("allocated pid {} in root_hoist", new_root_pid);
 
         let mut new_root_vec = vec![];
@@ -481,7 +476,7 @@ impl Tree {
         if cas == from {
             // TODO think about the racyness of this
             self.pages
-                .replace(new_root_pid, new_root_cas_key, new_root, scope)
+                .replace(new_root_pid, new_root_cas_key, new_root, guard)
                 .unwrap();
             debug!(
                 "{}: root hoist from {} to {} successful",
@@ -495,12 +490,12 @@ impl Tree {
         }
     }
 
-    fn get_internal<'s>(
+    fn get_internal<'g>(
         &self,
         key: &[u8],
-        scope: &'s Scope,
-    ) -> (Vec<(Node, HPtr<'s, Frag>)>, Option<Value>) {
-        let path = self.path_for_key(&*key, scope);
+        guard: &'g Guard,
+    ) -> (Vec<(Node, HPtr<'g, Frag>)>, Option<Value>) {
+        let path = self.path_for_key(&*key, guard);
 
         let ret = path.last().and_then(|&(ref last_node, ref _last_cas_key)| {
             let data = &last_node.data;
@@ -525,26 +520,25 @@ impl Tree {
 
     #[doc(hidden)]
     pub fn key_debug_str(&self, key: &[u8]) -> String {
-        pin(|scope| {
-            let path = self.path_for_key(key, scope);
-            let mut ret = String::new();
-            for &(ref node, _) in &path {
-                ret.push_str(&*format!("\n{:?}", node));
-            }
-            ret
-        })
+        let guard = pin();
+        let path = self.path_for_key(key, &guard);
+        let mut ret = String::new();
+        for &(ref node, _) in &path {
+            ret.push_str(&*format!("\n{:?}", node));
+        }
+        ret
     }
 
     /// returns the traversal path, completing any observed
     /// partially complete splits or merges along the way.
-    fn path_for_key<'s>(
+    fn path_for_key<'g>(
         &self,
         key: &[u8],
-        scope: &'s Scope,
-    ) -> Vec<(Node, HPtr<'s, Frag>)> {
+        guard: &'g Guard,
+    ) -> Vec<(Node, HPtr<'g, Frag>)> {
         let key_bound = Bound::Inc(key.into());
         let mut cursor = self.root.load(SeqCst);
-        let mut path: Vec<(Node, HPtr<'s, Frag>)> = vec![];
+        let mut path: Vec<(Node, HPtr<'g, Frag>)> = vec![];
 
         // unsplit_parent is used for tracking need
         // to complete partial splits.
@@ -552,7 +546,7 @@ impl Tree {
 
         let mut not_found_loops = 0;
         loop {
-            let get_cursor = self.pages.get(cursor, scope);
+            let get_cursor = self.pages.get(cursor, guard);
             if get_cursor.is_none() {
                 // restart search from the tree's root
                 not_found_loops += 1;
@@ -585,7 +579,7 @@ impl Tree {
                 // we have found the proper page for
                 // our split.
                 // println!("before: {:?}", self);
-                let &(ref parent_node, ref parent_cas_key): &(Node, HPtr<'s, Frag>) = &path[idx];
+                let &(ref parent_node, ref parent_cas_key): &(Node, HPtr<'g, Frag>) = &path[idx];
 
                 let ps = Frag::ParentSplit(ParentSplit {
                     at: node.lo.clone(),
@@ -596,7 +590,7 @@ impl Tree {
                     parent_node.id,
                     parent_cas_key.clone(),
                     ps,
-                    scope,
+                    guard,
                 );
                 // println!("trying to fix incomplete parent split: {:?}", res);
                 // println!("after: {:?}", self);
@@ -638,50 +632,48 @@ impl Debug for Tree {
         self.pages.fmt(f).unwrap();
         f.write_str("\tlevel 0:\n").unwrap();
 
-        pin(|scope| {
-            loop {
-                let (frag, _cas_key) = self.pages.get(pid, scope).unwrap();
-                let (node, _is_root) = frag.base().unwrap();
+        let guard = pin();
+        loop {
+            let (frag, _cas_key) = self.pages.get(pid, &guard).unwrap();
+            let (node, _is_root) = frag.base().unwrap();
 
-                f.write_str("\t\t").unwrap();
-                node.fmt(f).unwrap();
-                f.write_str("\n").unwrap();
+            f.write_str("\t\t").unwrap();
+            node.fmt(f).unwrap();
+            f.write_str("\n").unwrap();
 
-                if let Some(next_pid) = node.next {
-                    pid = next_pid;
-                } else {
-                    // we've traversed our level, time to bump down
-                    let (left_frag, _left_cas_key) =
-                        self.pages.get(left_most, scope).unwrap();
-                    let (left_node, _is_root) = left_frag.base().unwrap();
+            if let Some(next_pid) = node.next {
+                pid = next_pid;
+            } else {
+                // we've traversed our level, time to bump down
+                let (left_frag, _left_cas_key) =
+                    self.pages.get(left_most, &guard).unwrap();
+                let (left_node, _is_root) = left_frag.base().unwrap();
 
-                    match left_node.data {
-                        Data::Index(ptrs) => {
-                            if let Some(&(ref _sep, ref next_pid)) =
-                                ptrs.first()
-                            {
-                                pid = *next_pid;
-                                left_most = *next_pid;
-                                level += 1;
-                                f.write_str(
-                                    &*format!("\n\tlevel {}:\n", level),
-                                ).unwrap();
-                            } else {
-                                panic!(
-                                    "trying to debug print empty index node"
-                                );
-                            }
+                match left_node.data {
+                    Data::Index(ptrs) => {
+                        if let Some(&(ref _sep, ref next_pid)) =
+                            ptrs.first()
+                        {
+                            pid = *next_pid;
+                            left_most = *next_pid;
+                            level += 1;
+                            f.write_str(
+                                &*format!("\n\tlevel {}:\n", level),
+                            ).unwrap();
+                        } else {
+                            panic!(
+                                "trying to debug print empty index node"
+                            );
                         }
-                        Data::Leaf(_items) => {
-                            // we've reached the end of our tree, all leafs are on
-                            // the lowest level.
-                            break;
-                        }
+                    }
+                    Data::Leaf(_items) => {
+                        // we've reached the end of our tree, all leafs are on
+                        // the lowest level.
+                        break;
                     }
                 }
             }
-        });
-
+        }
 
         Ok(())
     }

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -1,5 +1,5 @@
 extern crate sled;
-extern crate coco;
+extern crate crossbeam_epoch as epoch;
 extern crate rand;
 extern crate quickcheck;
 
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, StdGen};
-use coco::epoch::{Ptr, pin};
+use epoch::{Shared, pin};
 
 use sled::*;
 
@@ -47,22 +47,21 @@ fn pagecache_caching() {
     let mut pc = PageCache::new(TestMaterializer, conf.clone());
     pc.recover();
 
-    pin(|scope| {
-        let mut keys = HashMap::new();
+    let guard = pin();
+    let mut keys = HashMap::new();
 
-        for _ in 0..2 {
-            let (id, key) = pc.allocate(scope);
-            let key = pc.replace(id, key, vec![0], scope).unwrap();
-            keys.insert(id, key);
-        }
+    for _ in 0..2 {
+        let (id, key) = pc.allocate(&guard);
+        let key = pc.replace(id, key, vec![0], &guard).unwrap();
+        keys.insert(id, key);
+    }
 
-        for i in 0..1000 {
-            let id = i as usize % 2;
-            let (_, key) = pc.get(id, scope).unwrap();
-            let key = pc.link(id, key, vec![i], scope).unwrap();
-            keys.insert(id, key);
-        }
-    });
+    for i in 0..1000 {
+        let id = i as usize % 2;
+        let (_, key) = pc.get(id, &guard).unwrap();
+        let key = pc.link(id, key, vec![i], &guard).unwrap();
+        keys.insert(id, key);
+    }
 }
 
 #[test]
@@ -78,21 +77,20 @@ fn pagecache_strange_crash_1() {
         let mut pc = PageCache::new(TestMaterializer, conf.clone());
         pc.recover();
 
-        pin(|scope| {
-            let mut keys = HashMap::new();
-            for _ in 0..2 {
-                let (id, key) = pc.allocate(scope);
-                let key = pc.replace(id, key, vec![0], scope).unwrap();
-                keys.insert(id, key);
-            }
+        let guard = pin();
+        let mut keys = HashMap::new();
+        for _ in 0..2 {
+            let (id, key) = pc.allocate(&guard);
+            let key = pc.replace(id, key, vec![0], &guard).unwrap();
+            keys.insert(id, key);
+        }
 
-            for i in 0..1000 {
-                let id = i as usize % 2;
-                let (_, key) = pc.get(id, scope).unwrap();
-                let key = pc.link(id, key, vec![i], scope).unwrap();
-                keys.insert(id, key);
-            }
-        });
+        for i in 0..1000 {
+            let id = i as usize % 2;
+            let (_, key) = pc.get(id, &guard).unwrap();
+            let key = pc.link(id, key, vec![i], &guard).unwrap();
+            keys.insert(id, key);
+        }
     }
     println!("!!!!!!!!!!!!!!!!!!!!! recovering !!!!!!!!!!!!!!!!!!!!!!");
     let mut pc = PageCache::new(TestMaterializer, conf.clone());
@@ -104,39 +102,38 @@ fn pagecache_strange_crash_1() {
 #[test]
 fn pagecache_strange_crash_2() {
     for x in 0..10 {
-        pin(|scope| {
-            let conf = Config::default()
-                .cache_capacity(40)
-                .cache_bits(0)
-                .flush_every_ms(None)
-                .snapshot_after_ops(1_000_000)
-                .io_buf_size(5000);
+        let guard = pin();
+        let conf = Config::default()
+            .cache_capacity(40)
+            .cache_bits(0)
+            .flush_every_ms(None)
+            .snapshot_after_ops(1_000_000)
+            .io_buf_size(5000);
 
-            println!("!!!!!!!!!!!!!!!!!!!!! {} !!!!!!!!!!!!!!!!!!!!!!", x);
-            let mut pc = PageCache::new(TestMaterializer, conf.clone());
-            pc.recover();
+        println!("!!!!!!!!!!!!!!!!!!!!! {} !!!!!!!!!!!!!!!!!!!!!!", x);
+        let mut pc = PageCache::new(TestMaterializer, conf.clone());
+        pc.recover();
 
-            let mut keys = HashMap::new();
-            for _ in 0..2 {
-                let (id, key) = pc.allocate(scope);
-                let key = pc.replace(id, key, vec![0], scope).unwrap();
-                keys.insert(id, key);
+        let mut keys = HashMap::new();
+        for _ in 0..2 {
+            let (id, key) = pc.allocate(&guard);
+            let key = pc.replace(id, key, vec![0], &guard).unwrap();
+            keys.insert(id, key);
+        }
+
+        for i in 0..1000 {
+            let id = i as usize % 2;
+            println!("------ beginning op on pid {} ------", id);
+            let (_, key) = pc.get(id, &guard).unwrap();
+            println!("got key {:?} for pid {}", key, id);
+            assert!(!key.is_null());
+            let key_res = pc.link(id, key, vec![i], &guard);
+            if key_res.is_err() {
+                println!("failed linking pid {}", id);
             }
-
-            for i in 0..1000 {
-                let id = i as usize % 2;
-                println!("------ beginning op on pid {} ------", id);
-                let (_, key) = pc.get(id, scope).unwrap();
-                println!("got key {:?} for pid {}", key, id);
-                assert!(!key.is_null());
-                let key_res = pc.link(id, key, vec![i], scope);
-                if key_res.is_err() {
-                    println!("failed linking pid {}", id);
-                }
-                let key = key_res.unwrap();
-                keys.insert(id, key);
-            }
-        });
+            let key = key_res.unwrap();
+            keys.insert(id, key);
+        }
     }
 }
 
@@ -146,36 +143,35 @@ fn basic_pagecache_recovery() {
 
     let mut pc = PageCache::new(TestMaterializer, conf.clone());
 
-    pin(|scope| {
-        pc.recover();
-        let (id, key) = pc.allocate(scope);
-        let key = pc.replace(id, key, vec![1], scope).unwrap();
-        let key = pc.link(id, key, vec![2], scope).unwrap();
-        let _key = pc.link(id, key, vec![3], scope).unwrap();
-        let (consolidated, _) = pc.get(id, scope).unwrap();
-        assert_eq!(consolidated, vec![1, 2, 3]);
-        drop(pc);
+    let guard = pin();
+    pc.recover();
+    let (id, key) = pc.allocate(&guard);
+    let key = pc.replace(id, key, vec![1], &guard).unwrap();
+    let key = pc.link(id, key, vec![2], &guard).unwrap();
+    let _key = pc.link(id, key, vec![3], &guard).unwrap();
+    let (consolidated, _) = pc.get(id, &guard).unwrap();
+    assert_eq!(consolidated, vec![1, 2, 3]);
+    drop(pc);
 
-        let mut pc2 = PageCache::new(TestMaterializer, conf.clone());
-        pc2.recover();
-        let (consolidated2, key) = pc2.get(id, scope).unwrap();
-        assert_eq!(consolidated, consolidated2);
+    let mut pc2 = PageCache::new(TestMaterializer, conf.clone());
+    pc2.recover();
+    let (consolidated2, key) = pc2.get(id, &guard).unwrap();
+    assert_eq!(consolidated, consolidated2);
 
-        pc2.link(id, key, vec![4], scope).unwrap();
-        drop(pc2);
+    pc2.link(id, key, vec![4], &guard).unwrap();
+    drop(pc2);
 
-        let mut pc3 = PageCache::new(TestMaterializer, conf.clone());
-        pc3.recover();
-        let (consolidated3, _key) = pc3.get(id, scope).unwrap();
-        assert_eq!(consolidated3, vec![1, 2, 3, 4]);
-        pc3.free(id);
-        drop(pc3);
+    let mut pc3 = PageCache::new(TestMaterializer, conf.clone());
+    pc3.recover();
+    let (consolidated3, _key) = pc3.get(id, &guard).unwrap();
+    assert_eq!(consolidated3, vec![1, 2, 3, 4]);
+    pc3.free(id);
+    drop(pc3);
 
-        let mut pc4 = PageCache::new(TestMaterializer, conf.clone());
-        pc4.recover();
-        let res = pc4.get(id, scope);
-        assert!(res.is_none());
-    })
+    let mut pc4 = PageCache::new(TestMaterializer, conf.clone());
+    pc4.recover();
+    let res = pc4.get(id, &guard);
+    assert!(res.is_none());
 }
 
 #[derive(Debug, Clone)]
@@ -276,7 +272,7 @@ fn prop_pagecache_works(ops: OpVec, cache_fixup_threshold: u8) -> bool {
     let mut reference: HashMap<PageID, Vec<usize>> = HashMap::new();
 
     let bad_addr = 1 << std::mem::align_of::<Vec<usize>>().trailing_zeros();
-    let bad_ptr = unsafe { Ptr::from_raw(bad_addr as *mut _) };
+    let bad_ptr = Shared::from(bad_addr as *const _);
 
     for op in ops.ops.into_iter() {
         match op {
@@ -285,25 +281,25 @@ fn prop_pagecache_works(ops: OpVec, cache_fixup_threshold: u8) -> bool {
 
                 if present {
                     let ref mut existing = reference.get_mut(&pid).unwrap();
-                    pin(|scope| {
+                    {
+                        let guard = pin();
                         let old_key = if existing.is_empty() {
-                            Ptr::null().into()
+                            Shared::null().into()
                         } else {
-                            let (_, old_key) = pc.get(pid, scope).unwrap();
+                            let (_, old_key) = pc.get(pid, &guard).unwrap();
                             old_key
                         };
 
-                        pc.replace(pid, old_key.clone(), vec![c], scope)
+                        pc.replace(pid, old_key.clone(), vec![c], &guard)
                             .unwrap();
-                    });
+                    }
                     existing.clear();
                     existing.push(c);
                 } else {
-                    pin(|scope| {
-                        let res =
-                            pc.replace(pid, bad_ptr.into(), vec![c], scope);
-                        assert!(res.unwrap_err().is_none());
-                    })
+                    let guard = pin();
+                    let res =
+                        pc.replace(pid, bad_ptr.into(), vec![c], &guard);
+                    assert!(res.unwrap_err().is_none());
                 }
             }
             Link(pid, c) => {
@@ -311,57 +307,55 @@ fn prop_pagecache_works(ops: OpVec, cache_fixup_threshold: u8) -> bool {
 
                 if present {
                     let ref mut existing = reference.get_mut(&pid).unwrap();
-                    pin(|scope| {
+                    {
+                        let guard = pin();
                         let old_key = if existing.is_empty() {
-                            Ptr::null().into()
+                            Shared::null().into()
                         } else {
-                            let (_, old_key) = pc.get(pid, scope).unwrap();
+                            let (_, old_key) = pc.get(pid, &guard).unwrap();
                             old_key
                         };
 
-                        pc.link(pid, old_key.clone(), vec![c], scope).unwrap();
-                    });
+                        pc.link(pid, old_key.clone(), vec![c], &guard).unwrap();
+                    }
                     existing.push(c);
                 } else {
-                    pin(|scope| {
-                        let res = pc.link(pid, bad_ptr, vec![c], scope);
-                        assert!(res.unwrap_err().is_none());
-                    });
+                    let guard = pin();
+                    let res = pc.link(pid, bad_ptr, vec![c], &guard);
+                    assert!(res.unwrap_err().is_none());
                 }
             }
             Get(pid) => {
-                pin(|scope| {
-                    let r = reference.get(&pid).cloned();
-                    let a = pc.get(pid, scope).map(|(a, _)| a);
-                    if let Some(ref s) = r {
-                        if s.is_empty() {
-                            assert_eq!(a, None);
-                        } else {
-                            assert_eq!(r, a);
-                            let values = a.unwrap();
-                            values.iter().fold(0, |acc, cur| {
-                                if *cur <= acc {
-                                    panic!(
-                                        "out of order page fragments in page!"
-                                    );
-                                }
-                                *cur
-                            });
-                        }
+                let guard = pin();
+                let r = reference.get(&pid).cloned();
+                let a = pc.get(pid, &guard).map(|(a, _)| a);
+                if let Some(ref s) = r {
+                    if s.is_empty() {
+                        assert_eq!(a, None);
                     } else {
-                        assert_eq!(None, a);
+                        assert_eq!(r, a);
+                        let values = a.unwrap();
+                        values.iter().fold(0, |acc, cur| {
+                            if *cur <= acc {
+                                panic!(
+                                    "out of order page fragments in page!"
+                                );
+                            }
+                            *cur
+                        });
                     }
-                });
+                } else {
+                    assert_eq!(None, a);
+                }
             }
             Free(pid) => {
                 pc.free(pid);
                 reference.remove(&pid);
             }
             Allocate => {
-                pin(|scope| {
-                    let (pid, _key) = pc.allocate(scope);
-                    reference.insert(pid, vec![]);
-                });
+                let guard = pin();
+                let (pid, _key) = pc.allocate(&guard);
+                reference.insert(pid, vec![]);
             }
             Restart => {
                 drop(pc);


### PR DESCRIPTION
`crossbeam-epoch` is finally released.  How about moving from `coco` to `crossbeam-epoch`?


In my machine, the performance of this PR is comparable to the master.  Here is a one-shot measurement of `cargo build --bin=stress --features=stress,zstd; hack/flamerun.sh ./target/debug/stress --duration 5; firefox ./flamegraph.svg`:

crossbeam-epoch
```
did 26916 ops
did 28559 ops
did 28504 ops
did 29216 ops
did 27831 ops
did 141026 total ops in 5 seconds. 28205 ops/s
```

master
```
did 26796 ops
did 28563 ops
did 26291 ops
did 29387 ops
did 28827 ops
did 139864 total ops in 5 seconds. 27972 ops/s
```


 @stjepang, thank you for helping me in debugging!

Closes #116 