### PR TITLE
 64-bit target with `nightly` feature doesn't compile anymore.

### DIFF
--- a/crates/pagecache/src/io/segment.rs
+++ b/crates/pagecache/src/io/segment.rs
@@ -1208,9 +1208,9 @@ pub fn raw_segment_iter_from(
 
     Ok(LogIter {
         config: config.clone(),
-        #[cfg(feature = "nightly")]
+        #[cfg(target_pointer_width = "32")]
         max_lsn: std::i64::MAX,
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(target_pointer_width = "64")]
         max_lsn: std::isize::MAX,
         cur_lsn: SEG_HEADER_LEN as Lsn,
         segment_base: None,


### PR DESCRIPTION
Apparently I missed a case, where `--features=nightly` and target is a 64 bit arch...

I'm wondering whether it would be better to use `#[cfg(nightly)]` everywhere, and only use `#[cfg(target_pointer_width="32")]` for the error message. That way, the i64 type gets thoroughly tested with the nightly flag, independently from whether we're targetting 32 bit...

(fixes #304)