### PR TITLE
debug zc

### DIFF
--- a/crates/pagecache/src/ds/stack.rs
+++ b/crates/pagecache/src/ds/stack.rs
@@ -176,7 +176,7 @@ impl<T: Send + Sync + 'static> Stack<T> {
         }
     }
 
-    /// attempt consolidation
+    /// compare and swap
     pub(crate) fn cas<'g>(
         &self,
         old: Shared<'g, Node<T>>,

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -708,9 +708,12 @@ impl Tree {
             Ok(_) => {}
             Err(Error::CasFailed(_)) => {
                 // if we failed, don't follow through with the parent split
-                self.pages
-                    .free(new_pid, new_ptr, guard)
-                    .map_err(|e| e.danger_cast())?;
+                if let Err(e) =
+                    self.pages.free(new_pid, new_ptr.clone(), guard)
+                {
+                    println!("failed to free newly allocated page {} with expected ptr {:?}: {:?}", new_pid, new_ptr, e);
+                    return Err(e.danger_cast());
+                }
                 return Err(Error::CasFailed(()));
             }
             Err(other) => return Err(other.danger_cast()),

--- a/tests/tests/test_pagecache.rs
+++ b/tests/tests/test_pagecache.rs
@@ -274,7 +274,7 @@ enum P {
 }
 
 fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
-    // tests::setup_logger();
+    tests::setup_logger();
     use self::Op::*;
     let config = ConfigBuilder::new()
         .temporary(true)
@@ -295,6 +295,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
         let guard = pin();
         match op {
             Replace(pid, c) => {
+                println!("tests/tests/test_pagecache.rs:298");
                 let get = pc.get(pid, &guard).unwrap();
                 let ref_get =
                     reference.entry(pid).or_insert(P::Unallocated);
@@ -331,6 +332,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Link(pid, c) => {
+                println!("tests/tests/test_pagecache.rs:335");
                 let get = pc.get(pid, &guard).unwrap();
                 let ref_get =
                     reference.entry(pid).or_insert(P::Unallocated);
@@ -364,6 +366,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Get(pid) => {
+                println!("tests/tests/test_pagecache.rs:369");
                 let get = pc.get(pid, &guard).unwrap();
 
                 match reference.get(&pid) {
@@ -390,6 +393,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Free(pid) => {
+                println!("tests/tests/test_pagecache.rs:396");
                 let pre_get = pc.get(pid, &guard).unwrap();
 
                 match pre_get {
@@ -416,12 +420,14 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Allocate => {
+                println!("tests/tests/test_pagecache.rs:423");
                 let pid = pc.allocate(&guard).unwrap();
                 reference.insert(pid, P::Allocated);
                 let get = pc.get(pid, &guard);
                 assert!(get.unwrap().is_allocated());
             }
             Restart => {
+                println!("tests/tests/test_pagecache.rs:430");
                 drop(pc);
 
                 config


### PR DESCRIPTION
concurrency testing found a race condition where a newly-allocated page could be relocated by the pagecache's segment compactor, and when a child split failed to apply, it would free the newly allocated child node, assuming that the pointer had not changed.

This makes clear a new rule: never assume a pointer won't change, even if you haven't told any other threads about this data by publishing it into a shared tree. The pagecache will move things around to keep segments dense.