### PR TITLE
pagecache: Add RAII-style and lambda-style measure

### DIFF
--- a/crates/pagecache/src/io/log.rs
+++ b/crates/pagecache/src/io/log.rs
@@ -179,7 +179,7 @@ impl Log {
     /// blocks until the specified log sequence number has
     /// been made stable on disk
     pub fn make_stable(&self, lsn: Lsn) -> CacheResult<(), ()> {
-        let start = clock();
+        let _measure = Measure::new(&M.make_stable);
 
         // NB before we write the 0th byte of the file, stable  is -1
         while self.iobufs.stable() < lsn {
@@ -198,7 +198,6 @@ impl Log {
             }
         }
 
-        M.make_stable.measure(clock() - start);
         Ok(())
     }
 

--- a/crates/pagecache/src/io/page_cache.rs
+++ b/crates/pagecache/src/io/page_cache.rs
@@ -327,9 +327,9 @@ impl<PM, P, R> PageCache<PM, P, R>
             pid: pid,
             update: Update::Allocate,
         };
-        let serialize_start = clock();
-        let bytes = serialize(&prepend, Infinite).unwrap();
-        M.serialize.measure(clock() - serialize_start);
+        let bytes = measure(&M.serialize, || {
+            serialize(&prepend, Infinite).unwrap()
+        });
 
         // reserve slot in log
         // FIXME not threadsafe?
@@ -367,9 +367,9 @@ impl<PM, P, R> PageCache<PM, P, R>
             pid: pid,
             update: Update::Free,
         };
-        let serialize_start = clock();
-        let bytes = serialize(&prepend, Infinite).unwrap();
-        M.serialize.measure(clock() - serialize_start);
+        let bytes = measure(&M.serialize, || {
+            serialize(&prepend, Infinite).unwrap()
+        });
 
         // reserve slot in log
         let res = self.log.reserve(bytes).map_err(|e| e.danger_cast())?;
@@ -432,9 +432,9 @@ impl<PM, P, R> PageCache<PM, P, R>
                 Update::Append(new.clone())
             },
         };
-        let serialize_start = clock();
-        let bytes = serialize(&prepend, Infinite).unwrap();
-        M.serialize.measure(clock() - serialize_start);
+        let bytes = measure(&M.serialize, || {
+            serialize(&prepend, Infinite).unwrap()
+        });
         let log_reservation =
             self.log.reserve(bytes).map_err(|e| e.danger_cast())?;
         let lsn = log_reservation.lsn();
@@ -538,9 +538,9 @@ impl<PM, P, R> PageCache<PM, P, R>
             pid: pid,
             update: new.clone(),
         };
-        let serialize_start = clock();
-        let bytes = serialize(&replace, Infinite).unwrap();
-        M.serialize.measure(clock() - serialize_start);
+        let bytes = measure(&M.serialize, || {
+            serialize(&replace, Infinite).unwrap()
+        });
         let log_reservation =
             self.log.reserve(bytes).map_err(|e| e.danger_cast())?;
         let lsn = log_reservation.lsn();
@@ -651,7 +651,7 @@ impl<PM, P, R> PageCache<PM, P, R>
         stack_ptr: Shared<'g, ds::stack::Stack<CacheEntry<P>>>,
         guard: &'g Guard,
     ) -> CacheResult<PageGet<'g, PM::PageFrag>, Option<PagePtr<'g, P>>> {
-        let start = clock();
+        let _measure = Measure::new(&M.page_in);
         let stack_iter = StackIter::from_ptr(head, guard);
 
         let mut to_merge = vec![];
@@ -691,7 +691,6 @@ impl<PM, P, R> PageCache<PM, P, R>
         }
 
         if lids.is_empty() {
-            M.page_in.measure(clock() - start);
             return Ok(PageGet::Allocated);
         }
 
@@ -726,9 +725,9 @@ impl<PM, P, R> PageCache<PM, P, R>
             .rev()
             .collect();
 
-        let before_merge = clock();
-        let merged = self.t.merge(&*combined);
-        M.merge_page.measure(clock() - before_merge);
+        let merged = measure(&M.merge_page, || {
+            self.t.merge(&*combined)
+        });
 
         let size = std::mem::size_of_val(&merged);
         let to_evict = self.lru.accessed(pid, size);
@@ -795,8 +794,6 @@ impl<PM, P, R> PageCache<PM, P, R>
             }
         }
 
-        M.page_in.measure(clock() - start);
-
         Ok(PageGet::Materialized(merged, head))
     }
 
@@ -805,7 +802,7 @@ impl<PM, P, R> PageCache<PM, P, R>
         to_evict: Vec<PageID>,
         guard: &'g Guard,
     ) -> std::io::Result<()> {
-        let start = clock();
+        let _measure = Measure::new(&M.page_out);
         for pid in to_evict {
             let stack_ptr = self.inner.get(pid, guard);
             if stack_ptr.is_none() {
@@ -844,7 +841,6 @@ impl<PM, P, R> PageCache<PM, P, R>
             });
 
             if last.is_none() {
-                M.page_out.measure(clock() - start);
                 return Ok(());
             }
 
@@ -878,7 +874,6 @@ impl<PM, P, R> PageCache<PM, P, R>
                 {}
             }
         }
-        M.page_out.measure(clock() - start);
         Ok(())
     }
 
@@ -888,7 +883,7 @@ impl<PM, P, R> PageCache<PM, P, R>
         lid: LogID,
     ) -> CacheResult<P, Option<PagePtr<'g, P>>> {
         trace!("pulling lsn {} lid {} from disk", lsn, lid);
-        let start = clock();
+        let _measure = Measure::new(&M.pull);
         let bytes = match self.log.read(lsn, lid).map_err(|_| ()) {
             Ok(LogRead::Flush(read_lsn, data, _len)) => {
                 assert_eq!(
@@ -908,13 +903,12 @@ impl<PM, P, R> PageCache<PM, P, R>
             }),
         }?;
 
-        let deserialize_start = clock();
-        let logged_update = deserialize::<LoggedUpdate<P>>(&*bytes)
-            .map_err(|_| ())
-            .expect("failed to deserialize data");
-        M.deserialize.measure(clock() - deserialize_start);
+        let logged_update = measure(&M.deserialize, || {
+            deserialize::<LoggedUpdate<P>>(&*bytes)
+                .map_err(|_| ())
+                .expect("failed to deserialize data")
+        });
 
-        M.pull.measure(clock() - start);
         match logged_update.update {
             Update::Compact(page_frag) |
             Update::Append(page_frag) => Ok(page_frag),


### PR DESCRIPTION
The pagecache crate measure the time spent on running a piece of code for several times.  This PR introduces an RAII-style and lambda-style utility for measuring the time, which, IMHO, slightly improves the readability of the code.