### PR TITLE
syntax highlighting for model

### DIFF
--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! model-based testing:
 //!
-//! ```noexecute
+//! ```rust,noexecute
 //! #[macro_use]
 //! extern crate model;
 //! #[macro_use]
@@ -53,7 +53,7 @@
 //!
 //! linearizability testing:
 //!
-//! ```noexecute
+//! ```rust,noexecute
 //! #[macro_use]
 //! extern crate model;
 //! #[macro_use]


### PR DESCRIPTION
Adds syntax highlighting for the model crate. Saw it missing in the examples;
figured this would be helpful for folks. Thanks!