### PR TITLE
simplify config. Closes #326.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,9 @@ An alpha modern embedded database.
 ```rust
 extern crate sled;
 
-use sled::{ConfigBuilder, Tree};
+use sled::Tree;
 
-let config = ConfigBuilder::new()
-  .path(path)
-  .build();
-
-let tree = Tree::start(config).unwrap();
+let tree = Tree::start_default(path)?;
 
 // set and get
 tree.set(k, v1);

--- a/benchmarks/stress2/src/main.rs
+++ b/benchmarks/stress2/src/main.rs
@@ -5,16 +5,27 @@ extern crate docopt;
 extern crate rand;
 extern crate sled;
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::thread;
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+};
 
 use chan_signal::Signal;
 use docopt::Docopt;
 use rand::{thread_rng, Rng};
 
 const USAGE: &'static str = "
-Usage: stress [--threads=<#>] [--burn-in] [--duration=<s>] [--kv-len=<l>]
+Usage: stress [--threads=<#>] [--burn-in] [--duration=<s>] \
+    [--key-len=<l>] [--val-len=<l>] \
+    [--get-prop=<p>] \
+    [--set-prop=<p>] \
+    [--del-prop=<p>] \
+    [--cas-prop=<p>] \
+    [--scan-prop=<p>] \
+    [--merge-prop=<p>]
 
 Options:
     --threads=<#>      Number of threads [default: 4].
@@ -165,7 +176,7 @@ fn main() {
         .cache_bits(6)
         .cache_capacity(1_000_000_000)
         .flush_every_ms(Some(10))
-        .snapshot_after_ops(100000000)
+        .snapshot_after_ops(100_000_000)
         .print_profile_on_drop(true)
         .merge_operator(concatenate_merge)
         .build();

--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -56,10 +56,6 @@ pub struct ConfigBuilder {
     #[doc(hidden)]
     pub io_buf_size: usize,
     #[doc(hidden)]
-    pub min_free_segments: usize,
-    #[doc(hidden)]
-    pub min_items_per_segment: usize,
-    #[doc(hidden)]
     pub page_consolidation_threshold: usize,
     #[doc(hidden)]
     pub path: PathBuf,
@@ -81,10 +77,6 @@ pub struct ConfigBuilder {
     pub tmp_path: PathBuf,
     #[doc(hidden)]
     pub use_compression: bool,
-    #[doc(hidden)]
-    pub use_os_cache: bool,
-    #[doc(hidden)]
-    pub zero_copy_storage: bool,
     #[doc(hidden)]
     pub zstd_compression_factor: i32,
     #[doc(hidden)]
@@ -121,15 +113,13 @@ impl Default for ConfigBuilder {
 
         ConfigBuilder {
             io_bufs: 3,
-            io_buf_size: 2 << 22,     // 8mb
-            min_items_per_segment: 4, // capacity for >=4 pages/segment
+            io_buf_size: 2 << 22, // 8mb
             blink_node_split_size: 4096,
             page_consolidation_threshold: 10,
             path: PathBuf::from("default.sled"),
             read_only: false,
             cache_bits: 6, // 64 shards
             cache_capacity: 1024 * 1024 * 1024, // 1gb
-            use_os_cache: true,
             use_compression: true,
             zstd_compression_factor: 5,
             flush_every_ms: Some(500),
@@ -137,8 +127,6 @@ impl Default for ConfigBuilder {
             snapshot_path: None,
             segment_cleanup_threshold: 0.2,
             segment_cleanup_skew: 10,
-            min_free_segments: 3,
-            zero_copy_storage: false,
             tmp_path: PathBuf::from(tmp_path),
             temporary: false,
             segment_mode: SegmentMode::Gc,
@@ -213,22 +201,18 @@ impl ConfigBuilder {
     builder!(
         (io_bufs, get_io_bufs, set_io_bufs, usize, "number of io buffers"),
         (io_buf_size, get_io_buf_size, set_io_buf_size, usize, "size of each io flush buffer. MUST be multiple of 512!"),
-        (min_items_per_segment, get_min_items_per_segment, set_min_items_per_segment, usize, "minimum data chunks/pages in a segment."),
         (blink_node_split_size, get_blink_node_split_size, set_blink_node_split_size, usize, "b-link tree node size in bytes before splitting"),
         (page_consolidation_threshold, get_page_consolidation_threshold, set_page_consolidation_threshold, usize, "page consolidation threshold"),
         (temporary, get_temporary, set_temporary, bool, "if this database should be removed after the ConfigBuilder is dropped"),
         (read_only, get_read_only, set_read_only, bool, "whether to run in read-only mode"),
         (cache_bits, get_cache_bits, set_cache_bits, usize, "log base 2 of the number of cache shards"),
         (cache_capacity, get_cache_capacity, set_cache_capacity, usize, "maximum size for the system page cache"),
-        (use_os_cache, get_use_os_cache, set_use_os_cache, bool, "whether to use the OS page cache"),
         (use_compression, get_use_compression, set_use_compression, bool, "whether to use zstd compression"),
         (zstd_compression_factor, get_zstd_compression_factor, set_zstd_compression_factor, i32, "the compression factor to use with zstd compression"),
         (flush_every_ms, get_flush_every_ms, set_flush_every_ms, Option<u64>, "number of ms between IO buffer flushes"),
         (snapshot_after_ops, get_snapshot_after_ops, set_snapshot_after_ops, usize, "number of operations between page table snapshots"),
         (segment_cleanup_threshold, get_segment_cleanup_threshold, set_segment_cleanup_threshold, f64, "the proportion of remaining valid pages in the segment"),
         (segment_cleanup_skew, get_segment_cleanup_skew, set_segment_cleanup_skew, usize, "the cleanup threshold skew in percentage points between the first and last segments"),
-        (min_free_segments, get_min_free_segments, set_min_free_segments, usize, "the minimum number of free segments to have on-deck before a compaction occurs"),
-        (zero_copy_storage, get_zero_copy_storage, set_zero_copy_storage, bool, "disabling of the log segment copy cleaner"),
         (segment_mode, get_segment_mode, set_segment_mode, SegmentMode, "the file segment selection mode"),
         (snapshot_path, get_snapshot_path, set_snapshot_path, Option<PathBuf>, "snapshot file location"),
         (print_profile_on_drop, get_print_profile_on_drop, set_print_profile_on_drop, bool, "print a performance profile when the Config is dropped")
@@ -447,22 +431,12 @@ impl Config {
             self.inner.io_buf_size <= 1 << 24,
             "io_buf_size should be <= 16mb"
         );
-        supported!(
-            self.inner.min_items_per_segment >= 1,
-            "min_items_per_segment must be >= 4"
-        );
-        supported!(
-            self.inner.min_items_per_segment < 128,
-            "min_items_per_segment must be < 128"
-        );
         supported!(self.inner.page_consolidation_threshold >= 1, "must consolidate pages after a non-zero number of updates");
         supported!(self.inner.page_consolidation_threshold < 1 << 20, "must consolidate pages after fewer than 1 million updates");
         supported!(
             self.inner.cache_bits <= 20,
             "# LRU shards = 2^cache_bits. set this to 20 or less."
         );
-        supported!(self.inner.min_free_segments <= 32, "min_free_segments need not be higher than the number IO buffers (io_bufs)");
-        supported!(self.inner.min_free_segments >= 1, "min_free_segments must be nonzero or the database will never reclaim storage");
         supported!(
             self.inner.segment_cleanup_threshold >= 0.01,
             "segment_cleanup_threshold must be >= 1%"
@@ -484,9 +458,7 @@ impl Config {
 
     fn verify_config_changes_ok(&self) -> Result<(), ()> {
         match self.read_config() {
-            Ok(Some(mut old)) => {
-                let old_tmp = old.tmp_path;
-                old.tmp_path = self.inner.tmp_path.clone();
+            Ok(Some(old)) => {
                 if old.merge_operator.is_some() {
                     supported!(self.inner.merge_operator.is_some(),
                         "this system was previously opened with a \
@@ -494,19 +466,14 @@ impl Config {
                         choosing to do so once, BWAHAHAHAHAHAHA!!!!");
                 }
 
-                old.merge_operator = self.inner.merge_operator;
-
                 supported!(
-                    &*self.inner == &old,
-                    "changing the configuration \
-                     between usages is currently unsupported"
+                    self.inner.io_buf_size == old.io_buf_size,
+                    format!(
+                        "cannot change the io buffer size across restarts. \
+                        please change it back to {}",
+                        old.io_buf_size
+                    )
                 );
-                // need to keep the old path so that when old gets
-                // dropped we don't remove our tmp_path (but it
-                // might not matter even if we did, since it just
-                // becomes anonymous as long as we keep a reference
-                // open to it in the Config)
-                old.tmp_path = old_tmp;
                 Ok(())
             }
             Ok(None) => self.write_config().map_err(|e| e.into()),

--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -468,6 +468,10 @@ impl Config {
             "segment_cleanup_threshold must be >= 1%"
         );
         supported!(
+            self.inner.segment_cleanup_skew < 99,
+            "cleanup skew cannot be greater than 99%"
+        );
+        supported!(
             self.inner.zstd_compression_factor >= 1,
             "compression factor must be >= 0"
         );

--- a/crates/pagecache/src/constants.rs
+++ b/crates/pagecache/src/constants.rs
@@ -36,3 +36,8 @@ pub const SEG_TRAILER_LEN: usize = 10;
 /// contain a value (in addition to their header)
 /// of this length.
 pub const BLOB_INLINE_LEN: usize = std::mem::size_of::<Lsn>();
+
+/// The minimum number of items per segment.
+/// Items larger than this fraction of an io_buf
+/// will be stored as an off-log blob.
+pub const MINIMUM_ITEMS_PER_SEGMENT: usize = 4;

--- a/crates/pagecache/src/iobuf.rs
+++ b/crates/pagecache/src/iobuf.rs
@@ -386,14 +386,11 @@ impl IoBufs {
 
         let total_buf_len = MSG_HEADER_LEN + buf.len();
 
-        let max_overhead = if self.config.min_items_per_segment == 1 {
-            SEG_HEADER_LEN + SEG_TRAILER_LEN
-        } else {
-            std::cmp::max(SEG_HEADER_LEN, SEG_TRAILER_LEN)
-        };
+        let max_overhead =
+            std::cmp::max(SEG_HEADER_LEN, SEG_TRAILER_LEN);
 
         let max_buf_size = (self.config.io_buf_size
-            / self.config.min_items_per_segment)
+            / MINIMUM_ITEMS_PER_SEGMENT)
             - max_overhead;
 
         let over_blob_threshold = total_buf_len > max_buf_size;

--- a/crates/pagecache/src/iobuf.rs
+++ b/crates/pagecache/src/iobuf.rs
@@ -62,8 +62,10 @@ pub(super) struct IoBufs {
     // full, and in order to prevent threads from having to spin in
     // the reserve function, we can have them block until a buffer becomes
     // available.
-    buf_mu: Mutex<()>,
-    bufs_updated: Condvar,
+    current_buf_mu: Mutex<()>,
+    written_bufs_mu: Mutex<()>,
+    current_buf_updated: Condvar,
+    written_bufs_updated: Condvar,
     bufs: Vec<IoBuf>,
     current_buf: AtomicUsize,
     written_bufs: AtomicUsize,
@@ -198,8 +200,10 @@ impl IoBufs {
         Ok(IoBufs {
             config: config,
 
-            buf_mu: Mutex::new(()),
-            bufs_updated: Condvar::new(),
+            current_buf_mu: Mutex::new(()),
+            written_bufs_mu: Mutex::new(()),
+            current_buf_updated: Condvar::new(),
+            written_bufs_updated: Condvar::new(),
             bufs: bufs,
             current_buf: AtomicUsize::new(current_buf),
             written_bufs: AtomicUsize::new(0),
@@ -456,9 +460,12 @@ impl IoBufs {
 
                 // use a condition variable to wait until
                 // we've updated the written_bufs counter.
-                let mut buf_mu = self.buf_mu.lock().unwrap();
+                let mut buf_mu = self.written_bufs_mu.lock().unwrap();
                 while written_bufs == self.written_bufs.load(SeqCst) {
-                    buf_mu = self.bufs_updated.wait(buf_mu).unwrap();
+                    buf_mu = self
+                        .written_bufs_updated
+                        .wait(buf_mu)
+                        .unwrap();
                 }
                 continue;
             }
@@ -475,10 +482,13 @@ impl IoBufs {
                 spin_loop_hint();
 
                 // use a condition variable to wait until
-                // we've updated the written_bufs counter.
-                let mut buf_mu = self.buf_mu.lock().unwrap();
-                while written_bufs == self.written_bufs.load(SeqCst) {
-                    buf_mu = self.bufs_updated.wait(buf_mu).unwrap();
+                // we've updated the current_buf counter.
+                let mut buf_mu = self.current_buf_mu.lock().unwrap();
+                while current_buf == self.current_buf.load(SeqCst) {
+                    buf_mu = self
+                        .current_buf_updated
+                        .wait(buf_mu)
+                        .unwrap();
                 }
                 continue;
             }
@@ -888,9 +898,21 @@ impl IoBufs {
 
         trace!("{} zeroed header", next_idx);
 
+        // we acquire this mutex to guarantee that any threads that
+        // are going to wait on the condition variable will observe
+        // the change.
+        debug_delay();
+        let _ = self.current_buf_mu.lock().unwrap();
+
+        // communicate to other threads that we have advanced an IO buffer.
         debug_delay();
         let _current_buf = self.current_buf.fetch_add(1, SeqCst) + 1;
         trace!("{} current_buf", _current_buf % self.config.io_bufs);
+
+        // let any threads that are blocked on buf_mu know about the
+        // updated counter.
+        debug_delay();
+        self.current_buf_updated.notify_all();
 
         // if writers is 0, it's our responsibility to write the buffer.
         if n_writers(sealed) == 0 {
@@ -1021,7 +1043,7 @@ impl IoBufs {
         // are going to wait on the condition variable will observe
         // the change.
         debug_delay();
-        let _ = self.buf_mu.lock().unwrap();
+        let _ = self.written_bufs_mu.lock().unwrap();
 
         // communicate to other threads that we have written an IO buffer.
         debug_delay();
@@ -1031,7 +1053,7 @@ impl IoBufs {
         // let any threads that are blocked on buf_mu know about the
         // updated counter.
         debug_delay();
-        self.bufs_updated.notify_all();
+        self.written_bufs_updated.notify_all();
 
         Ok(())
     }

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -134,8 +134,8 @@ pub use self::{
 pub use self::{
     constants::{
         BLOB_FLUSH, BLOB_INLINE_LEN, EVIL_BYTE, FAILED_FLUSH,
-        INLINE_FLUSH, MSG_HEADER_LEN, SEGMENT_PAD, SEG_HEADER_LEN,
-        SEG_TRAILER_LEN,
+        INLINE_FLUSH, MINIMUM_ITEMS_PER_SEGMENT, MSG_HEADER_LEN,
+        SEGMENT_PAD, SEG_HEADER_LEN, SEG_TRAILER_LEN,
     },
     metrics::Measure,
     snapshot::{read_snapshot_or_default, Snapshot},

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -526,9 +526,11 @@ impl SegmentAccountant {
                 self.config.segment_cleanup_threshold;
             let cleanup_skew = self.config.segment_cleanup_skew;
 
-            assert!(!self.segments.is_empty());
-            let relative_prop =
-                idx as f64 / self.segments.len() as f64;
+            let relative_prop = if self.segments.is_empty() {
+                0.5
+            } else {
+                idx as f64 / self.segments.len() as f64
+            };
 
             // we bias to having a higher threshold closer to segment 0
             let inverse_prop = 1. - relative_prop;

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -518,8 +518,30 @@ impl SegmentAccountant {
             self.ordering.insert(lsn, segment_start);
 
             // can we transition these segments?
-            let cleanup_threshold =
+
+            // we calculate the cleanup threshold in a skewed way,
+            // which encourages earlier segments to be rewritten
+            // more frequently.
+            let base_cleanup_threshold =
                 self.config.segment_cleanup_threshold;
+            let cleanup_skew = self.config.segment_cleanup_skew;
+
+            assert!(!self.segments.is_empty());
+            let relative_prop =
+                idx as f64 / self.segments.len() as f64;
+
+            // we bias to having a higher threshold closer to segment 0
+            let inverse_prop = 1. - relative_prop;
+            let relative_threshold =
+                cleanup_skew as f64 * inverse_prop;
+            let computed_threshold =
+                base_cleanup_threshold + relative_threshold;
+            // We should always be below 1, or we will rewrite everything
+            let cleanup_threshold = if computed_threshold < 1. {
+                computed_threshold
+            } else {
+                0.99
+            };
             let min_items = self.config.min_items_per_segment;
 
             let segment_low_pct =
@@ -822,7 +844,28 @@ impl SegmentAccountant {
         idx: usize,
         lsn: Lsn,
     ) {
-        let cleanup_threshold = self.config.segment_cleanup_threshold;
+        // we calculate the cleanup threshold in a skewed way,
+        // which encourages earlier segments to be rewritten
+        // more frequently.
+        let base_cleanup_threshold =
+            self.config.segment_cleanup_threshold;
+        let cleanup_skew = self.config.segment_cleanup_skew;
+
+        assert!(!self.segments.is_empty());
+        let relative_prop = idx as f64 / self.segments.len() as f64;
+
+        // we bias to having a higher threshold closer to segment 0
+        let inverse_prop = 1. - relative_prop;
+        let relative_threshold = cleanup_skew as f64 * inverse_prop;
+        let computed_threshold =
+            base_cleanup_threshold + relative_threshold;
+        // We should always be below 1, or we will rewrite everything
+        let cleanup_threshold = if computed_threshold < 1. {
+            computed_threshold
+        } else {
+            0.99
+        };
+
         let min_items = self.config.min_items_per_segment;
 
         let segment_start = (idx * self.config.io_buf_size) as LogId;

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -542,13 +542,13 @@ impl SegmentAccountant {
             } else {
                 0.99
             };
-            let min_items = self.config.min_items_per_segment;
 
             let segment_low_pct =
                 segment.live_pct() <= cleanup_threshold;
 
             let segment_low_count = (segment.len() as f64)
-                < min_items as f64 * cleanup_threshold;
+                < MINIMUM_ITEMS_PER_SEGMENT as f64
+                    * cleanup_threshold;
 
             let can_free = segment.is_empty()
                 && !self.pause_rewriting
@@ -866,15 +866,13 @@ impl SegmentAccountant {
             0.99
         };
 
-        let min_items = self.config.min_items_per_segment;
-
         let segment_start = (idx * self.config.io_buf_size) as LogId;
 
         let segment_low_pct =
             self.segments[idx].live_pct() <= cleanup_threshold;
 
         let segment_low_count = (self.segments[idx].len() as f64)
-            < min_items as f64 * cleanup_threshold;
+            < MINIMUM_ITEMS_PER_SEGMENT as f64 * cleanup_threshold;
 
         let can_drain = self.segments[idx].is_inactive()
             && (segment_low_pct || segment_low_count);

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -3,9 +3,7 @@
 //! # Examples
 //!
 //! ```
-//! let config = sled::ConfigBuilder::new().temporary(true).build();
-//!
-//! let t = sled::Tree::start(config).unwrap();
+//! let t = sled::Tree::start_default("my_db").unwrap();
 //!
 //! t.set(b"yo!".to_vec(), b"v1".to_vec());
 //! assert!(t.get(b"yo!").unwrap().unwrap() == &*b"v1".to_vec());

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -30,6 +30,14 @@ unsafe impl Send for Tree {}
 unsafe impl Sync for Tree {}
 
 impl Tree {
+    /// Load existing or create a new `Tree` with a default configuration.
+    pub fn start_default<P: AsRef<std::path::Path>>(
+        path: P,
+    ) -> Result<Tree, ()> {
+        let config = ConfigBuilder::new().path(path).build();
+        Self::start(config)
+    }
+
     /// Load existing or create a new `Tree`.
     pub fn start(config: Config) -> Result<Tree, ()> {
         let _measure = Measure::new(&M.tree_start);

--- a/tests/tests/test_log.rs
+++ b/tests/tests/test_log.rs
@@ -19,7 +19,8 @@ use rand::{thread_rng, Rng};
 
 use pagecache::{
     ConfigBuilder, DiskPtr, Log, LogRead, SegmentMode,
-    MSG_HEADER_LEN, SEG_HEADER_LEN, SEG_TRAILER_LEN,
+    MINIMUM_ITEMS_PER_SEGMENT, MSG_HEADER_LEN, SEG_HEADER_LEN,
+    SEG_TRAILER_LEN,
 };
 
 type Lsn = i64;
@@ -58,7 +59,7 @@ fn non_contiguous_log_flush() {
     let log = Log::start_raw_log(config.clone()).unwrap();
 
     let seg_overhead = std::cmp::max(SEG_HEADER_LEN, SEG_TRAILER_LEN);
-    let buf_len = (config.io_buf_size / config.min_items_per_segment)
+    let buf_len = (config.io_buf_size / MINIMUM_ITEMS_PER_SEGMENT)
         - (MSG_HEADER_LEN + seg_overhead);
 
     let res1 = log.reserve(vec![0; buf_len]).unwrap();
@@ -92,7 +93,7 @@ fn concurrent_logging() {
         let seg_overhead =
             std::cmp::max(SEG_HEADER_LEN, SEG_TRAILER_LEN);
         let buf_len = (config.io_buf_size
-            / config.min_items_per_segment)
+            / MINIMUM_ITEMS_PER_SEGMENT)
             - (MSG_HEADER_LEN + seg_overhead);
 
         let t1 = thread::Builder::new()
@@ -248,7 +249,6 @@ fn log_chunky_iterator() {
                 .temporary(true)
                 .segment_mode(SegmentMode::Linear)
                 .io_buf_size(100)
-                .min_items_per_segment(1)
                 .build();
 
             let log = Log::start_raw_log(config.clone()).unwrap();
@@ -351,7 +351,6 @@ fn multi_segment_log_iteration() {
         .temporary(true)
         .segment_mode(SegmentMode::Linear)
         .io_buf_size(1000)
-        .min_items_per_segment(1)
         .build();
 
     let total_seg_overhead = SEG_HEADER_LEN + SEG_TRAILER_LEN;

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -131,9 +131,8 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
     let config = ConfigBuilder::new()
         .temporary(true)
         .snapshot_after_ops(1)
-        .flush_every_ms(if flusher { Some(1) } else {None})
+        .flush_every_ms(if flusher { Some(1) } else { None })
         .io_buf_size(io_buf_size)
-        .min_items_per_segment(1)
         .blink_node_split_size(0) // smol pages for smol buffers
         .cache_capacity(40)
         .cache_bits(2)
@@ -207,10 +206,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     continue;
                 }
                 other => {
-                    println!(
-                        "got non-failpoint err: {:?}",
-                        other
-                    );
+                    println!("got non-failpoint err: {:?}", other);
                     return false;
                 }
             }


### PR DESCRIPTION
adds a default tree open method
allows databases to be moved around now
fewer configuration options
add sloped cleanup thresholds that should drive 10% more cleanup efforts towards lower segments to keep db's leaner