### PR TITLE
Compilation for 32-bit architectures on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,18 @@ matrix:
       env:
         - TEST=crash
         - RUST_BACKTRACE=1
+    - rust: nightly-2018-01-02
+      env:
+        - TEST=cross-build
+        - TARGET=i686-unknown-linux-gnu
+
+install:
+  - curl https://sh.rustup.rs -sSf |
+    sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
+  - if [ -n "$TARGET" ]; then
+        rustup target add $TARGET;
+    fi
+  - source ~/.cargo/env
 
 script:
   - bash -c 'case "$TEST" in
@@ -37,6 +49,11 @@ script:
                  ;;
                crash)
                  cargo test test_crash_recovery --release --features="check_snapshot_integrity" -- --nocapture
+                 ;;
+               cross-build)
+                 echo "https://github.com/rust-lang/cargo/issues/4753";
+                 pushd crates/sled; cargo build --target $TARGET --features=nightly; popd;
+                 pushd crates/pagecache; cargo build --target $TARGET --features=nightly; popd
                  ;;
                *)
                  cargo check;

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ assert_eq!(tree.get(&k), Ok(Some(vec![4])));
   operations per second with mixed workloads, and 7 million/s
   for read-only workloads on tiny keys. this will be improving 
   dramatically soon!
+* 32 bit architectures [require Rust nightly with the `nightly` feature enabled](https://github.com/spacejam/sled/issues/145).
 
 # contribution welcome!
 

--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -16,6 +16,7 @@ lock_free_delays = ["rand"]
 failpoints = ["fail"]
 no_metrics = ["historian/bypass"]
 no_logs = ["log/max_level_off"]
+nightly = []
 
 [dependencies.historian]
 version = "3.0"

--- a/crates/pagecache/src/io/iobuf.rs
+++ b/crates/pagecache/src/io/iobuf.rs
@@ -1,8 +1,8 @@
 use std::sync::{Condvar, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicUsize};
-#[cfg(feature = "nightly")]
+#[cfg(target_pointer_width = "32")]
 use std::sync::atomic::AtomicI64;
-#[cfg(not(feature = "nightly"))]
+#[cfg(target_pointer_width = "64")]
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering::SeqCst;
 
@@ -17,9 +17,9 @@ use self::reader::LogReader;
 use super::*;
 
 type Header = u64;
-#[cfg(not(feature = "nightly"))]
+#[cfg(target_pointer_width = "64")]
 type AtomicLsn = AtomicIsize;
-#[cfg(feature = "nightly")]
+#[cfg(target_pointer_width = "32")]
 type AtomicLsn = AtomicI64;
 
 macro_rules! io_fail {

--- a/crates/pagecache/src/io/segment.rs
+++ b/crates/pagecache/src/io/segment.rs
@@ -1208,6 +1208,9 @@ pub fn raw_segment_iter_from(
 
     Ok(LogIter {
         config: config.clone(),
+        #[cfg(feature = "nightly")]
+        max_lsn: std::i64::MAX,
+        #[cfg(not(feature = "nightly"))]
         max_lsn: std::isize::MAX,
         cur_lsn: SEG_HEADER_LEN as Lsn,
         segment_base: None,

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 #![cfg_attr(feature="clippy", allow(inline_always))]
+#![cfg_attr(feature="nightly", feature(integer_atomics))]
 
 #[macro_use]
 extern crate serde_derive;
@@ -75,6 +76,10 @@ pub type SegmentID = usize;
 pub type LogID = u64;
 
 /// A logical sequence number.
+#[cfg(feature = "nightly")]
+pub type Lsn = i64;
+/// A logical sequence number.
+#[cfg(not(feature = "nightly"))]
 pub type Lsn = isize;
 
 /// A page identifier.

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -5,6 +5,9 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 #![cfg_attr(feature="clippy", allow(inline_always))]
 #![cfg_attr(feature="nightly", feature(integer_atomics))]
+#[cfg(all(not(feature="nightly"), target_pointer_width = "32"))]
+compile_error!("32 bit architectures require a nightly compiler for now.
+               See https://github.com/spacejam/sled/issues/145");
 
 #[macro_use]
 extern crate serde_derive;
@@ -76,10 +79,10 @@ pub type SegmentID = usize;
 pub type LogID = u64;
 
 /// A logical sequence number.
-#[cfg(feature = "nightly")]
+#[cfg(target_pointer_width = "32")]
 pub type Lsn = i64;
 /// A logical sequence number.
-#[cfg(not(feature = "nightly"))]
+#[cfg(target_pointer_width = "64")]
 pub type Lsn = isize;
 
 /// A page identifier.

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -18,6 +18,7 @@ check_snapshot_integrity = []
 no_logs = ["log/max_level_off", "pagecache/no_logs"]
 rayon = ["pagecache/rayon"]
 zstd = ["pagecache/zstd"]
+nightly = ["pagecache/nightly"]
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
Discussion points:

- [x] Is a global `nightly` feature good in this case? Should I give it a better name?
- [x] I didn't run the tests on an ARM 32-bit; would you want me to test that?
- [x] `pagecache::Lsn` is now of type `i64` when the `nightly` feature is enabled.

Let me know if you want me to change stuff! :-)

Issue #145 for reference.