### PR TITLE
Use HTTPS for merit badges, and GitHub raw link for embedded images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sled likes eating data! it's pre-alpha
 
 <p>
-  <img src="https://github.com/spacejam/rsdb/blob/master/art/tree_face.png" width="20%" height="auto" />
+  <img src="https://raw.githubusercontent.com/spacejam/sled/master/art/tree_face.png" width="20%" height="auto" />
 </p>
 
 [![Build Status](https://travis-ci.org/spacejam/sled.svg?branch=master)](https://travis-ci.org/spacejam/sled)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 [![Build Status](https://travis-ci.org/spacejam/sled.svg?branch=master)](https://travis-ci.org/spacejam/sled)
-[![crates.io](http://meritbadge.herokuapp.com/sled)](https://crates.io/crates/sled)
+[![crates.io](https://meritbadge.herokuapp.com/sled)](https://crates.io/crates/sled)
 [![documentation](https://docs.rs/sled/badge.svg)](https://docs.rs/sled)
 
 A pre-alpha modern embedded database.

--- a/crates/pagecache/README.md
+++ b/crates/pagecache/README.md
@@ -1,7 +1,7 @@
 # pagecache
 
 [![Build Status](https://travis-ci.org/spacejam/sled.svg?branch=master)](https://travis-ci.org/spacejam/sled)
-[![crates.io](http://meritbadge.herokuapp.com/pagecache)](https://crates.io/crates/pagecache)
+[![crates.io](https://meritbadge.herokuapp.com/pagecache)](https://crates.io/crates/pagecache)
 [![documentation](https://docs.rs/pagecache/badge.svg)](https://docs.rs/pagecache)
 
 A construction kit for databases. Provides a lock-free log store and pagecache.


### PR DESCRIPTION
The READMEs for sled and pagecache were rendering incorrectly on crates.io, due to some embedded merit badges with non-HTTPS links, and an image that wasn't actually linked to the raw image. Fix the links appropriately.