### PR TITLE
Fix model doctests compilation

### DIFF
--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -20,6 +20,7 @@
 //!
 //! use std::sync::atomic::{AtomicUsize, Ordering};
 //!
+//!# fn main() {
 //! model! {
 //!     Model => let m = AtomicUsize::new(0),
 //!     Implementation => let mut i: usize = 0,
@@ -49,6 +50,7 @@
 //!         assert_eq!(expected, actual);
 //!     }
 //! }
+//!# }
 //! ```
 //!
 //! linearizability testing:
@@ -61,6 +63,7 @@
 //!
 //! use std::sync::atomic::{AtomicUsize, Ordering};
 //!
+//!# fn main() {
 //! linearizable! {
 //!     Implementation => let i = Shared::new(AtomicUsize::new(0)),
 //!     BuggyAdd(usize)(v in 0usize..4) -> usize {
@@ -83,6 +86,7 @@
 //!         }
 //!     }
 //! }
+//!# }
 //! ```
 extern crate permutohedron;
 

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! model-based testing:
 //!
-//! ```rust,noexecute
+//! ```rust,no_run
 //! #[macro_use]
 //! extern crate model;
 //! #[macro_use]
@@ -55,7 +55,7 @@
 //!
 //! linearizability testing:
 //!
-//! ```rust,noexecute
+//! ```rust,no_run
 //! #[macro_use]
 //! extern crate model;
 //! #[macro_use]

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! model-based testing:
 //!
-//! ```rust,no_run
+//! ```no_run
 //! #[macro_use]
 //! extern crate model;
 //! #[macro_use]
@@ -55,7 +55,7 @@
 //!
 //! linearizability testing:
 //!
-//! ```rust,no_run
+//! ```no_run
 //! #[macro_use]
 //! extern crate model;
 //! #[macro_use]

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //!# fn main() {
 //! linearizable! {
-//!     Implementation => let i = Shared::new(AtomicUsize::new(0)),
+//!     Implementation => let i = model::Shared::new(AtomicUsize::new(0)),
 //!     BuggyAdd(usize)(v in 0usize..4) -> usize {
 //!         let current = i.load(Ordering::SeqCst);
 //!         thread::yield_now();


### PR DESCRIPTION
A few small fixes that make the doctests compile (tested using Rust 1.27.0). 