### PR TITLE
fix page relocation race condition

### DIFF
--- a/crates/pagecache/src/ds/stack.rs
+++ b/crates/pagecache/src/ds/stack.rs
@@ -176,7 +176,7 @@ impl<T: Send + Sync + 'static> Stack<T> {
         }
     }
 
-    /// attempt consolidation
+    /// compare and swap
     pub(crate) fn cas<'g>(
         &self,
         old: Shared<'g, Node<T>>,

--- a/crates/pagecache/src/pagecache.rs
+++ b/crates/pagecache/src/pagecache.rs
@@ -1160,6 +1160,8 @@ where
 
             let guard = pin();
 
+            // Set up new stack
+
             let shared_stack = Owned::new(stack).into_shared(&guard);
 
             self.inner

--- a/crates/pagecache/src/pagecache.rs
+++ b/crates/pagecache/src/pagecache.rs
@@ -1129,8 +1129,6 @@ where
 
         let mut snapshot_free = snapshot.free.clone();
 
-        let guard = pin();
-
         for (pid, state) in &snapshot.pt {
             trace!("load_snapshot page {} {:?}", pid, state);
 
@@ -1150,7 +1148,6 @@ where
                 &PageState::Free(lsn, ptr) => {
                     // blow away any existing state
                     trace!("load_snapshot freeing pid {}", *pid);
-                    let _ = self.inner.del(*pid, &guard);
                     stack.push(CacheEntry::Free(lsn, ptr));
                     self.free.lock().unwrap().push(*pid);
                     snapshot_free.remove(&pid);
@@ -1160,6 +1157,8 @@ where
                     // empty stack with null ptr head implies Allocated
                 }
             }
+
+            let guard = pin();
 
             let shared_stack = Owned::new(stack).into_shared(&guard);
 

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -708,9 +708,12 @@ impl Tree {
             Ok(_) => {}
             Err(Error::CasFailed(_)) => {
                 // if we failed, don't follow through with the parent split
-                self.pages
-                    .free(new_pid, new_ptr, guard)
-                    .map_err(|e| e.danger_cast())?;
+                if let Err(e) =
+                    self.pages.free(new_pid, new_ptr.clone(), guard)
+                {
+                    println!("failed to free newly allocated page {} with expected ptr {:?}: {:?}", new_pid, new_ptr, e);
+                    return Err(e.danger_cast());
+                }
                 return Err(Error::CasFailed(()));
             }
             Err(other) => return Err(other.danger_cast()),

--- a/tests/tests/test_pagecache.rs
+++ b/tests/tests/test_pagecache.rs
@@ -274,7 +274,7 @@ enum P {
 }
 
 fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
-    // tests::setup_logger();
+    tests::setup_logger();
     use self::Op::*;
     let config = ConfigBuilder::new()
         .temporary(true)
@@ -295,6 +295,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
         let guard = pin();
         match op {
             Replace(pid, c) => {
+                println!("tests/tests/test_pagecache.rs:298");
                 let get = pc.get(pid, &guard).unwrap();
                 let ref_get =
                     reference.entry(pid).or_insert(P::Unallocated);
@@ -331,6 +332,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Link(pid, c) => {
+                println!("tests/tests/test_pagecache.rs:335");
                 let get = pc.get(pid, &guard).unwrap();
                 let ref_get =
                     reference.entry(pid).or_insert(P::Unallocated);
@@ -364,6 +366,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Get(pid) => {
+                println!("tests/tests/test_pagecache.rs:369");
                 let get = pc.get(pid, &guard).unwrap();
 
                 match reference.get(&pid) {
@@ -390,6 +393,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Free(pid) => {
+                println!("tests/tests/test_pagecache.rs:396");
                 let pre_get = pc.get(pid, &guard).unwrap();
 
                 match pre_get {
@@ -416,12 +420,14 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Allocate => {
+                println!("tests/tests/test_pagecache.rs:423");
                 let pid = pc.allocate(&guard).unwrap();
                 reference.insert(pid, P::Allocated);
                 let get = pc.get(pid, &guard);
                 assert!(get.unwrap().is_allocated());
             }
             Restart => {
+                println!("tests/tests/test_pagecache.rs:430");
                 drop(pc);
 
                 config

--- a/tests/tests/test_pagecache.rs
+++ b/tests/tests/test_pagecache.rs
@@ -274,7 +274,7 @@ enum P {
 }
 
 fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
-    tests::setup_logger();
+    // tests::setup_logger();
     use self::Op::*;
     let config = ConfigBuilder::new()
         .temporary(true)
@@ -295,7 +295,6 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
         let guard = pin();
         match op {
             Replace(pid, c) => {
-                println!("tests/tests/test_pagecache.rs:298");
                 let get = pc.get(pid, &guard).unwrap();
                 let ref_get =
                     reference.entry(pid).or_insert(P::Unallocated);
@@ -332,7 +331,6 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Link(pid, c) => {
-                println!("tests/tests/test_pagecache.rs:335");
                 let get = pc.get(pid, &guard).unwrap();
                 let ref_get =
                     reference.entry(pid).or_insert(P::Unallocated);
@@ -366,7 +364,6 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Get(pid) => {
-                println!("tests/tests/test_pagecache.rs:369");
                 let get = pc.get(pid, &guard).unwrap();
 
                 match reference.get(&pid) {
@@ -393,7 +390,6 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Free(pid) => {
-                println!("tests/tests/test_pagecache.rs:396");
                 let pre_get = pc.get(pid, &guard).unwrap();
 
                 match pre_get {
@@ -420,14 +416,12 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
                 }
             }
             Allocate => {
-                println!("tests/tests/test_pagecache.rs:423");
                 let pid = pc.allocate(&guard).unwrap();
                 reference.insert(pid, P::Allocated);
                 let get = pc.get(pid, &guard);
                 assert!(get.unwrap().is_allocated());
             }
             Restart => {
-                println!("tests/tests/test_pagecache.rs:430");
                 drop(pc);
 
                 config


### PR DESCRIPTION
concurrency tests uncovered a panic where we were assuming that we cound allocate -> replace -> free and have the free work using the pointer returned from replace. But the page may change locations if the segment accountant wishes to clean up its segment. Now we no longer assume it is unchanged.