### PR TITLE
Fix `USAGE` string in stress2

### DIFF
--- a/benchmarks/stress2/src/main.rs
+++ b/benchmarks/stress2/src/main.rs
@@ -14,7 +14,7 @@ use docopt::Docopt;
 use rand::{thread_rng, Rng};
 
 const USAGE: &'static str = "
-Usage: stress [--threads=<#>] [--burn-in] [--duration=<s>]
+Usage: stress [--threads=<#>] [--burn-in] [--duration=<s>] [--kv-len=<l>]
 
 Options:
     --threads=<#>      Number of threads [default: 4].


### PR DESCRIPTION
kv-len was present in the long help message but not the short one, so was ignored by DocOpt