### PR TITLE
Improve the ways of opening Db and Trees

### DIFF
--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -33,5 +33,5 @@ version = "0.4"
 
 [dependencies]
 pagecache = { path = "../pagecache", version = "0.9.4" }
-sled_sync = { version = "0.2.2", path = "../sled_sync" }
+sled_sync = { path = "../sled_sync", version = "0.2.2" }
 futures = "0.1"

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -22,7 +22,7 @@
 //! assert_eq!(t.get(b"yo!"), Ok(None));
 //! ```
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![cfg_attr(test, deny(clippy::warnings))]
 #![cfg_attr(test, deny(clippy::bad_style))]
 #![cfg_attr(test, deny(clippy::future_incompatible))]
@@ -55,7 +55,7 @@ const TX_TREE_ID: &[u8] = b"__sled__transactions";
 
 pub use {
     self::{
-        db::Db,
+        db::{Db, OpenOptions, TreeOpenOptions},
         iter::{Iter, Keys, Values},
         pinned_value::PinnedValue,
         subscription::{Event, Subscriber},

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -102,9 +102,8 @@ impl Tree {
     ///
     /// Note that this is not atomic.
     pub fn clear(&self) -> Result<(), ()> {
-        for k in self.keys(b"") {
-            let key = k?;
-            self.del(key)?;
+        for key in self.keys("") {
+            self.del(key?)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Here is some work on fixing #492, I thought of a builder constructor that follows the [std::fs::OpenOptions](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) type.

I would be cool to guide me a little bit about the `Context` type you talked about, it will help me continue working on the `OpenOptions` types. What do we put in it? Where does it lives, pagecache or sled?

Here is the list of things I need to do:
 - [ ] Introduce some `OpenOptions`/`TreeOpenOptions` type constructors.
  The `OpenOptions::merge_operator` setting will be passed to the `TreeOpenOptions::merge_operator` to open the default tree.

- [ ] Remove the `Db::start_default/start` methods.

 - [ ] Remove the `pagecache::Config::merge_operator` setting, it does not need to care about, only the `Tree`s must. So, one serialized config by tree?

 - [ ] Introduce a `Context` type that owns a `PageCache`.
  This type is aware of the settings relative to a `Tree`, it must be serializable, this way a `Tree` can be loaded again with the same settings (e.g. the merge operator) and reduce the introduction of bugs related to settings.

 - [ ] Remove the `Config::temporary` and the `DEFAULT_PATH` setting, it could be better to make `Config`s parametric on `AsRef<Path>` and being able to use [`TempDir`](https://docs.rs/tempfile/3.0.5/tempfile/struct.TempDir.html).
