### PR TITLE
fractional segments

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ use super::*;
 pub struct Config {
     io_bufs: usize,
     io_buf_size: usize,
+    min_items_per_segment: usize,
     blink_fanout: usize,
     page_consolidation_threshold: usize,
     path: String,
@@ -67,6 +68,7 @@ impl Default for Config {
         Config {
             io_bufs: 3,
             io_buf_size: 2 << 22, // 8mb
+            min_items_per_segment: 4, // capacity for >=4 pages/segment
             blink_fanout: 32,
             page_consolidation_threshold: 10,
             path: tmp_path.to_owned(),
@@ -119,6 +121,7 @@ impl Config {
     builder!(
         (io_bufs, get_io_bufs, set_io_bufs, usize, "number of io buffers"),
         (io_buf_size, get_io_buf_size, set_io_buf_size, usize, "size of each io flush buffer. MUST be multiple of 512!"),
+        (min_items_per_segment, get_min_items_per_segment, set_min_items_per_segment, usize, "minimum data chunks/pages in a segment."),
         (blink_fanout, get_blink_fanout, set_blink_fanout, usize, "b-link node fanout, minimum of 2"),
         (page_consolidation_threshold, get_page_consolidation_threshold, set_page_consolidation_threshold, usize, "page consolidation threshold"),
         (path, get_path, set_path, String, "path for the main storage file"),

--- a/src/io/iobuf.rs
+++ b/src/io/iobuf.rs
@@ -104,7 +104,7 @@ impl IoBufs {
             next_lid
         );
 
-        if next_lsn % io_buf_size as Lsn == 0 {
+        if next_lsn == 0 {
             // recovering at segment boundary
             assert_eq!(next_lid, next_lsn as LogID);
             let iobuf = &bufs[current_buf];

--- a/src/io/iobuf.rs
+++ b/src/io/iobuf.rs
@@ -240,12 +240,19 @@ impl IoBufs {
 
         let buf = self.encapsulate(raw_buf);
 
+        let segment_overhead = SEG_HEADER_LEN + SEG_TRAILER_LEN;
+        let max_buf_size = (self.config.get_io_buf_size() - segment_overhead) /
+            self.config.get_min_items_per_segment();
+
         assert!(
-            buf.len() <=
-                self.config.get_io_buf_size() -
-                    (SEG_HEADER_LEN + SEG_TRAILER_LEN),
+            buf.len() <= max_buf_size,
             "trying to write a buffer that is too large \
-            to be stored in the IO buffer."
+            to be stored in the IO buffer. buf len: {} current max: {}. \
+            a future version of sled will implement automatic \
+            fragmentation of large values. feel free to open \
+            an issue if this is a pressing need of yours.",
+            buf.len(),
+            max_buf_size
         );
 
         trace!("reserving buf of len {}", buf.len());

--- a/src/io/page_cache.rs
+++ b/src/io/page_cache.rs
@@ -288,6 +288,14 @@ impl<PM, P, R> PageCache<PM, P, R>
             return;
         }
 
+        match self.get(pid, &guard) {
+            PageGet::Free =>
+                // already freed or never allocated
+                return,
+            PageGet::Unallocated |
+            PageGet::Materialized(_, _) => (),
+        }
+
         let old_stack = old_stack_opt.unwrap();
 
         // serialize log update

--- a/src/io/segment.rs
+++ b/src/io/segment.rs
@@ -156,6 +156,11 @@ impl Default for SegmentState {
 }
 
 impl Segment {
+    fn len(&self) -> usize {
+        std::cmp::max(self.present.len(), self.removed.len()) -
+            self.removed.len()
+    }
+
     fn _is_free(&self) -> bool {
         match self.state {
             Free => true,
@@ -378,6 +383,10 @@ impl SegmentAccountant {
 
         let io_buf_size = self.config.get_io_buf_size();
 
+        let max_idx = segments.iter().fold(0, |acc, segment| {
+            std::cmp::max(acc, segment.lsn.unwrap_or(acc))
+        }) as usize / io_buf_size;
+
         for (idx, ref mut segment) in segments.iter_mut().enumerate() {
             if segment.lsn.is_none() {
                 continue;
@@ -390,17 +399,21 @@ impl SegmentAccountant {
 
             let lsn = segment.lsn();
 
+            // can we transition these segments?
             let cleanup_threshold = self.config.get_segment_cleanup_threshold();
-            let min_items = self.config.get_min_segment_items();
-            let segment_low_pct = segment.live_pct() <=
-                self.config.get_segment_cleanup_threshold();
-            let segment_low_count = segment.len() as f64 <=
-                min_items as f64 * segment_low_pct;
+            let min_items = self.config.get_min_items_per_segment();
 
-            let can_free = segment.is_empty() && !self.pause_rewriting;
+            let segment_low_pct = segment.live_pct() <= cleanup_threshold;
+
+            let segment_low_count = (segment.len() as f64) <
+                min_items as f64 * cleanup_threshold;
+
+            let can_free = segment.is_empty() && !self.pause_rewriting &&
+                idx != max_idx;
 
             let can_drain = (segment_low_pct || segment_low_count) &&
-                !self.pause_rewriting;
+                !self.pause_rewriting &&
+                idx != max_idx;
 
             // populate free and to_clean if the segment has seen
             if can_free {
@@ -580,16 +593,26 @@ impl SegmentAccountant {
 
             self.segments[old_idx].remove_pid(pid, lsn);
 
+            // can we transition these segments?
+            let cleanup_threshold = self.config.get_segment_cleanup_threshold();
+            let min_items = self.config.get_min_items_per_segment();
+
+            let segment_low_pct = self.segments[old_idx].live_pct() <=
+                cleanup_threshold;
+
+            let segment_low_count = (self.segments[old_idx].len() as f64) <
+                min_items as f64 * cleanup_threshold;
+
+            let can_drain = self.segments[old_idx].is_inactive() &&
+                (segment_low_pct || segment_low_count);
+
             if self.segments[old_idx].can_free() {
                 // can be reused immediately
                 self.segments[old_idx].draining_to_free(lsn);
                 self.to_clean.remove(&segment_start);
                 trace!("freed segment {} in replace", segment_start);
                 self.free_segment(segment_start, false);
-            } else if self.segments[old_idx].is_inactive() &&
-                       self.segments[old_idx].live_pct() <=
-                           self.config.get_segment_cleanup_threshold()
-            {
+            } else if can_drain {
                 // can be cleaned
                 trace!(
                     "SA inserting {} into to_clean from mark_replace",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,13 @@ fn global_init() {
         #[cfg(feature = "env_logger")]
         {
             let format = |record: &_log::LogRecord| {
-                format!("{:05} {}: {}", record.level(), tn(), record.args())
+                format!(
+                    "{:05} {:10} {:10} {}",
+                    record.level(),
+                    tn(),
+                    record.location().module_path().split("::").last().unwrap(),
+                    record.args()
+                )
             };
 
             let mut builder = env_logger::LogBuilder::new();

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -624,6 +624,28 @@ fn pagecache_bug_15() {
     );
 }
 
+#[test]
+fn pagecache_bug_16() {
+    // postmortem:
+    use Op::*;
+    prop_pagecache_works(
+        OpVec {
+            ops: vec![
+                Allocate,
+                Free(0),
+                Free(0),
+                Free(0),
+                Allocate,
+                Link(0, 5622),
+                Allocate,
+                Restart,
+                Get(0),
+            ],
+        },
+        0,
+    );
+}
+
 fn _pagecache_bug_() {
     // postmortem: TEMPLATE
     // portmortem 2: ...

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -384,7 +384,7 @@ fn quickcheck_pagecache_works() {
     QuickCheck::new()
         .gen(StdGen::new(rand::thread_rng(), 1))
         .tests(1000)
-        .max_tests(10000)
+        .max_tests(2000)
         .quickcheck(prop_pagecache_works as fn(OpVec, u8) -> bool);
 }
 

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -42,7 +42,7 @@ fn pagecache_caching() {
         .cache_bits(0)
         .flush_every_ms(None)
         .snapshot_after_ops(1_000_000)
-        .io_buf_size(5000)
+        .io_buf_size(20000)
         .build();
 
     let pc = PageCache::start(TestMaterializer, conf.clone());
@@ -71,7 +71,7 @@ fn pagecache_strange_crash_1() {
         .cache_bits(0)
         .flush_every_ms(None)
         .snapshot_after_ops(1_000_000)
-        .io_buf_size(5000)
+        .io_buf_size(20000)
         .build();
 
     {
@@ -107,7 +107,7 @@ fn pagecache_strange_crash_2() {
             .cache_bits(0)
             .flush_every_ms(None)
             .snapshot_after_ops(1_000_000)
-            .io_buf_size(5000)
+            .io_buf_size(20000)
             .build();
 
         println!("!!!!!!!!!!!!!!!!!!!!! {} !!!!!!!!!!!!!!!!!!!!!!", x);


### PR DESCRIPTION
there is now a configurable minimum number of elements that can be put into a single segment. when we have fewer than `page_consolidation_threshold` * `min_items_per_segment` pages in a segment, it can be marked as "draining" for accelerated relocation of the remaining pages, so that the segment may be reused.