### PR TITLE
pagecache: Replace reference to sled to that of pagecache

### DIFF
--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -29,7 +29,7 @@ use io::LogReader;
 ///
 /// Read-only mode
 /// ```
-/// let _config = sled::ConfigBuilder::default()
+/// let _config = pagecache::ConfigBuilder::default()
 ///     .path("/path/to/data".to_owned())
 ///     .read_only(true);
 /// ```
@@ -69,10 +69,10 @@ impl Default for ConfigBuilder {
 
         // use shared memory for temporary linux files
         #[cfg(target_os = "linux")]
-        let tmp_path = format!("/dev/shm/sled.tmp.{}", nanos);
+        let tmp_path = format!("/dev/shm/pagecache.tmp.{}", nanos);
 
         #[cfg(not(target_os = "linux"))]
-        let tmp_path = format!("sled.tmp.{}", nanos);
+        let tmp_path = format!("pagecache.tmp.{}", nanos);
 
         ConfigBuilder {
             io_bufs: 3,
@@ -80,7 +80,7 @@ impl Default for ConfigBuilder {
             min_items_per_segment: 4, // capacity for >=4 pages/segment
             blink_fanout: 32,
             page_consolidation_threshold: 10,
-            path: "sled".to_owned().into(),
+            path: "pagecache".to_owned().into(),
             read_only: false,
             cache_bits: 6, // 64 shards
             cache_capacity: 1024 * 1024 * 1024, // 1gb

--- a/crates/pagecache/src/io/iobuf.rs
+++ b/crates/pagecache/src/io/iobuf.rs
@@ -247,7 +247,7 @@ impl IoBufs {
             buf.len() <= max_buf_size,
             "trying to write a buffer that is too large \
             to be stored in the IO buffer. buf len: {} current max: {}. \
-            a future version of sled will implement automatic \
+            a future version of pagecache will implement automatic \
             fragmentation of large values. feel free to open \
             an issue if this is a pressing need of yours.",
             buf.len(),

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -73,7 +73,7 @@ pub type PageID = usize;
 type HPtr<'g, P> = epoch::Shared<'g, ds::stack::Node<io::CacheEntry<P>>>;
 
 lazy_static! {
-    /// A metric collector for all sled instances running in this
+    /// A metric collector for all pagecache users running in this
     /// process.
     pub static ref M: Metrics = Metrics::default();
 }
@@ -146,7 +146,7 @@ fn global_init() {
             let key = "CPUPROFILE";
             let path = match env::var(key) {
                 Ok(val) => val,
-                Err(_) => "sled.profile".to_owned(),
+                Err(_) => "pagecache.profile".to_owned(),
             };
             cpuprofiler::PROFILER.lock().unwrap().start(path).expect(
                 "could not start cpu profiler!",

--- a/crates/pagecache/src/metrics.rs
+++ b/crates/pagecache/src/metrics.rs
@@ -42,7 +42,7 @@ impl Metrics {
 
     pub fn print_profile(&self) {
         println!(
-            "sled profile:\n\
+            "pagecache profile:\n\
             {0: >17} | {1: >10} | {2: >10} | {3: >10} | {4: >10} | {5: >10} | {6: >10} | {7: >10}",
             "op",
             "min (us)",


### PR DESCRIPTION
Hi!  I just replaced a few mention of "sled" into that of "pagecache" in the pagecache crate.  Because maybe pagecache can be a standalone crate that can be used outside of the context of sled :)  Thanks!