### PR TITLE
Added helpful notice regarding proptest versions.

### DIFF
--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -10,6 +10,13 @@
 //! trying to find a sequential ordering that results
 //! in the same return values.
 //!
+//! **important**: the crate makes use of
+//! [proptest](https://crates.io/crates/proptest) via
+//! macros. ensure that you are using the same version
+//! of `proptest` that `model` lists in `Cargo.toml`,
+//! otherwise mismatched API change will manifest as
+//! strange compile-time errors hidden in macros.
+//!
 //! model-based testing:
 //!
 //! ```rust,noexecute


### PR DESCRIPTION
Currently, using the latest version of proptest along with the model crate will result in breaking code with a fairly opaque error:

```
error[E0614]: type `test_model::Op` cannot be dereferenced
  --> tests/model.rs:10:5
   |
10 | /     model! {
11 | |         Model => let m = AtomicUsize::new(0),
12 | |         Implementation => let mut i: usize = 0,
13 | |         Add(usize)(v in 0usize..4) => {
...  |
37 | |         }
38 | |     }
   | |_____^
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

This is with proptest 0.8. Apparently, some types are now passed by value instead of by reference, causing the model! macro to fail. Downgrading to 0.7 fixes this; it took me a bit to get to the bottom of this issue because there is little indication for the actual underlying cause in the error messages.