### PR TITLE
Optimise prefix comparison

### DIFF
--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -64,7 +64,7 @@ use self::bound::Bound;
 use self::data::Data;
 use self::frag::{ChildSplit, ParentSplit};
 use self::node::Node;
-use self::prefix::{prefix_cmp, prefix_decode, prefix_encode};
+use self::prefix::{prefix_cmp, prefix_decode, prefix_encode, prefix_cmp_encoded};
 
 pub(crate) use self::frag::Frag;
 pub(crate) use self::materializer::BLinkMaterializer;

--- a/crates/sled/src/prefix.rs
+++ b/crates/sled/src/prefix.rs
@@ -64,7 +64,7 @@ pub(crate) fn prefix_cmp(a: &[u8], b: &[u8]) -> Ordering {
 }
 
 /// Compare `a` and `b`, assuming that `a` is prefix encoded and `b` is not.
-pub fn prefix_cmp_encoded(a: &[u8], mut b: &[u8], mut prefix: &[u8]) -> Ordering {
+pub(crate) fn prefix_cmp_encoded(a: &[u8], mut b: &[u8], mut prefix: &[u8]) -> Ordering {
     assert!(a.len() >= 1 && a[0] as usize <= prefix.len());
 
     let mut a_prefix_len = a[0];

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt::{self, Debug};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
@@ -895,10 +896,10 @@ impl Tree {
             {
                 Data::Index(ref ptrs) => {
                     let old_cursor = cursor;
+
+                    let encoded_key = prefix_encode(&*prefix, key);
                     for &(ref sep_k, ref ptr) in ptrs {
-                        let decoded_sep_k =
-                            prefix_decode(&*prefix, sep_k);
-                        if &*decoded_sep_k <= &*key {
+                        if prefix_cmp(sep_k, &*encoded_key) != Ordering::Greater {
                             cursor = *ptr;
                         } else {
                             break; // we've found our next cursor

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -438,7 +438,7 @@ impl Tree {
                 Data::Leaf(ref items) => {
                     let search =
                         items.binary_search_by(|&(ref k, ref _v)| {
-                            prefix_cmp(k, &*encoded_key)
+                            prefix_cmp(k, &encoded_key)
                         });
                     if let Ok(idx) = search {
                         ret = Some(items[idx].1.clone());
@@ -766,11 +766,9 @@ impl Tree {
             let data = &last_node.data;
             let items =
                 data.leaf_ref().expect("last_node should be a leaf");
-            let encoded_key =
-                prefix_encode(last_node.lo.inner(), key);
             let search =
                 items.binary_search_by(|&(ref k, ref _v)| {
-                    prefix_cmp(k, &*encoded_key)
+                    prefix_cmp_encoded(k, &key, last_node.lo.inner())
                 });
             if let Ok(idx) = search {
                 Some(&*items[idx].1)
@@ -897,9 +895,8 @@ impl Tree {
                 Data::Index(ref ptrs) => {
                     let old_cursor = cursor;
 
-                    let encoded_key = prefix_encode(&*prefix, key);
                     for &(ref sep_k, ref ptr) in ptrs {
-                        if prefix_cmp(sep_k, &*encoded_key) != Ordering::Greater {
+                        if prefix_cmp_encoded(sep_k, key, &prefix) != Ordering::Greater {
                             cursor = *ptr;
                         } else {
                             break; // we've found our next cursor


### PR DESCRIPTION
Closes #285

Output from `stress2`:

```
master
traverse |        2.5 |       73.9 |      129.3 |      224.1 |     8537.7 |     699934 |     27.632

prefix-opt
traverse |        1.7 |       80.8 |      135.9 |      206.9 |     1045.5 |     649053 |     27.825
```

There's not much change in the smaller columns, but since that's only a handful of us, I assume it's not significant. The max is improved by more than 8x. I don't know how to interpret the 'sum' column.

Flamegraphs:

master:
<img width="1790" alt="master" src="https://user-images.githubusercontent.com/762626/47125708-76f45a00-d2e1-11e8-9a27-6ff291f3e003.png">

prefix-opt:
<img width="1779" alt="prefix-opt" src="https://user-images.githubusercontent.com/762626/47125711-7d82d180-d2e1-11e8-9922-c9ab1152fede.png">

These flame graphs show the same view of stress2. On master, there is significant time spent in `prefix_decode` and jemalloc. On the prefix-opt branch, both have disappeared (they are not even present on hovering the small items on the far right, and nor is any other tree comparison function.

r? @spacejam 