### PR TITLE
track page allocations

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -33,7 +33,7 @@ pub use self::snapshot::{Snapshot, read_snapshot_or_default};
 
 pub use self::log::Log;
 pub use self::materializer::Materializer;
-pub use self::page_cache::{CacheEntry, PageCache};
+pub use self::page_cache::{CacheEntry, PageCache, PageGet};
 pub use self::reservation::Reservation;
 pub use self::segment::SegmentMode;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -43,4 +43,4 @@ use self::iterator::LogIter;
 use self::page_cache::{LoggedUpdate, Update};
 use self::parallel_io::Pio;
 use self::segment::{SegmentAccountant, raw_segment_iter};
-use self::snapshot::advance_snapshot;
+use self::snapshot::{PageState, advance_snapshot};

--- a/src/io/page_cache.rs
+++ b/src/io/page_cache.rs
@@ -91,6 +91,14 @@ impl<'a, P> PageGet<'a, P>
         }
     }
 
+    /// Returns true if the `PageGet` is `Materialized`.
+    pub fn is_materialized(&self) -> bool {
+        match *self {
+            PageGet::Materialized(_, _) => true,
+            _ => false,
+        }
+    }
+
     /// Returns true if the `PageGet` is `Free`.
     pub fn is_free(&self) -> bool {
         match *self {

--- a/src/io/segment.rs
+++ b/src/io/segment.rs
@@ -328,6 +328,7 @@ impl SegmentAccountant {
 
         if let SegmentMode::Linear = ret.config.segment_mode {
             // this is a hack to prevent segments from being overwritten
+            // when operating without a `PageCache`
             ret.pause_rewriting();
         }
         if snapshot.last_lid > ret.tip {
@@ -386,8 +387,7 @@ impl SegmentAccountant {
     }
 
     fn initialize_from_segments(&mut self, mut segments: Vec<Segment>) {
-        // populate ordering from segments
-        //
+        // populate ordering from segments.
         // use last segment as active even if it's full
         let safety_buffer = self.config.get_io_bufs();
         let logical_tail: Vec<LogID> = self.ordering

--- a/src/io/snapshot.rs
+++ b/src/io/snapshot.rs
@@ -118,8 +118,18 @@ impl<R> Snapshot<R> {
                 self.pt.insert(pid, vec![(lsn, log_id)]);
                 self.free.remove(&pid);
             }
+            Update::Allocate => {
+                trace!(
+                    "allocate  of pid {} at lid {} lsn {}",
+                    pid,
+                    log_id,
+                    lsn
+                );
+                self.pt.insert(pid, vec![]);
+                self.free.remove(&pid);
+            }
             Update::Free => {
-                trace!("del of pid {} at lid {} lsn {}", pid, log_id, lsn);
+                trace!("free of pid {} at lid {} lsn {}", pid, log_id, lsn);
                 self.replace_pid(pid, replaced_at_idx, lsn, io_buf_size);
                 self.pt.insert(pid, vec![(lsn, log_id)]);
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -575,7 +575,7 @@ impl Tree {
         let mut not_found_loops = 0;
         loop {
             let get_cursor = self.pages.get(cursor, guard);
-            if get_cursor.is_free() {
+            if get_cursor.is_free() || get_cursor.is_allocated() {
                 // restart search from the tree's root
                 not_found_loops += 1;
                 debug_assert_ne!(
@@ -587,6 +587,10 @@ impl Tree {
                 cursor = self.root.load(SeqCst);
                 continue;
             }
+            if !get_cursor.is_materialized() {
+                error!("unwrapping {:?}", get_cursor);
+            }
+
             let (frag, cas_key) = get_cursor.unwrap();
             let (node, _is_root) = frag.into_base().unwrap();
 

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -266,43 +266,6 @@ enum P {
     Present(Vec<usize>),
 }
 
-impl P {
-    fn is_free(&self) -> bool {
-        match *self {
-            P::Free => true,
-            _ => false,
-        }
-    }
-
-    fn is_unallocated(&self) -> bool {
-        match *self {
-            P::Unallocated => true,
-            _ => false,
-        }
-    }
-
-    fn is_allocated(&self) -> bool {
-        match *self {
-            P::Allocated => true,
-            _ => false,
-        }
-    }
-
-    fn is_present(&self) -> bool {
-        match *self {
-            P::Present(_) => true,
-            _ => false,
-        }
-    }
-
-    fn entries(&self) -> &Vec<usize> {
-        match *self {
-            P::Present(ref entries) => entries,
-            _ => panic!("entries called on non-present page"),
-        }
-    }
-}
-
 fn prop_pagecache_works(ops: OpVec) -> bool {
     use self::Op::*;
     let config = Config::default()
@@ -325,7 +288,6 @@ fn prop_pagecache_works(ops: OpVec) -> bool {
         let guard = pin();
         match op {
             Replace(pid, c) => {
-                println!("replacing pid {}", pid);
                 let get = pc.get(pid, &guard);
                 let ref_get = reference.entry(pid).or_insert(P::Unallocated);
 
@@ -415,7 +377,6 @@ fn prop_pagecache_works(ops: OpVec) -> bool {
             }
             Allocate => {
                 let pid = pc.allocate(&guard);
-                println!("allocated pid {}", pid);
                 reference.insert(pid, P::Allocated);
                 let get = pc.get(pid, &guard);
                 assert!(get.is_allocated());

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -259,6 +259,50 @@ impl Arbitrary for OpVec {
     }
 }
 
+enum P {
+    Free,
+    Allocated,
+    Unallocated,
+    Present(Vec<usize>),
+}
+
+impl P {
+    fn is_free(&self) -> bool {
+        match *self {
+            P::Free => true,
+            _ => false,
+        }
+    }
+
+    fn is_unallocated(&self) -> bool {
+        match *self {
+            P::Unallocated => true,
+            _ => false,
+        }
+    }
+
+    fn is_allocated(&self) -> bool {
+        match *self {
+            P::Allocated => true,
+            _ => false,
+        }
+    }
+
+    fn is_present(&self) -> bool {
+        match *self {
+            P::Present(_) => true,
+            _ => false,
+        }
+    }
+
+    fn entries(&self) -> &Vec<usize> {
+        match *self {
+            P::Present(ref entries) => entries,
+            _ => panic!("entries called on non-present page"),
+        }
+    }
+}
+
 fn prop_pagecache_works(ops: OpVec) -> bool {
     use self::Op::*;
     let config = Config::default()
@@ -272,110 +316,112 @@ fn prop_pagecache_works(ops: OpVec) -> bool {
 
     let mut pc = PageCache::start(TestMaterializer, config.clone());
 
-    let mut reference: HashMap<PageID, Vec<usize>> = HashMap::new();
-
-    let bad_addr = 1 << std::mem::align_of::<Vec<usize>>().trailing_zeros();
-    let bad_ptr = Shared::from(bad_addr as *const _);
+    let mut reference: HashMap<PageID, P> = HashMap::new();
 
     // TODO use returned pointers, cleared on restart, with caching set to
     // a large amount, to test linkage.
     // println!("{:?}", ops);
     for op in ops.ops.into_iter() {
+        let guard = pin();
         match op {
             Replace(pid, c) => {
-                let present = reference.contains_key(&pid);
+                println!("replacing pid {}", pid);
+                let get = pc.get(pid, &guard);
+                let ref_get = reference.entry(pid).or_insert(P::Unallocated);
 
-                if present {
-                    let ref mut existing = reference.get_mut(&pid).unwrap();
-                    {
-                        let guard = pin();
-                        let old_key = if existing.is_empty() {
-                            Shared::null().into()
-                        } else {
-                            let (_, old_key) = pc.get(pid, &guard).unwrap();
-                            old_key
-                        };
-
-                        // FIXME called `Result::unwrap()` on an `Err`
-                        // value: Some(Shared { raw: 0x7ff813022680, tag: 0 })
+                match ref_get {
+                    &mut P::Allocated => {
+                        pc.replace(pid, Shared::null(), vec![c], &guard)
+                            .unwrap();
+                        *ref_get = P::Present(vec![c]);
+                    }
+                    &mut P::Present(ref mut existing) => {
+                        let (_, old_key) = get.unwrap();
                         pc.replace(pid, old_key.clone(), vec![c], &guard)
                             .unwrap();
+                        existing.clear();
+                        existing.push(c);
                     }
-                    existing.clear();
-                    existing.push(c);
-                } else {
-                    let guard = pin();
-
-                    // ensure this returns an Err of some kind
-                    let _ = pc.replace(pid, bad_ptr.into(), vec![c], &guard)
-                        .unwrap_err();
+                    &mut P::Free => {
+                        assert_eq!(get, sled::PageGet::Free);
+                    }
+                    &mut P::Unallocated => {
+                        assert_eq!(get, sled::PageGet::Unallocated);
+                    }
                 }
             }
             Link(pid, c) => {
-                let present = reference.contains_key(&pid);
+                let get = pc.get(pid, &guard);
+                let ref_get = reference.entry(pid).or_insert(P::Unallocated);
 
-                if present {
-                    let ref mut existing = reference.get_mut(&pid).unwrap();
-                    {
-                        let guard = pin();
-                        let old_key = if existing.is_empty() {
-                            Shared::null().into()
-                        } else {
-                            let (_, old_key) = pc.get(pid, &guard).unwrap();
-                            old_key
-                        };
-
-                        pc.link(pid, old_key.clone(), vec![c], &guard).unwrap();
+                match ref_get {
+                    &mut P::Allocated => {
+                        pc.link(pid, Shared::null(), vec![c], &guard).unwrap();
+                        *ref_get = P::Present(vec![c]);
                     }
-                    existing.push(c);
-                } else {
-                    let guard = pin();
-
-                    // ensure this returns an Err of some kind
-                    let _ = pc.link(pid, bad_ptr.into(), vec![c], &guard)
-                        .unwrap_err();
+                    &mut P::Present(ref mut existing) => {
+                        let (_, old_key) = get.unwrap();
+                        pc.link(pid, old_key.clone(), vec![c], &guard).unwrap();
+                        existing.push(c);
+                    }
+                    &mut P::Free => {
+                        assert_eq!(get, sled::PageGet::Free);
+                    }
+                    &mut P::Unallocated => {
+                        assert_eq!(get, sled::PageGet::Unallocated);
+                    }
                 }
             }
             Get(pid) => {
-                let guard = pin();
-                let r = reference.get(&pid).cloned();
-                let a = pc.get(pid, &guard);
-                if let Some(ref s) = r {
-                    if s.is_empty() {
-                        assert!(a.is_free() || a.is_unallocated());
-                    } else {
-                        let (a_val, _a_ptr) = a.unwrap();
-                        assert_eq!(s, &a_val);
-                        a_val.iter().fold(0, |acc, cur| {
+                let get = pc.get(pid, &guard);
+
+                match reference.get(&pid) {
+                    Some(&P::Allocated) => {
+                        assert!(get.is_allocated());
+                    }
+                    Some(&P::Present(ref existing)) => {
+                        let (val, _ptr) = get.unwrap();
+                        assert_eq!(existing, &val);
+                        val.iter().fold(0, |acc, cur| {
                             if *cur <= acc {
                                 panic!("out of order page fragments in page!");
                             }
                             *cur
                         });
                     }
-                } else {
-                    assert!(a.is_free() || a.is_unallocated());
+                    Some(&P::Free) => {
+                        assert!(get.is_free());
+                    }
+                    Some(&P::Unallocated) |
+                    None => {
+                        assert_eq!(get, sled::PageGet::Unallocated);
+                    }
                 }
             }
             Free(pid) => {
                 pc.free(pid);
-                reference.remove(&pid);
+                let get = pc.get(pid, &guard);
+
+                match reference.get(&pid) {
+                    Some(&P::Allocated) |
+                    Some(&P::Present(_)) |
+                    Some(&P::Free) => {
+                        reference.insert(pid, P::Free);
+                        assert!(get.is_free())
+                    }
+                    Some(&P::Unallocated) |
+                    None => assert!(get.is_unallocated()),
+                }
             }
             Allocate => {
-                let guard = pin();
                 let pid = pc.allocate(&guard);
-                reference.insert(pid, vec![]);
+                println!("allocated pid {}", pid);
+                reference.insert(pid, P::Allocated);
+                let get = pc.get(pid, &guard);
+                assert!(get.is_allocated());
             }
             Restart => {
                 drop(pc);
-                // any pages with no updates should be cleared
-                let mut to_clear = vec![];
-                for (pid, items) in &reference {
-                    if items.is_empty() {
-                        to_clear.push(*pid);
-                    }
-                }
-                reference.retain(|p, _v| !to_clear.contains(p));
 
                 config.verify_snapshot(Arc::new(TestMaterializer));
 
@@ -407,7 +453,7 @@ fn pagecache_bug_01() {
 }
 
 #[test]
-fn pagecache_bug_2() {
+fn pagecache_bug_02() {
     // postmortem: historically needed to "seed" a page by writing
     // a compacting base to it. changed the snapshot and page-in code
     // to allow a link being the first update to hit a page.
@@ -602,28 +648,26 @@ fn pagecache_bug_16() {
     });
 }
 
-// FIXME currently breaking in new and exciting ways!
 #[test]
-#[ignore]
 fn pagecache_bug_17() {
     // postmortem:
     use Op::*;
     prop_pagecache_works(OpVec {
         ops: vec![
             Allocate,
-            Link(0, 205),
             Allocate,
+            Allocate,
+            Allocate,
+            Allocate,
+            Allocate,
+            Link(0, 205),
             Replace(0, 207),
             Link(1, 208),
-            Allocate,
-            Allocate,
-            Allocate,
             Link(2, 213),
             Replace(3, 215),
             Replace(2, 216),
             Replace(3, 218),
             Free(1),
-            Allocate,
             Link(4, 220),
             Restart,
             Allocate,
@@ -636,10 +680,10 @@ fn pagecache_bug_17() {
             Replace(1, 224),
             Link(0, 226),
             Restart,
+            Allocate,
+            Allocate,
             Link(0, 227),
-            Allocate,
             Link(0, 228),
-            Allocate,
             Replace(4, 229),
             Free(1),
             Free(0),
@@ -710,6 +754,26 @@ fn pagecache_bug_19() {
             Restart,
             Restart,
         ],
+    });
+}
+
+#[test]
+fn pagecache_bug_20() {
+    // postmortem: failed to handle Unallocated nodes properly
+    // in refactored test model.
+    use Op::*;
+    prop_pagecache_works(OpVec {
+        ops: vec![Free(0), Replace(0, 17)],
+    });
+}
+
+#[test]
+fn pagecache_bug_21() {
+    // postmortem: test model marked unused pids as Unallocated
+    // instead of Free during recovery.
+    use Op::*;
+    prop_pagecache_works(OpVec {
+        ops: vec![Allocate, Free(0), Restart, Allocate, Restart, Get(0)],
     });
 }
 

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -219,7 +219,7 @@ struct OpVec {
 impl Arbitrary for OpVec {
     fn arbitrary<G: Gen>(g: &mut G) -> OpVec {
         let mut ops = vec![];
-        for _ in 0..g.gen_range(1, 50) {
+        for _ in 0..g.gen_range(1, 100) {
             let op = Op::arbitrary(g);
             ops.push(op);
 
@@ -312,8 +312,8 @@ fn prop_tree_matches_btreemap(
 fn quickcheck_tree_matches_btreemap() {
     QuickCheck::new()
         .gen(StdGen::new(rand::thread_rng(), 1))
-        .tests(50)
-        .max_tests(100)
+        .tests(1000)
+        .max_tests(10000)
         .quickcheck(prop_tree_matches_btreemap as fn(OpVec, u8, u8) -> bool);
 }
 

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -310,9 +310,16 @@ fn prop_tree_matches_btreemap(
 
 #[test]
 fn quickcheck_tree_matches_btreemap() {
+    // use fewer tests for travis OSX builds that stall out all the time
+    #[cfg(target_os = "macos")]
+    let n_tests = 100;
+
+    #[cfg(not(target_os = "macos"))]
+    let n_tests = 1000;
+
     QuickCheck::new()
         .gen(StdGen::new(rand::thread_rng(), 1))
-        .tests(1000)
+        .tests(n_tests)
         .max_tests(10000)
         .quickcheck(prop_tree_matches_btreemap as fn(OpVec, u8, u8) -> bool);
 }

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -315,7 +315,7 @@ fn quickcheck_tree_matches_btreemap() {
     let n_tests = 100;
 
     #[cfg(not(target_os = "macos"))]
-    let n_tests = 1000;
+    let n_tests = 500;
 
     QuickCheck::new()
         .gen(StdGen::new(rand::thread_rng(), 1))


### PR DESCRIPTION
This adds more information about the state of various pages, so that it can be reasoned about more effectively in tests and by users. This makes the testing model much less ambiguous, so hopefully future bugs will be more clear when they pop up in quickcheck.