### PR TITLE
sled: use saturating u64 for size calculations

### DIFF
--- a/crates/sled/src/bound.rs
+++ b/crates/sled/src/bound.rs
@@ -17,17 +17,18 @@ impl Bound {
     }
 
     #[inline]
-    pub(crate) fn size_in_bytes(&self) -> usize {
-        let self_sz = size_of::<Bound>();
+    pub(crate) fn size_in_bytes(&self) -> u64 {
+        let self_sz = size_of::<Bound>() as u64;
 
         let inner_sz = match self {
             Bound::Inclusive(ref v) | Bound::Exclusive(ref v) => {
-                v.len() + size_of::<Vec<u8>>()
+                (v.len() as u64)
+                    .saturating_add(size_of::<Vec<u8>>() as u64)
             }
-            Bound::Inf => 0,
+            Bound::Inf => 0u64,
         };
 
-        self_sz + inner_sz
+        self_sz.saturating_add(inner_sz)
     }
 }
 

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -103,7 +103,8 @@ impl<'a> Iterator for Iter<'a> {
                 self.inclusive = false;
                 leaf.binary_search_by(|&(ref k, ref _v)| {
                     prefix_cmp_encoded(k, &self.last_key, prefix)
-                }).ok()
+                })
+                .ok()
                 .or_else(|| {
                     binary_search_gt(leaf, |&(ref k, ref _v)| {
                         prefix_cmp_encoded(k, &self.last_key, prefix)
@@ -181,7 +182,8 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
                 self.inclusive = false;
                 leaf.binary_search_by(|&(ref k, ref _v)| {
                     prefix_cmp_encoded(k, &self.last_key, prefix)
-                }).ok()
+                })
+                .ok()
                 .or_else(|| {
                     binary_search_lt(leaf, |&(ref k, ref _v)| {
                         prefix_cmp_encoded(k, &self.last_key, prefix)

--- a/crates/sled/src/materializer.rs
+++ b/crates/sled/src/materializer.rs
@@ -94,7 +94,8 @@ impl Materializer for BLinkMaterializer {
     fn size_in_bytes(&self, frag: &Frag) -> usize {
         match *frag {
             Frag::Base(ref node, _prev_root) => {
-                std::mem::size_of::<Frag>() + node.size_in_bytes()
+                std::mem::size_of::<Frag>()
+                    .saturating_add(node.size_in_bytes() as usize)
             }
             _ => std::mem::size_of::<Frag>(),
         }

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -13,13 +13,16 @@ pub(crate) struct Node {
 
 impl Node {
     #[inline]
-    pub(crate) fn size_in_bytes(&self) -> usize {
-        let self_sz = size_of::<Node>();
+    pub(crate) fn size_in_bytes(&self) -> u64 {
+        let self_sz = size_of::<Node>() as u64;
         let lo_sz = self.lo.size_in_bytes();
         let hi_sz = self.hi.size_in_bytes();
         let data_sz = self.data.size_in_bytes();
 
-        self_sz + lo_sz + hi_sz + data_sz
+        self_sz
+            .saturating_add(lo_sz)
+            .saturating_add(hi_sz)
+            .saturating_add(data_sz)
     }
 
     pub(crate) fn apply(
@@ -165,7 +168,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn should_split(&self, max_sz: usize) -> bool {
+    pub(crate) fn should_split(&self, max_sz: u64) -> bool {
         self.data.len() > 2 && self.size_in_bytes() > max_sz
     }
 

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -151,7 +151,8 @@ impl Tree {
                     PagePtr::allocated(),
                     counter,
                     &guard,
-                ).map_err(|e| e.danger_cast())?;
+                )
+                .map_err(|e| e.danger_cast())?;
 
             // set up empty leaf
             let leaf_id = pages.allocate(&guard)?;
@@ -276,7 +277,8 @@ impl Tree {
                         key.clone(),
                         counter_frag,
                         &guard,
-                    ).map_err(|e| e.danger_cast())?;
+                    )
+                    .map_err(|e| e.danger_cast())?;
 
                 // during recovery we add 2x the interval. we only
                 // need to block if the last one wasn't stable yet.
@@ -624,13 +626,14 @@ impl Tree {
                 Ok(new_cas_key) => {
                     // success
                     if node.should_split(
-                        self.config.blink_node_split_size,
+                        self.config.blink_node_split_size as u64,
                     ) {
                         let mut path2 = path
                             .iter()
                             .map(|&(f, ref p)| {
                                 (Cow::Borrowed(f), p.clone())
-                            }).collect::<Vec<(Cow<'_, Frag>, _)>>();
+                            })
+                            .collect::<Vec<(Cow<'_, Frag>, _)>>();
                         let mut node2 = node.clone();
                         node2
                             .apply(&frag, self.config.merge_operator);
@@ -806,13 +809,14 @@ impl Tree {
                 Ok(new_cas_key) => {
                     // success
                     if node.should_split(
-                        self.config.blink_node_split_size,
+                        self.config.blink_node_split_size as u64,
                     ) {
                         let mut path2 = path
                             .iter()
                             .map(|&(f, ref p)| {
                                 (Cow::Borrowed(f), p.clone())
-                            }).collect::<Vec<(Cow<'_, Frag>, _)>>();
+                            })
+                            .collect::<Vec<(Cow<'_, Frag>, _)>>();
                         let mut node2 = node.clone();
                         node2
                             .apply(&frag, self.config.merge_operator);
@@ -989,7 +993,9 @@ impl Tree {
             let (parent_frag, parent_ptr) = window[0].clone();
             let (node_frag, node_ptr) = window[1].clone();
             let node: &Node = node_frag.unwrap_base();
-            if node.should_split(self.config.blink_node_split_size) {
+            if node.should_split(
+                self.config.blink_node_split_size as u64,
+            ) {
                 // try to child split
                 if let Ok(parent_split) =
                     self.child_split(node, node_ptr.clone(), guard)
@@ -1020,7 +1026,9 @@ impl Tree {
         let (ref root_frag, ref root_ptr) = path[0];
         let root_node: &Node = root_frag.unwrap_base();
 
-        if root_node.should_split(self.config.blink_node_split_size) {
+        if root_node
+            .should_split(self.config.blink_node_split_size as u64)
+        {
             if let Ok(parent_split) =
                 self.child_split(&root_node, root_ptr.clone(), guard)
             {
@@ -1030,7 +1038,8 @@ impl Tree {
                         parent_split.to,
                         parent_split.at.inner().to_vec(),
                         guard,
-                    ).map(|_| ())
+                    )
+                    .map(|_| ())
                     .map_err(|e| e.danger_cast());
             }
         }
@@ -1068,7 +1077,8 @@ impl Tree {
                 PagePtr::allocated(),
                 Frag::Base(rhs, None),
                 guard,
-            ).map_err(|e| e.danger_cast())?;
+            )
+            .map_err(|e| e.danger_cast())?;
 
         // try to install a child split on the left side
         let link = self.pages.link(
@@ -1152,7 +1162,8 @@ impl Tree {
                 PagePtr::allocated(),
                 new_root,
                 guard,
-            ).expect(
+            )
+            .expect(
                 "we should be able to replace a newly \
                  allocated page without issue",
             );
@@ -1196,7 +1207,8 @@ impl Tree {
                         key.as_ref(),
                         last_node.lo.inner(),
                     )
-                }).ok();
+                })
+                .ok();
 
             search.map(|idx| &*items[idx].1)
         });


### PR DESCRIPTION
This introduces u64 and saturating adds for size-related math internal
to sled.