### PR TITLE
Defer the dropping of the internal stacks when PageTable is dropped. …

### DIFF
--- a/crates/pagetable/Cargo.toml
+++ b/crates/pagetable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagetable"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "simple wait-free two-level pagetable with 2mb pages"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
…Prevents use after frees when a Tree is dropped and we have active PinnedValue pointers