### PR TITLE
Make the IVec Debug impl support formatting

### DIFF
--- a/crates/sled/src/ivec.rs
+++ b/crates/sled/src/ivec.rs
@@ -115,7 +115,7 @@ impl PartialEq<[u8]> for IVec {
 
 impl fmt::Debug for IVec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.deref())
+        self.deref().fmt(f)
     }
 }
 


### PR DESCRIPTION
It is now possible to specify formatting rules, the "underlying" slice will be informed of the outer formatting rules. For example the `{:x?}` will now correctly display the slice in its hex representation.