### PR TITLE
support for off-log external blobs. closes #198.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
 
 matrix:
   include:
-   - rust: nightly-2018-09-13
+    - rust: nightly-2018-09-13
       env:
         - TEST=tsan
         - RUSTFLAGS="-Z sanitizer=thread"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,20 @@ rust:
 
 matrix:
   include:
-    - rust: nightly-2018-05-03
+    - rust: nightly-2018-08-04
       env:
         - TEST=tsan
         - RUSTFLAGS="-Z sanitizer=thread"
         - TSAN_OPTIONS=suppressions=/home/travis/build/spacejam/sled/tsan_suppressions.txt
-    - rust: nightly-2018-08-05
+    - rust: nightly-2018-08-04
       env:
         - TEST=lsan
         - RUSTFLAGS="-Z sanitizer=leak"
-    - rust: nightly-2018-08-05
+    - rust: nightly-2018-08-04
       env:
         - TEST=crash
         - RUST_BACKTRACE=1
-    - rust: nightly-2018-08-05
+    - rust: nightly-2018-08-04
       env:
         - TEST=cross-build
         - TARGET=i686-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ matrix:
         - TEST=tsan
         - RUSTFLAGS="-Z sanitizer=thread"
         - TSAN_OPTIONS=suppressions=/home/travis/build/spacejam/sled/tsan_suppressions.txt
-    - rust: nightly-2018-05-03
+    - rust: nightly-2018-08-05
       env:
         - TEST=lsan
         - RUSTFLAGS="-Z sanitizer=leak"
-    - rust: nightly-2018-05-03
+    - rust: nightly-2018-08-05
       env:
         - TEST=crash
         - RUST_BACKTRACE=1
-    - rust: nightly-2018-05-03
+    - rust: nightly-2018-08-05
       env:
         - TEST=cross-build
         - TARGET=i686-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,9 @@ exclude = [
   "examples/crdt_merge_store",
   "examples/pessimistic_transactions",
 ]
+
+[profile.release]
+debug = 2
+
+[profile.dev]
+opt-level = 1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn concatenate_merge(
 ) -> Option<Vec<u8>> {       // set the new value, return None to delete
   let mut ret = old_value
     .map(|ov| ov.to_vec())
-    .unwrap_or_else(|| vec![]); 
+    .unwrap_or_else(|| vec![]);
 
   ret.extend_from_slice(merged_bytes);
 
@@ -104,8 +104,6 @@ assert_eq!(tree.get(&k), Ok(Some(vec![4])));
 
 # known issues, warnings
 
-* keys and values must fit into `io_buf_size` divided by
-  `min_items_per_segment`. 
 * quite young, should be considered unstable for the time being
 * the C API is likely to change rapidly
 * the on-disk format is going to change in non-forward compatible ways
@@ -115,7 +113,7 @@ assert_eq!(tree.get(&k), Ok(Some(vec![4])));
   it has an extremely high theoretical performance but there
   is a bit of tuning to get there. currently only around 200k
   operations per second with mixed workloads, and 7 million/s
-  for read-only workloads on tiny keys. this will be improving 
+  for read-only workloads on tiny keys. this will be improving
   dramatically soon!
 * 32 bit architectures [require Rust nightly with the `nightly` feature enabled](https://github.com/spacejam/sled/issues/145).
 

--- a/benchmarks/stress2/Cargo.toml
+++ b/benchmarks/stress2/Cargo.toml
@@ -18,7 +18,7 @@ no_logs = ["sled/no_logs"]
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
-docopt = "0.8"
+docopt = "1.0"
 chan-signal = "0.3"
 rand = "0.4"
 sled = { path = "../../crates/sled" }

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -19,11 +19,9 @@
 //!
 //! model-based testing:
 //!
-//! ```no_run
+//! ```
 //! #[macro_use]
 //! extern crate model;
-//! #[macro_use]
-//! extern crate proptest;
 //!
 //! use std::sync::atomic::{AtomicUsize, Ordering};
 //!
@@ -96,6 +94,7 @@
 //!# }
 //! ```
 extern crate permutohedron;
+extern crate proptest;
 
 use std::ops::Deref;
 

--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagecache"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "lock-free pagecache and log for high-performance databases"
 license = "MIT/Apache-2.0"

--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -36,7 +36,7 @@ rayon = {version = "1.0", optional = true}
 zstd = {version = "0.4", optional = true}
 clippy = {version = "0.0", optional = true}
 rand = {version = "0.4", optional = true}
-pagetable = { path = "../pagetable", version = "0.0" }
+pagetable = {version = "0.0", path = "../pagetable"}
 
 [dev-dependencies]
 rand = "0.4"

--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagecache"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "lock-free pagecache and log for high-performance databases"
 license = "MIT/Apache-2.0"

--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -614,6 +614,8 @@ impl Config {
             + Send
             + PartialEq,
     {
+        debug!("generating incremental snapshot");
+
         let incremental =
             read_snapshot_or_default::<PM, P, R>(&self)?;
 
@@ -621,6 +623,7 @@ impl Config {
             std::fs::remove_file(snapshot_path)?;
         }
 
+        debug!("generating snapshot without the previous one");
         let regenerated =
             read_snapshot_or_default::<PM, P, R>(&self)?;
 

--- a/crates/pagecache/src/diskptr.rs
+++ b/crates/pagecache/src/diskptr.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+use io::LogReader;
+
+/// A pointer to a location on disk or an off-log blob.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum DiskPtr {
+    /// Points to a value stored in the single-file log.
+    Inline(LogID),
+    /// Points to a value stored off-log in the blob directory.
+    External(LogID, ExternalPointer),
+}
+
+impl DiskPtr {
+    pub(crate) fn new_inline(l: LogID) -> DiskPtr {
+        DiskPtr::Inline(l)
+    }
+
+    pub(crate) fn new_external(
+        lid: LogID,
+        ptr: ExternalPointer,
+    ) -> DiskPtr {
+        DiskPtr::External(lid, ptr)
+    }
+
+    pub(crate) fn is_inline(&self) -> bool {
+        match self {
+            DiskPtr::Inline(_) => true,
+            DiskPtr::External(_, _) => false,
+        }
+    }
+
+    pub(crate) fn is_external(&self) -> bool {
+        match self {
+            DiskPtr::External(_, _) => true,
+            DiskPtr::Inline(_) => false,
+        }
+    }
+
+    pub(crate) fn inline(&self) -> LogID {
+        match self {
+            DiskPtr::Inline(l) => *l,
+            DiskPtr::External(_, _) => {
+                panic!("inline called on External disk pointer")
+            }
+        }
+    }
+
+    pub(crate) fn external(&self) -> (LogID, ExternalPointer) {
+        match self {
+            DiskPtr::External(lid, ptr) => (*lid, *ptr),
+            DiskPtr::Inline(_) => {
+                panic!("external called on Internal disk pointer")
+            }
+        }
+    }
+
+    pub(crate) fn lid(&self) -> LogID {
+        match self {
+            DiskPtr::External(lid, _) | DiskPtr::Inline(lid) => *lid,
+        }
+    }
+
+    pub(crate) fn read(
+        &self,
+        config: &Config,
+    ) -> CacheResult<Vec<u8>, ()> {
+        match self {
+            DiskPtr::External(_lid, ptr) => read_blob(*ptr, &config),
+            DiskPtr::Inline(lid) => {
+                let mut f = config.file()?;
+
+                f.read_message(*lid, &config).map(|log_read| {
+                    log_read
+                        .inline()
+                        .expect(
+                            "call to DiskPtr::read with \
+                             an Inline pointer should result \
+                             in a valid Inline read. It's \
+                             possible the DiskPtr outlived \
+                             an outer guard.",
+                        )
+                        .1
+                })
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for DiskPtr {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter,
+    ) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)
+    }
+}

--- a/crates/pagecache/src/diskptr.rs
+++ b/crates/pagecache/src/diskptr.rs
@@ -55,7 +55,8 @@ impl DiskPtr {
         }
     }
 
-    pub(crate) fn lid(&self) -> LogID {
+    #[doc(hidden)]
+    pub fn lid(&self) -> LogID {
         match self {
             DiskPtr::External(lid, _) | DiskPtr::Inline(lid) => *lid,
         }

--- a/crates/pagecache/src/ds/stack.rs
+++ b/crates/pagecache/src/ds/stack.rs
@@ -103,7 +103,8 @@ impl<T: Send + 'static> Stack<T> {
             loop {
                 let head = self.head(unprotected());
                 node.deref().next.store(head, SeqCst);
-                if self.head
+                if self
+                    .head
                     .compare_and_set(
                         head,
                         node,
@@ -127,7 +128,8 @@ impl<T: Send + 'static> Stack<T> {
             match unsafe { head.as_ref() } {
                 Some(h) => {
                     let next = h.next.load(SeqCst, &guard);
-                    match self.head
+                    match self
+                        .head
                         .compare_and_set(head, next, SeqCst, &guard)
                     {
                         Ok(_) => unsafe {

--- a/crates/pagecache/src/io/blob_io.rs
+++ b/crates/pagecache/src/io/blob_io.rs
@@ -1,0 +1,109 @@
+use std::io::{Read, Write};
+
+use super::*;
+
+use epoch::pin;
+
+pub(crate) fn read_blob(
+    external_ptr: Lsn,
+    config: &Config,
+) -> CacheResult<Vec<u8>, ()> {
+    let path = config.blob_path(external_ptr);
+    let mut f = std::fs::OpenOptions::new().read(true).open(&path)?;
+
+    let mut crc_expected_bytes = [0u8; EXTERNAL_VALUE_LEN];
+    f.read_exact(&mut crc_expected_bytes).unwrap();
+    let crc_expected: u64 =
+        unsafe { std::mem::transmute(crc_expected_bytes) };
+
+    let mut buf = vec![];
+    f.read_to_end(&mut buf)?;
+
+    let crc_actual = crc64(&*buf);
+
+    if crc_expected != crc_actual {
+        warn!("blob {} failed crc check!", external_ptr);
+
+        Err(Error::Corruption {
+            // FIXME Corruption pointer below should not have 0 as its LogID
+            at: DiskPtr::External(0, external_ptr),
+        })
+    } else {
+        Ok(buf)
+    }
+}
+
+pub(crate) fn write_blob(
+    config: &Config,
+    id: Lsn,
+    mut data: Vec<u8>,
+) -> CacheResult<(), ()> {
+    let path = config.blob_path(id);
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+
+    let mut crc: [u8; EXTERNAL_VALUE_LEN] =
+        unsafe { std::mem::transmute(crc64(&*data)) };
+
+    f.write_all(&mut crc)
+        .and_then(|_| f.write_all(&mut data))
+        .map_err(|e| e.into())
+}
+
+pub(crate) fn gc_blobs(
+    config: &Config,
+    stable_lsn: Lsn,
+) -> CacheResult<(), ()> {
+    let stable = config.blob_path(stable_lsn);
+    let blob_dir = stable.parent().unwrap();
+    let blobs = std::fs::read_dir(blob_dir)?;
+
+    for blob in blobs {
+        let path = blob?.path();
+        let lsn_str = path.file_name().unwrap().to_str().unwrap();
+        let lsn_res: Result<Lsn, _> = lsn_str.parse();
+
+        if let Err(e) = lsn_res {
+            return Err(Error::Unsupported(format!(
+                "blobs directory contains \
+                 unparsable path ({:?}): {}",
+                path, e
+            )));
+        }
+
+        let lsn = lsn_res.unwrap();
+
+        if lsn > stable_lsn {
+            warn!(
+                "removing blob {:?} that has \
+                 a higher lsn than our stable log: {:?}",
+                path, stable
+            );
+            std::fs::remove_file(&path)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn remove_blob(
+    id: Lsn,
+    config: &Config,
+) -> CacheResult<(), ()> {
+    let path = config.blob_path(id);
+
+    let guard = pin();
+
+    unsafe {
+        guard.defer(move || {
+            if let Err(e) = std::fs::remove_file(&path) {
+                warn!("removing blob at {:?} failed: {}", path, e);
+            }
+        });
+    }
+
+    // TODO return a future
+    Ok(())
+}

--- a/crates/pagecache/src/io/iobuf.rs
+++ b/crates/pagecache/src/io/iobuf.rs
@@ -242,6 +242,7 @@ impl IoBufs {
     ) -> CacheResult<Vec<u8>, ()> {
         let buf = if over_blob_threshold {
             // write blob to file
+            io_fail!(self, "external blob write");
             write_blob(&self.config, lsn, raw_buf)?;
 
             let lsn_buf: [u8;

--- a/crates/pagecache/src/io/log.rs
+++ b/crates/pagecache/src/io/log.rs
@@ -252,6 +252,7 @@ pub enum LogRead {
     Failed(Lsn, usize),
     Pad(Lsn),
     Corrupted(usize),
+    DanglingExternal(Lsn, ExternalPointer),
 }
 
 impl LogRead {

--- a/crates/pagecache/src/io/log.rs
+++ b/crates/pagecache/src/io/log.rs
@@ -12,6 +12,9 @@ pub const SEG_HEADER_LEN: usize = 10;
 #[doc(hidden)]
 pub const SEG_TRAILER_LEN: usize = 10;
 
+#[doc(hidden)]
+pub const EXTERNAL_VALUE_LEN: usize = std::mem::size_of::<Lsn>();
+
 /// A sequential store which allows users to create
 /// reservations placed at known log offsets, used
 /// for writing persistent data structures that need
@@ -104,6 +107,16 @@ impl Log {
         self.iobufs.reserve(buf)
     }
 
+    /// Reserve a replacement buffer for a previously written
+    /// external write. This ensures the message header has the
+    /// proper external flag set.
+    pub(super) fn reserve_external(
+        &self,
+        external_ptr: ExternalPointer,
+    ) -> CacheResult<Reservation, ()> {
+        self.iobufs.reserve_external(external_ptr)
+    }
+
     /// Write a buffer into the log. Returns the log sequence
     /// number and the file offset of the write.
     pub fn write(
@@ -145,25 +158,34 @@ impl Log {
     pub fn read(
         &self,
         lsn: Lsn,
-        lid: LogID,
+        ptr: DiskPtr,
     ) -> CacheResult<LogRead, ()> {
-        trace!("reading log lsn {} lid {}", lsn, lid);
+        trace!("reading log lsn {} ptr {}", lsn, ptr);
+
         self.make_stable(lsn)?;
-        let f = self.config.file()?;
 
-        let read = f.read_message(
-            lid,
-            self.config.io_buf_size,
-            self.config.use_compression,
-        );
+        if ptr.is_inline() {
+            let lid = ptr.inline();
+            let f = self.config.file()?;
 
-        read.and_then(|log_read| match log_read {
-            LogRead::Flush(read_lsn, _, _) => {
-                assert_eq!(lsn, read_lsn);
-                Ok(log_read)
-            }
-            _ => Ok(log_read),
-        }).map_err(|e| e.into())
+            let read = f.read_message(lid, &self.config);
+
+            read.and_then(|log_read| match log_read {
+                LogRead::Inline(read_lsn, _, _)
+                | LogRead::External(read_lsn, _, _) => {
+                    if lsn != read_lsn {
+                        Err(Error::Corruption { at: ptr })
+                    } else {
+                        Ok(log_read)
+                    }
+                }
+                _ => Ok(log_read),
+            }).map_err(|e| e.into())
+        } else {
+            let (_lid, external_ptr) = ptr.external();
+            read_blob(external_ptr, &self.config)
+                .map(|buf| LogRead::External(lsn, buf, external_ptr))
+        }
     }
 
     /// returns the current stable offset written to disk
@@ -223,39 +245,49 @@ pub(crate) struct SegmentTrailer {
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, PartialEq)]
-pub enum InlineOrExternalValue {
-    InlineValue(Vec<u8>),
-    ExternalValue(Lsn),
-}
-
-#[doc(hidden)]
 #[derive(Debug)]
 pub enum LogRead {
-    Flush(Lsn, InlineOrExternalValue, usize),
+    Inline(Lsn, Vec<u8>, usize),
+    External(Lsn, Vec<u8>, ExternalPointer),
     Failed(Lsn, usize),
     Pad(Lsn),
     Corrupted(usize),
 }
 
 impl LogRead {
-    /// Optionally return successfully read bytes, or None if
-    /// the data was corrupt or this log entry was aborted.
-    pub fn flush(
-        self,
-    ) -> Option<(Lsn, InlineOrExternalValue, usize)> {
+    /// Optionally return successfully read inline bytes, or
+    /// None if the data was corrupt or this log entry was aborted.
+    pub fn inline(self) -> Option<(Lsn, Vec<u8>, usize)> {
         match self {
-            LogRead::Flush(lsn, bytes, len) => {
+            LogRead::Inline(lsn, bytes, len) => {
                 Some((lsn, bytes, len))
             }
             _ => None,
         }
     }
 
-    /// Return true if we read a completed write successfully.
-    pub fn is_flush(&self) -> bool {
+    /// Return true if this is an Inline value..
+    pub fn is_inline(&self) -> bool {
         match *self {
-            LogRead::Flush(_, _, _) => true,
+            LogRead::Inline(_, _, _) => true,
+            _ => false,
+        }
+    }
+
+    /// Optionally return a successfully read pointer to an
+    /// external value, or None if the data was corrupt or
+    /// this log entry was aborted.
+    pub fn external(self) -> Option<(Lsn, Vec<u8>, ExternalPointer)> {
+        match self {
+            LogRead::External(lsn, buf, ptr) => Some((lsn, buf, ptr)),
+            _ => None,
+        }
+    }
+
+    /// Return true if we read a completed external write successfully.
+    pub fn is_external(&self) -> bool {
+        match self {
+            LogRead::External(..) => true,
             _ => false,
         }
     }
@@ -284,31 +316,12 @@ impl LogRead {
         }
     }
 
-    /// Retrieve the read bytes from a completed, successful write.
-    ///
-    /// # Panics
-    ///
-    /// panics if `is_flush()` is false.
-    pub fn unwrap(self) -> (Lsn, InlineOrExternalValue, usize) {
+    /// Return the underlying data read from a log read, if successful.
+    pub fn into_data(self) -> Option<Vec<u8>> {
         match self {
-            LogRead::Flush(lsn, bytes, len) => (lsn, bytes, len),
-            _ => panic!("called unwrap on a non-flush LogRead"),
-        }
-    }
-
-    /// Retrieves the read bytes from a successful write, or
-    /// panics with the provided error message.
-    ///
-    /// # Panics
-    ///
-    /// panics if `is_flush()` is false.
-    pub fn expect<'a>(
-        self,
-        msg: &'a str,
-    ) -> (Lsn, InlineOrExternalValue, usize) {
-        match self {
-            LogRead::Flush(lsn, bytes, len) => (lsn, bytes, len),
-            _ => panic!("{}", msg),
+            LogRead::External(_, buf, _)
+            | LogRead::Inline(_, buf, _) => Some(buf),
+            _ => None,
         }
     }
 }

--- a/crates/pagecache/src/io/log.rs
+++ b/crates/pagecache/src/io/log.rs
@@ -122,7 +122,7 @@ impl Log {
     pub fn write(
         &self,
         buf: Vec<u8>,
-    ) -> CacheResult<(Lsn, LogID), ()> {
+    ) -> CacheResult<(Lsn, DiskPtr), ()> {
         self.iobufs.reserve(buf).and_then(|res| res.complete())
     }
 
@@ -296,6 +296,16 @@ impl LogRead {
     pub fn is_failed(&self) -> bool {
         match *self {
             LogRead::Failed(_, _) => true,
+            _ => false,
+        }
+    }
+
+    /// Return true if we read a successful Inline or External value.
+    pub fn is_successful(&self) -> bool {
+        match *self {
+            LogRead::Inline(_, _, _) | LogRead::External(_, _, _) => {
+                true
+            }
             _ => false,
         }
     }

--- a/crates/pagecache/src/io/mod.rs
+++ b/crates/pagecache/src/io/mod.rs
@@ -33,7 +33,9 @@ pub(super) use self::reader::LogReader;
 #[doc(hidden)]
 pub use self::snapshot::{read_snapshot_or_default, Snapshot};
 
-pub use self::log::Log;
+pub use self::log::{
+    InlineOrExternalValue::{ExternalValue, InlineValue}, Log,
+};
 pub use self::materializer::{Materializer, NullMaterializer};
 pub use self::page_cache::{CacheEntry, PageCache, PageGet};
 pub use self::reservation::Reservation;
@@ -49,15 +51,18 @@ use self::parallel_io::Pio;
 use self::segment::{raw_segment_iter_from, SegmentAccountant};
 use self::snapshot::{advance_snapshot, PageState};
 
-// The EVIL_BYTE is written to force detection of
-// a corruption when dealing with unused segment space.
-const EVIL_BYTE: u8 = 6;
-
-// This message represents valid data.
-const SUCCESSFUL_FLUSH: u8 = 1;
-
 // This message should be skipped to preserve linearizability.
 const FAILED_FLUSH: u8 = 0;
 
+// This message represents valid data, stored inline.
+const SUCCESSFUL_FLUSH: u8 = 1;
+
+// This message represents valid data, stored externally.
+const SUCCESSFUL_EXTERNAL_FLUSH: u8 = 2;
+
 // This message represents a pad.
-const SEGMENT_PAD: u8 = 2;
+const SEGMENT_PAD: u8 = 3;
+
+// The EVIL_BYTE is written to force detection of
+// a corruption when dealing with unused segment space.
+const EVIL_BYTE: u8 = 6;

--- a/crates/pagecache/src/io/mod.rs
+++ b/crates/pagecache/src/io/mod.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 
 use super::*;
 
+mod blob_io;
 mod iobuf;
 mod iterator;
 mod log;
@@ -25,7 +26,12 @@ mod snapshot;
 
 #[doc(hidden)]
 pub use self::log::{
-    LogRead, MSG_HEADER_LEN, SEG_HEADER_LEN, SEG_TRAILER_LEN,
+    LogRead, EXTERNAL_VALUE_LEN, MSG_HEADER_LEN, SEG_HEADER_LEN,
+    SEG_TRAILER_LEN,
+};
+
+pub(crate) use self::blob_io::{
+    gc_blobs, read_blob, remove_blob, write_blob,
 };
 
 pub(super) use self::reader::LogReader;
@@ -33,9 +39,7 @@ pub(super) use self::reader::LogReader;
 #[doc(hidden)]
 pub use self::snapshot::{read_snapshot_or_default, Snapshot};
 
-pub use self::log::{
-    InlineOrExternalValue::{ExternalValue, InlineValue}, Log,
-};
+pub use self::log::Log;
 pub use self::materializer::{Materializer, NullMaterializer};
 pub use self::page_cache::{CacheEntry, PageCache, PageGet};
 pub use self::reservation::Reservation;

--- a/crates/pagecache/src/io/page_cache.rs
+++ b/crates/pagecache/src/io/page_cache.rs
@@ -568,7 +568,6 @@ where
             self.cas_page(pid, key, update, guard).map(|_| ())?;
 
             // drop all previous external pointers
-
             let external_ptrs = cache_entries
                 .iter()
                 .filter(|ce| ce.ptr().is_external())

--- a/crates/pagecache/src/io/reservation.rs
+++ b/crates/pagecache/src/io/reservation.rs
@@ -34,6 +34,10 @@ impl<'a> Reservation<'a> {
 
             assert_eq!(self.lsn, blob_ptr);
 
+            trace!(
+                "removing blob for aborted reservation at lsn {}",
+                blob_ptr
+            );
             remove_blob(blob_ptr, &self.iobufs.config)?;
         }
 

--- a/crates/pagecache/src/io/reservation.rs
+++ b/crates/pagecache/src/io/reservation.rs
@@ -28,7 +28,7 @@ impl<'a> Drop for Reservation<'a> {
 impl<'a> Reservation<'a> {
     /// Cancel the reservation, placing a failed flush on disk, returning
     /// the (cancelled) log sequence number and file offset.
-    pub fn abort(mut self) -> CacheResult<(Lsn, LogID), ()> {
+    pub fn abort(mut self) -> CacheResult<(Lsn, DiskPtr), ()> {
         if self.is_external {
             let blob_ptr = self.external_ptr().unwrap();
 
@@ -42,7 +42,7 @@ impl<'a> Reservation<'a> {
 
     /// Complete the reservation, placing the buffer on disk. returns
     /// the log sequence number of the write, and the file offset.
-    pub fn complete(mut self) -> CacheResult<(Lsn, LogID), ()> {
+    pub fn complete(mut self) -> CacheResult<(Lsn, DiskPtr), ()> {
         self.flush(true)
     }
 
@@ -85,7 +85,7 @@ impl<'a> Reservation<'a> {
     fn flush(
         &mut self,
         valid: bool,
-    ) -> CacheResult<(Lsn, LogID), ()> {
+    ) -> CacheResult<(Lsn, DiskPtr), ()> {
         if self.flushed {
             panic!("flushing already-flushed reservation!");
         }
@@ -102,6 +102,6 @@ impl<'a> Reservation<'a> {
 
         self.iobufs.exit_reservation(self.idx)?;
 
-        Ok((self.lsn(), self.lid()))
+        Ok((self.lsn(), self.ptr()))
     }
 }

--- a/crates/pagecache/src/io/snapshot.rs
+++ b/crates/pagecache/src/io/snapshot.rs
@@ -259,7 +259,17 @@ impl<R> Snapshot<R> {
                         .map(|(_, ptr)| ptr.external().1);
 
                     for external_ptr in external_ptrs {
-                        remove_blob(external_ptr, config).expect("should be able to clean up orphaned external writes");
+                        trace!(
+                            "removing blob while advancing \
+                             snapshot: {}",
+                            external_ptr,
+                        );
+
+                        // we don't care if this actually works
+                        // because it's possible that a previous
+                        // snapshot has run over this log and
+                        // removed the blob already.
+                        let _ = remove_blob(external_ptr, config);
                     }
                 }
             }

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -40,6 +40,7 @@ pub use ds::{Radix, Stack};
 
 /// general-purpose configuration
 pub use config::{Config, ConfigBuilder};
+pub use diskptr::DiskPtr;
 pub use io::*;
 pub use result::{CacheResult, Error};
 
@@ -61,7 +62,7 @@ macro_rules! rep_no_copy {
 }
 
 mod config;
-/// auxilliary data structures
+mod diskptr;
 mod ds;
 mod hash;
 mod io;
@@ -69,7 +70,6 @@ mod metrics;
 mod periodic;
 mod result;
 
-// use log::{Iter, MessageHeader, SegmentHeader, SegmentTrailer};
 use ds::*;
 use hash::{crc16_arr, crc64};
 use historian::Histo;
@@ -81,12 +81,11 @@ pub type SegmentID = usize;
 /// A log file offset.
 pub type LogID = u64;
 
+/// A pointer to an external blob.
+pub type ExternalPointer = Lsn;
+
 /// A logical sequence number.
-#[cfg(target_pointer_width = "32")]
 pub type Lsn = i64;
-/// A logical sequence number.
-#[cfg(target_pointer_width = "64")]
-pub type Lsn = isize;
 
 /// A page identifier.
 pub type PageID = usize;
@@ -117,11 +116,7 @@ where
     }
 }
 
-unsafe impl<'g, P> Send for RayonPagePtr<'g, P>
-where
-    P: Send,
-{
-}
+unsafe impl<'g, P> Send for RayonPagePtr<'g, P> where P: Send {}
 
 lazy_static! {
     /// A metric collector for all pagecache users running in this

--- a/crates/pagecache/src/metrics.rs
+++ b/crates/pagecache/src/metrics.rs
@@ -13,6 +13,7 @@ pub struct Metrics {
     pub tree_cas: Histo,
     pub tree_scan: Histo,
     pub page_in: Histo,
+    pub rewrite_page: Histo,
     pub merge_page: Histo,
     pub page_out: Histo,
     pub pull: Histo,

--- a/crates/pagecache/src/result.rs
+++ b/crates/pagecache/src/result.rs
@@ -24,7 +24,7 @@ pub enum Error<Actual> {
     /// Corruption has been detected in the storage file.
     Corruption {
         /// The file location that corrupted data was found at.
-        at: LogID,
+        at: DiskPtr,
     },
     // a failpoint has been triggered for testing purposes
     #[doc(hidden)]

--- a/crates/pagetable/Cargo.toml
+++ b/crates/pagetable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagetable"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "simple wait-free two-level pagetable with 2mb pages"
 license = "MIT/Apache-2.0"
@@ -8,6 +8,9 @@ homepage = "https://github.com/spacejam/sled/tree/master/crates/pagetable"
 repository = "https://github.com/spacejam/sled"
 keywords = ["paging", "page-table", "table", "data-structure", "lookup"]
 documentation = "https://docs.rs/pagetable/"
+
+[profile.dev]
+opt-level = 1
 
 [dependencies]
 crossbeam-epoch = "0.4"

--- a/crates/pagetable/Cargo.toml
+++ b/crates/pagetable/Cargo.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/spacejam/sled"
 keywords = ["paging", "page-table", "table", "data-structure", "lookup"]
 documentation = "https://docs.rs/pagetable/"
 
-[profile.dev]
-opt-level = 1
-
 [dependencies]
 crossbeam-epoch = "0.4"
 

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.15.17"
+version = "0.15.18"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a flash-sympathetic persistent lock-free B+ tree"
 license = "MIT/Apache-2.0"
@@ -32,4 +32,4 @@ bincode = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 clippy = {version = "0.0", optional = true}
-pagecache = { path = "../pagecache", version = "0.4.5" }
+pagecache = { path = "../pagecache", version = "0.4.6" }

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -20,9 +20,6 @@ rayon = ["pagecache/rayon"]
 zstd = ["pagecache/zstd"]
 nightly = ["pagecache/nightly"]
 
-[profile.release]
-debug = 2
-
 [dependencies.log]
 version = "0.4"
 

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.15.18"
+version = "0.15.19"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a flash-sympathetic persistent lock-free B+ tree"
 license = "MIT/Apache-2.0"
@@ -32,4 +32,4 @@ bincode = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 clippy = {version = "0.0", optional = true}
-pagecache = { path = "../pagecache", version = "0.4.6" }
+pagecache = { path = "../pagecache", version = "0.5.0" }

--- a/tests/tests/test_crash_recovery.rs
+++ b/tests/tests/test_crash_recovery.rs
@@ -4,6 +4,7 @@ extern crate libc;
 extern crate pagecache;
 extern crate rand;
 extern crate sled;
+extern crate tests;
 
 use std::fs;
 use std::mem::size_of;
@@ -91,6 +92,7 @@ fn slice_to_u32(b: &[u8]) -> u32 {
 }
 
 fn run(config: Config) {
+    // tests::setup_logger();
     let tree = sled::Tree::start(config).unwrap();
 
     // flush to ensure the initial root is stable.
@@ -232,43 +234,13 @@ fn test_crash_recovery_no_runtime_snapshot() {
 fn cleanup_with_snapshots() {
     let dir = Path::new("test_crashes_with_snapshot");
     if dir.exists() {
-        let _res = fs::remove_file("test_crashes_with_snapshot/db");
-        let _res = fs::remove_file("test_crashes_with_snapshot/conf");
-
-        for dir_entry in fs::read_dir(dir).unwrap() {
-            if let Ok(de) = dir_entry {
-                let path_buf = de.path();
-                let path = path_buf.as_path();
-                let path_str = path.to_str().unwrap();
-                if path_str
-                    .starts_with("test_crashes_with_snapshot/snap.")
-                {
-                    let _res = fs::remove_file(path);
-                }
-            }
-        }
-
-        fs::remove_dir_all("test_crashes_with_snapshot").unwrap();
+        fs::remove_dir_all(dir).unwrap();
     }
 }
 
 fn cleanup() {
     let dir = Path::new("test_crashes");
     if dir.exists() {
-        let _res = fs::remove_file("test_crashes/db");
-        let _res = fs::remove_file("test_crashes/conf");
-
-        for dir_entry in fs::read_dir(dir).unwrap() {
-            if let Ok(de) = dir_entry {
-                let path_buf = de.path();
-                let path = path_buf.as_path();
-                let path_str = path.to_str().unwrap();
-                if path_str.starts_with("test_crashes/snap.") {
-                    let _res = fs::remove_file(path);
-                }
-            }
-        }
-
-        fs::remove_dir_all("test_crashes").unwrap();
+        fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/tests/tests/test_crash_recovery.rs
+++ b/tests/tests/test_crash_recovery.rs
@@ -1,11 +1,12 @@
 #![cfg(all(not(target_os = "fuchsia"), not(target_os = "android")))]
 
-extern crate pagecache;
-extern crate sled;
 extern crate libc;
+extern crate pagecache;
 extern crate rand;
+extern crate sled;
 
 use std::fs;
+use std::mem::size_of;
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
@@ -37,7 +38,7 @@ fn verify(tree: &sled::Tree) -> (u32, u32) {
     let mut lowest = 0;
     for res in iter {
         let (mut k, v) = res.unwrap();
-        if v == highest_vec {
+        if &v[..4] == &highest_vec[..4] {
             contiguous += 1;
         } else {
             k.reverse();
@@ -77,13 +78,14 @@ fn verify(tree: &sled::Tree) -> (u32, u32) {
 }
 
 fn u32_to_vec(u: u32) -> Vec<u8> {
-    let buf: [u8; 4] = unsafe { std::mem::transmute(u) };
+    let buf: [u8; size_of::<u32>()] =
+        unsafe { std::mem::transmute(u) };
     buf.to_vec()
 }
 
 fn slice_to_u32(b: &[u8]) -> u32 {
-    let mut buf = [0u8; 4];
-    buf.copy_from_slice(b);
+    let mut buf = [0u8; size_of::<u32>()];
+    buf.copy_from_slice(&b[..size_of::<u32>()]);
 
     unsafe { std::mem::transmute(buf) }
 }
@@ -95,8 +97,6 @@ fn run(config: Config) {
     // TODO is this necessary or voodoo?
     tree.flush().unwrap();
 
-    let (key, highest) = verify(&tree);
-
     thread::spawn(|| {
         let runtime = rand::thread_rng().gen_range(0, 200);
         thread::sleep(Duration::from_millis(runtime));
@@ -104,6 +104,8 @@ fn run(config: Config) {
             libc::raise(9);
         }
     });
+
+    let (key, highest) = verify(&tree);
 
     let mut hu = ((highest as usize) * CYCLE) + key as usize;
     assert_eq!(hu % CYCLE, key as usize);
@@ -118,7 +120,11 @@ fn run(config: Config) {
 
         let mut key = u32_to_vec((hu % CYCLE) as u32);
         key.reverse();
-        let value = u32_to_vec((hu / CYCLE) as u32);
+
+        let mut value = u32_to_vec((hu / CYCLE) as u32);
+        let additional_len = rand::thread_rng().gen_range(0, 100_000);
+        value.append(&mut vec![0u8; additional_len]);
+
         tree.set(key, value).unwrap();
     }
 }
@@ -139,7 +145,13 @@ fn run_without_snapshot() {
         .snapshot_after_ops(1 << 56)
         .build();
 
-    run(config);
+    match thread::spawn(|| run(config)).join() {
+        Err(e) => {
+            println!("worker thread failed: {:?}", e);
+            std::process::exit(15);
+        }
+        _ => {}
+    }
 }
 
 fn run_with_snapshot() {
@@ -158,7 +170,13 @@ fn run_with_snapshot() {
         .snapshot_after_ops(1 << 10)
         .build();
 
-    run(config);
+    match thread::spawn(|| run(config)).join() {
+        Err(e) => {
+            println!("worker thread failed: {:?}", e);
+            std::process::exit(15);
+        }
+        _ => {}
+    }
 }
 
 #[test]
@@ -171,7 +189,11 @@ fn test_crash_recovery_with_runtime_snapshot() {
         } else {
             let mut status = 0;
             unsafe {
-                libc::waitpid(child, &mut status as *mut libc::c_int, 0);
+                libc::waitpid(
+                    child,
+                    &mut status as *mut libc::c_int,
+                    0,
+                );
             }
             if status != 9 {
                 cleanup();
@@ -192,7 +214,11 @@ fn test_crash_recovery_no_runtime_snapshot() {
         } else {
             let mut status = 0;
             unsafe {
-                libc::waitpid(child, &mut status as *mut libc::c_int, 0);
+                libc::waitpid(
+                    child,
+                    &mut status as *mut libc::c_int,
+                    0,
+                );
             }
             if status != 9 {
                 cleanup();
@@ -214,7 +240,9 @@ fn cleanup_with_snapshots() {
                 let path_buf = de.path();
                 let path = path_buf.as_path();
                 let path_str = path.to_str().unwrap();
-                if path_str.starts_with("test_crashes_with_snapshot/snap.") {
+                if path_str
+                    .starts_with("test_crashes_with_snapshot/snap.")
+                {
                     let _res = fs::remove_file(path);
                 }
             }

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -256,20 +256,8 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 // insert false certainty before completes
                 reference.insert(k as u16, (k as u16, false));
 
-                let res = fp_crash!(tree.del(&*vec![0, k]));
-                match res {
-                    Some(_) => {
-                        // we definitely caused a file write
-                        tree.flush().expect(
-                            "should be able to flush after del",
-                        )
-                    }
-                    None => {
-                        // we might not have actually written anything
-                        // because the key wasn't there.
-                        let _ = tree.flush();
-                    }
-                }
+                fp_crash!(tree.del(&*vec![0, k]));
+                fp_crash!(tree.flush());
 
                 reference.remove(&(k as u16));
             }
@@ -526,7 +514,6 @@ fn failpoints_bug_9() {
 }
 
 #[test]
-#[ignore]
 fn failpoints_bug_10() {
     // expected to iterate over 50 but got 49 instead
     // postmortem 1:
@@ -660,7 +647,6 @@ fn failpoints_bug_10() {
             Del(0),
             Set,
             Del(146),
-            Restart,
             Del(83),
             Restart,
             Del(0),
@@ -735,36 +721,15 @@ fn failpoints_bug_10() {
             Set,
             Del(49),
             Set,
-            Set,
-            Restart,
-            Set,
-            Set,
-            Set,
-            Set,
-            Del(197),
-            Restart,
-            Restart,
-            Del(192),
-            Set,
-            Del(10),
-            Set,
-            Set,
-            Set,
-            Set,
-            Set,
-            Set,
-            Set,
         ],
-        true,
+        false,
     ))
 }
 
 #[test]
-#[ignore]
 fn failpoints_bug_11() {
     // dupe lsn detected
     // postmortem 1:
-    tests::setup_logger();
     assert!(prop_tree_crashes_nicely(
         vec![
             Set,
@@ -805,7 +770,6 @@ fn failpoints_bug_11() {
 fn failpoints_bug_12() {
     // postmortem 1: we were not sorting the recovery state, which
     // led to divergent state across recoveries. TODO wut
-    tests::setup_logger();
     assert!(prop_tree_crashes_nicely(
         vec![
             Set,
@@ -829,7 +793,6 @@ fn failpoints_bug_12() {
 #[test]
 fn failpoints_bug_13() {
     // postmortem 1:
-    tests::setup_logger();
     assert!(prop_tree_crashes_nicely(
         vec![
             Set,

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 extern crate lazy_static;
-extern crate quickcheck;
 extern crate fail;
+extern crate pagecache;
+extern crate quickcheck;
 extern crate rand;
 extern crate sled;
-extern crate pagecache;
 extern crate tests;
 
 use std::collections::{BTreeMap, HashSet};
@@ -47,6 +47,7 @@ impl Arbitrary for Op {
             "snap write mv",
             "snap write mv post",
             "snap write rm old",
+            "external blob write",
         ];
 
         if g.gen_weighted_bool(30) {
@@ -69,10 +70,8 @@ impl Arbitrary for Op {
     fn shrink(&self) -> Box<Iterator<Item = Op>> {
         match *self {
             Op::Del(ref lid) if *lid > 0 => Box::new(
-                vec![
-                    Op::Del(*lid / 2),
-                    Op::Del(*lid - 1),
-                ].into_iter(),
+                vec![Op::Del(*lid / 2), Op::Del(*lid - 1)]
+                    .into_iter(),
             ),
             _ => Box::new(vec![].into_iter()),
         }
@@ -80,7 +79,9 @@ impl Arbitrary for Op {
 }
 
 fn v(b: &Vec<u8>) -> u16 {
-    assert_eq!(b.len(), 2);
+    if b[0] % 4 != 0 {
+        assert_eq!(b.len(), 2);
+    }
     ((b[0] as u16) << 8) + b[1] as u16
 }
 
@@ -90,14 +91,15 @@ fn prop_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
         static ref M: Mutex<()> = Mutex::new(());
     }
 
-    let _lock = M.lock().expect("our test lock should not be poisoned");
+    let _lock =
+        M.lock().expect("our test lock should not be poisoned");
 
     // clear all failpoints that may be left over from the last run
     fail::teardown();
 
-    let res = std::panic::catch_unwind(
-        || run_tree_crashes_nicely(ops.clone(), flusher),
-    );
+    let res = std::panic::catch_unwind(|| {
+        run_tree_crashes_nicely(ops.clone(), flusher)
+    });
 
     fail::teardown();
 
@@ -105,15 +107,16 @@ fn prop_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
         Err(e) => {
             println!(
                 "failed with {:?} on ops {:?} flusher {}",
-                e,
-                ops,
-                flusher
+                e, ops, flusher
             );
             false
         }
         Ok(res) => {
             if !res {
-                println!("failed with ops {:?} flusher: {}", ops, flusher);
+                println!(
+                    "failed with ops {:?} flusher: {}",
+                    ops, flusher
+                );
             }
             res
         }
@@ -121,11 +124,13 @@ fn prop_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
 }
 
 fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
+    let io_buf_size = 300;
+
     let config = ConfigBuilder::new()
         .temporary(true)
         .snapshot_after_ops(1)
         .flush_every_ms(if flusher { Some(1) } else {None})
-        .io_buf_size(300)
+        .io_buf_size(io_buf_size)
         .min_items_per_segment(1)
         .blink_fanout(2) // smol pages for smol buffers
         .cache_capacity(40)
@@ -200,14 +205,16 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     continue;
                 }
                 other => {
-                    println!("got non-failpoint err: {:?}", other);
+                    println!(
+                        "got non-failpoint err: {:?}",
+                        other
+                    );
                     return false;
-                },
+                }
             }
-        }
+        };
     }
 
-    // we always increase set_counter because
     let mut set_counter = 0u16;
 
     for op in ops.into_iter() {
@@ -215,11 +222,22 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
             Set => {
                 let hi = (set_counter >> 8) as u8;
                 let lo = set_counter as u8;
+                let val = if hi % 4 == 0 {
+                    let mut val = vec![hi, lo];
+                    val.extend(vec![
+                        lo;
+                        hi as usize * io_buf_size / 4
+                            * set_counter as usize
+                    ]);
+                    val
+                } else {
+                    vec![hi, lo]
+                };
 
                 // insert false certainty until it fully completes
                 reference.insert(set_counter, (set_counter, false));
 
-                fp_crash!(tree.set(vec![hi, lo], vec![hi, lo]));
+                fp_crash!(tree.set(vec![hi, lo], val));
 
                 // make sure we keep the disk and reference in-sync
                 // maybe in the future put pending things in their own
@@ -242,7 +260,9 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 match res {
                     Some(_) => {
                         // we definitely caused a file write
-                        tree.flush().expect("should be able to flush after del")
+                        tree.flush().expect(
+                            "should be able to flush after del",
+                        )
                     }
                     None => {
                         // we might not have actually written anything
@@ -258,9 +278,8 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
             }
             FailPoint(fp) => {
                 fail_points.insert(fp.clone());
-                fail::cfg(&*fp, "return").expect(
-                    "should be able to configure failpoint",
-                );
+                fail::cfg(&*fp, "return")
+                    .expect("should be able to configure failpoint");
             }
         }
     }
@@ -284,7 +303,9 @@ fn quickcheck_tree_with_failpoints() {
         .gen(StdGen::new(rand::thread_rng(), generator_sz))
         .tests(n_tests)
         .max_tests(10000)
-        .quickcheck(prop_tree_crashes_nicely as fn(Vec<Op>, bool) -> bool);
+        .quickcheck(
+            prop_tree_crashes_nicely as fn(Vec<Op>, bool) -> bool,
+        );
 }
 
 #[test]
@@ -800,6 +821,51 @@ fn failpoints_bug_12() {
             Set,
             Set,
             Restart,
+        ],
+        false,
+    ))
+}
+
+#[test]
+fn failpoints_bug_13() {
+    // postmortem 1:
+    tests::setup_logger();
+    assert!(prop_tree_crashes_nicely(
+        vec![
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Set,
+            Del(0),
+            Set,
+            Set,
+            Set,
+            Del(2),
+            Set,
+            Set,
+            Set,
+            Set,
+            Del(1),
+            Del(3),
+            Del(18),
+            Set,
+            Set,
+            Set,
+            Restart,
+            Set,
+            Set,
+            Set,
+            FailPoint("trailer write"),
+            Set,
+            FailPoint("snap write"),
+            Del(4),
         ],
         false,
     ))


### PR DESCRIPTION
this addresses one of the larger pain points that limited use cases of sled. now you can store large values, which are placed in the `blobs` subdirectory, indexed by original lsn. at attempt is made to keep them linearized with the log, by reading all post-checkpoint blobs and verifying their crc before advancing the associated log index during recovery. any blobs that have a higher lsn than the recovered log are deleted, as they are from an unrecoverable future. if there is interest maybe they can be moved to a "lost and found" directory instead, though.

these changes will be available in sled `0.15.18` and pagecache `0.4.6`.