### PR TITLE
simplify snapshot state

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -43,5 +43,5 @@ use self::iobuf::IoBufs;
 use self::iterator::LogIter;
 use self::page_cache::{LoggedUpdate, Update};
 use self::parallel_io::Pio;
-use self::segment::{Segment, SegmentAccountant, raw_segment_iter};
+use self::segment::{SegmentAccountant, raw_segment_iter};
 use self::snapshot::{advance_snapshot, read_snapshot_or_default};

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -170,7 +170,7 @@ fn basic_pagecache_recovery() {
 
     let pc4 = PageCache::start(TestMaterializer, conf.clone());
     let res = pc4.get(id, &guard);
-    assert!(res.is_unallocated());
+    assert!(res.is_free());
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
remove segment state from the `Snapshot` itself, recompute it on recovery from the page table. reduce bug space and concentrate responsibility.