### PR TITLE
Rustfmt and clippy

### DIFF
--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -233,10 +233,12 @@ impl ConfigBuilder {
             None
         };
 
-        let file = self.open_file().expect(&format!(
-            "should be able to open configured file at {:?}",
-            self.db_path(),
-        ));
+        let file = self.open_file().unwrap_or_else(|_| {
+            panic!(
+                "should be able to open configured file at {:?}",
+                self.db_path()
+            );
+        });
 
         // seal config in a Config
         Config {

--- a/crates/pagecache/src/iobuf.rs
+++ b/crates/pagecache/src/iobuf.rs
@@ -320,7 +320,7 @@ impl IoBufs {
             );
             std::ptr::copy_nonoverlapping(
                 to_reserve.as_ptr(),
-                out_buf.as_mut_ptr().offset(MSG_HEADER_LEN as isize),
+                out_buf.as_mut_ptr().add(MSG_HEADER_LEN),
                 to_reserve.len(),
             );
         }

--- a/crates/pagecache/src/iterator.rs
+++ b/crates/pagecache/src/iterator.rs
@@ -73,7 +73,8 @@ impl Iterator for LogIter {
             }
 
             let lid = self.segment_base.unwrap()
-                + (self.cur_lsn % self.config.io_buf_size as Lsn) as LogId;
+                + (self.cur_lsn % self.config.io_buf_size as Lsn)
+                    as LogId;
 
             let f = &self.config.file;
             match f.read_message(lid, &self.config) {
@@ -203,7 +204,8 @@ impl LogIter {
             .into());
         }
 
-        let trailer_offset = offset + self.config.io_buf_size as LogId
+        let trailer_offset = offset
+            + self.config.io_buf_size as LogId
             - SEG_TRAILER_LEN as LogId;
         let trailer_lsn = segment_header.lsn
             + self.config.io_buf_size as Lsn

--- a/crates/pagecache/src/meta.rs
+++ b/crates/pagecache/src/meta.rs
@@ -14,7 +14,7 @@ pub struct Meta {
 impl Meta {
     /// Retrieve the PageId associated with an identifier
     pub fn get_root(&self, table: &[u8]) -> Option<PageId> {
-        self.inner.get(table).map(|r| *r)
+        self.inner.get(table).cloned()
     }
 
     /// Set the PageId associated with an identifier

--- a/crates/pagecache/src/parallel_io.rs
+++ b/crates/pagecache/src/parallel_io.rs
@@ -70,7 +70,7 @@ impl Pio for std::fs::File {
                     return Err(io::Error::new(
                         io::ErrorKind::WriteZero,
                         "failed to write whole buffer",
-                    ))
+                    ));
                 }
                 Ok(n) => {
                     offset += n as LogId;
@@ -139,7 +139,7 @@ impl Pio for std::fs::File {
                     return Err(io::Error::new(
                         io::ErrorKind::WriteZero,
                         "failed to write whole buffer",
-                    ))
+                    ));
                 }
                 Ok(n) => {
                     offset += n as LogId;

--- a/crates/pagecache/src/reservation.rs
+++ b/crates/pagecache/src/reservation.rs
@@ -28,18 +28,16 @@ impl<'a> Reservation<'a> {
     /// Cancel the reservation, placing a failed flush on disk, returning
     /// the (cancelled) log sequence number and file offset.
     pub fn abort(mut self) -> Result<(Lsn, DiskPtr), ()> {
-        if self.ptr.is_blob() {
-            if !self.is_blob_rewrite {
-                // we don't want to remove this blob if something
-                // else may still be using it.
+        if self.ptr.is_blob() && !self.is_blob_rewrite {
+            // we don't want to remove this blob if something
+            // else may still be using it.
 
-                trace!(
-                    "removing blob for aborted reservation at lsn {}",
-                    self.ptr
-                );
+            trace!(
+                "removing blob for aborted reservation at lsn {}",
+                self.ptr
+            );
 
-                remove_blob(self.ptr.blob().1, &self.log.config)?;
-            }
+            remove_blob(self.ptr.blob().1, &self.log.config)?;
         }
 
         self.flush(false)
@@ -65,7 +63,7 @@ impl<'a> Reservation<'a> {
     /// Note that an blob write still has a pointer in the
     /// log at the provided lid location.
     pub fn ptr(&self) -> DiskPtr {
-        self.ptr.clone()
+        self.ptr
     }
 
     fn flush(&mut self, valid: bool) -> Result<(Lsn, DiskPtr), ()> {

--- a/crates/pagecache/src/tx.rs
+++ b/crates/pagecache/src/tx.rs
@@ -14,10 +14,7 @@ pub struct Tx {
 impl Tx {
     /// Creates a new Tx with a given timestamp.
     pub fn new(ts: u64) -> Self {
-        Self {
-            guard: pin(),
-            ts: ts,
-        }
+        Self { guard: pin(), ts }
     }
 }
 

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -346,7 +346,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
                     end
                 };
 
-                if !node.hi.is_empty() && &*node.hi < search_key {
+                if !node.hi.is_empty() && *node.hi < *search_key {
                     // the node has been split since we saw it,
                     // and we need to scan forward
                     split_detected = true;
@@ -411,7 +411,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
             while (!split_detected
                 && (next_node.next != Some(node.id))
                 && next_node.lo < node.lo)
-                || (split_detected && &*next_node.hi < split_key)
+                || (split_detected && *next_node.hi < *split_key)
             {
                 let res = self
                     .tree

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -39,7 +39,7 @@ impl Node {
                     || prefix_cmp_encoded(k, &self.hi, &self.lo)
                         == std::cmp::Ordering::Less
                 {
-                    self.set_leaf(k.clone().into(), v.clone().into());
+                    self.set_leaf(k.clone(), v.clone());
                 } else {
                     panic!("tried to consolidate set at key <= hi")
                 }
@@ -154,7 +154,7 @@ impl Node {
     pub(crate) fn parent_split(&mut self, ps: &ParentSplit) {
         if let Data::Index(ref mut ptrs) = self.data {
             let encoded_sep = prefix_encode(&self.lo, &ps.at);
-            ptrs.push((encoded_sep.into(), ps.to));
+            ptrs.push((encoded_sep, ps.to));
             ptrs.sort_unstable_by(|a, b| prefix_cmp(&*a.0, &*b.0));
         } else {
             panic!("tried to attach a ParentSplit to a Leaf chain");

--- a/crates/sled/src/prefix.rs
+++ b/crates/sled/src/prefix.rs
@@ -10,7 +10,9 @@ pub(crate) fn prefix_encode(prefix: &[u8], buf: &[u8]) -> IVec {
         buf
     );
     let mut prefix_len = 0_usize;
-    for (i, c) in prefix.iter().take(u8::max_value() as usize).enumerate() {
+    for (i, c) in
+        prefix.iter().take(u8::max_value() as usize).enumerate()
+    {
         if buf[i] == *c {
             prefix_len += 1;
         } else {


### PR DESCRIPTION
I ran rustfmt and clippy.  Fixed all clippy errors, but left a few warnings on "cyclomatic complexity", e.g.:

```
warning: the function has a cyclomatic complexity of 29
   --> crates/sled/src/iter.rs:210:5          
    |                                      
210 | /     fn next_back(&mut self) -> Option<Self::Item> {
211 | |         let _measure = Measure::new(&M.tree_scan);
212 | |                        
213 | |         if self.done {                                   
...   |                                                                                             
445 | |         }                                                                                   
446 | |     }                                                                                       
    | |_____^                                  
    |                   
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#c
yclomatic_complexity                             
```

Personally I'm fine with a little bit long functions and use ` #[allow(clippy::cyclomatic_complexity)]`.  Then we can close #393.