### PR TITLE
Add concurrent log test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Cargo.lock
 *.proptest-regressions
 corpus
 artifacts
+.idea


### PR DESCRIPTION
Share a log among several threads, and also share an AtomicUint counter.

Threads will attempt to successfully CAS on the counter to increment it by 1. 
If this succeeds, that signals to the test complete its log reservation,
otherwise it will abort.

This counter indicates the number of sucessful writes to the shared log.
The contents of the write will be the value read from the counter.

Finally, iterate through the log, and assert that the number of
successful entries exactly matches the success counter, and that the
values increment sequentially.

Refs #404
