### PR TITLE
Optionally measure allocations

### DIFF
--- a/benchmarks/stress2/Cargo.toml
+++ b/benchmarks/stress2/Cargo.toml
@@ -14,6 +14,7 @@ check_snapshot_integrity = ["sled/check_snapshot_integrity"]
 zstd = ["sled/zstd"]
 no_logs = ["sled/no_logs"]
 no_metrics = ["sled/no_metrics"]
+measure_allocs = ["sled/measure_allocs"]
 
 [dependencies]
 serde = "1.0"

--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -19,6 +19,7 @@ no_logs = ["log/max_level_off"]
 nightly = ["sled_sync/nightly"]
 no_inline = ["sled_sync/no_inline"]
 event_log = []
+measure_allocs = []
 
 [dependencies]
 libc = "0.2"

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -77,6 +77,14 @@ mod snapshot;
 mod tx;
 mod util;
 
+#[cfg(feature = "measure_allocs")]
+mod measure_allocs;
+
+#[cfg(feature = "measure_allocs")]
+#[global_allocator]
+static ALLOCATOR: measure_allocs::TrackingAllocator =
+    measure_allocs::TrackingAllocator;
+
 #[cfg(feature = "event_log")]
 /// The event log helps debug concurrency issues.
 pub mod event_log;

--- a/crates/pagecache/src/measure_allocs.rs
+++ b/crates/pagecache/src/measure_allocs.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+use std::sync::atomic::Ordering::Release;
+
+// define a passthrough allocator that tracks alloc calls.
+// adapted from the flatbuffer codebase
+use std::alloc::{GlobalAlloc, Layout, System};
+
+pub(crate) struct TrackingAllocator;
+
+pub static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+pub static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Release);
+        ALLOCATED_BYTES.fetch_add(layout.size(), Release);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+}

--- a/crates/pagecache/src/metrics.rs
+++ b/crates/pagecache/src/metrics.rs
@@ -10,6 +10,9 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed};
 
 use historian::Histo;
 
+#[cfg(feature = "measure_allocs")]
+use super::measure_allocs;
+
 lazy_static! {
     /// A metric collector for all pagecache users running in this
     /// process.
@@ -110,6 +113,10 @@ pub struct Metrics {
     pub log_reservation_attempts: AtomicUsize,
     pub accountant_lock: Histo,
     pub accountant_hold: Histo,
+    #[cfg(feature = "measure_allocs")]
+    pub allocations: AtomicUsize,
+    #[cfg(feature = "measure_allocs")]
+    pub allocated_bytes: AtomicUsize,
 }
 
 #[cfg(not(feature = "no_metrics"))]
@@ -234,6 +241,20 @@ impl Metrics {
             f("acquire", &self.accountant_lock),
             f("hold", &self.accountant_hold),
         ]);
+
+        #[cfg(feature = "measure_allocs")]
+        {
+            println!("{}", repeat("-").take(103).collect::<String>());
+            println!("allocation statistics:");
+            println!(
+                "total allocations: {}",
+                measure_allocs::ALLOCATIONS.load(Acquire)
+            );
+            println!(
+                "allocated bytes: {}",
+                measure_allocs::ALLOCATED_BYTES.load(Acquire)
+            );
+        }
     }
 }
 

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -21,6 +21,7 @@ zstd = ["pagecache/zstd"]
 nightly = ["pagecache/nightly"]
 no_inline = ["pagecache/no_inline"]
 event_log = ["pagecache/event_log"]
+measure_allocs = ["pagecache/measure_allocs"]
 
 [dependencies.log]
 version = "0.4"


### PR DESCRIPTION
@utaal Just added a pretty simple allocation counter based on @rw's counter in the flatbuffers codebase, but using AtomicUsize so it works across threads.

recommended to run from benchmarks/stress2:
```
 cargo run --features=measure_allocs --  --threads=1
```

non-release mode on my laptop does 250k high-level operations in 10 seconds, generating nearly 4 million allocations with about 840mb of total allocation.

release mode: roughly 10x higher in all measurements over 10 seconds.

TONS of low-hanging fruit :] Now this can be a fun game to get the number down