### PR TITLE
Several orthogonal improvements

### DIFF
--- a/crates/pagecache/README.md
+++ b/crates/pagecache/README.md
@@ -11,7 +11,7 @@ A construction kit for databases. Provides a lock-free log store and pagecache.
 * [LLAMA: A Cache/Storage Subsystem for Modern Hardware](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/llama-vldb2013.pdf)
 * [The Design and Implementation of a Log-Structured File System](https://people.eecs.berkeley.edu/~brewer/cs262/LFS.pdf)
 
-```
+```rust
 use pagecache::{PagePtr, pin, Materializer};
 
 pub struct TestMaterializer;

--- a/crates/pagecache/src/ds/stack.rs
+++ b/crates/pagecache/src/ds/stack.rs
@@ -132,8 +132,7 @@ impl<T: Send + Sync + 'static> Stack<T> {
                         .compare_and_set(head, next, SeqCst, &guard)
                     {
                         Ok(_) => unsafe {
-                            let head_owned = head.into_owned();
-                            guard.defer(move || head_owned);
+                            guard.defer_destroy(head);
                             return Some(ptr::read(&h.inner));
                         },
                         Err(h) => head = h.current,
@@ -191,8 +190,7 @@ impl<T: Send + Sync + 'static> Stack<T> {
             Ok(_) => {
                 if !old.is_null() {
                     unsafe {
-                        let old_owned = old.into_owned();
-                        guard.defer(move || old_owned)
+                        guard.defer_destroy(old);
                     };
                 }
                 Ok(new)

--- a/crates/pagecache/src/pagecache.rs
+++ b/crates/pagecache/src/pagecache.rs
@@ -432,10 +432,7 @@ where
         let mut pages_before_restart: HashMap<PageId, Vec<DiskPtr>> =
             HashMap::new();
 
-        let tx = Tx {
-            guard: pin(),
-            ts: 0,
-        };
+        let tx = Tx::new(0);
 
         for pid in 0..self.max_pid.load(SeqCst) {
             let pte = self.inner.get(pid, &tx);
@@ -587,10 +584,7 @@ where
 
     /// Begins a transaction.
     pub fn begin(&self) -> Result<Tx, ()> {
-        Ok(Tx {
-            guard: pin(),
-            ts: self.generate_id()?,
-        })
+        Ok(Tx::new(self.generate_id()?))
     }
 
     /// Create a new page, trying to reuse old freed pages if possible
@@ -1158,10 +1152,7 @@ where
             persisted = self.idgen_persists.load(SeqCst);
             if persisted < necessary_persists {
                 // it's our responsibility to persist up to our ID
-                let tx = Tx {
-                    guard: pin(),
-                    ts: u64::max_value(),
-                };
+                let tx = Tx::new(u64::max_value());
                 let page_get = self
                     .get(COUNTER_PID, &tx)
                     .map_err(|e| e.danger_cast())?;
@@ -1916,10 +1907,7 @@ where
                 Vec<DiskPtr>,
             > = HashMap::new();
 
-            let tx = Tx {
-                guard: pin(),
-                ts: 0,
-            };
+            let tx = Tx::new(0);
 
             for pid in 0..self.max_pid.load(SeqCst) {
                 let pte = self.inner.get(pid, &tx);

--- a/crates/pagecache/src/tx.rs
+++ b/crates/pagecache/src/tx.rs
@@ -11,6 +11,16 @@ pub struct Tx {
     pub ts: u64,
 }
 
+impl Tx {
+    /// Creates a new Tx with a given timestamp.
+    pub fn new(ts: u64) -> Self {
+        Self {
+            guard: pin(),
+            ts: ts,
+        }
+    }
+}
+
 impl std::ops::Deref for Tx {
     type Target = Guard;
 

--- a/crates/sled/src/context.rs
+++ b/crates/sled/src/context.rs
@@ -26,10 +26,7 @@ impl Drop for Context {
 
         #[cfg(feature = "event_log")]
         {
-            let tx = Tx {
-                guard: pin(),
-                ts: 0,
-            };
+            let tx = Tx::new(0);
 
             self.config.event_log.meta_before_restart(
                 self.pagecache

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -80,7 +80,7 @@ use {
         PageId, Tx, M,
     },
     serde::{Deserialize, Serialize},
-    sled_sync::{debug_delay, pin},
+    sled_sync::debug_delay,
 };
 
 type Key = Vec<u8>;

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -788,10 +788,7 @@ impl Tree {
             Err(e) => {
                 return Iter {
                     tree: &self,
-                    tx: Tx {
-                        ts: 0,
-                        guard: pin(),
-                    },
+                    tx: Tx::new(0),
                     broken: Some(e),
                     done: false,
                     hi: ops::Bound::Unbounded,


### PR DESCRIPTION
Here are some orthogonal improvements:

- Rust code highlight in pagecache's README
- Use `guard.defer_destroy()` instead of `guard.defer()`.  See [the API doc](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-epoch/src/guard.rs#L199).
- Create `Tx::new()`.
- Fix a documentation bug.
- Use `Relaxed` instead of `SeqCst` in pagetable's `drop`.  It is sound because the destructor is accessing the data without contention.