### PR TITLE
Reduce the number of times a value is cloned

### DIFF
--- a/crates/sled/src/subscription.rs
+++ b/crates/sled/src/subscription.rs
@@ -15,15 +15,17 @@ use futures::{
     },
 };
 
+use crate::ivec::IVec;
+
 static ID_GEN: AtomicUsize = AtomicUsize::new(0);
 
 /// An event that happened to a key that a subscriber is interested in.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Event {
     /// A new complete (key, value) pair
-    Set(Vec<u8>, Vec<u8>),
+    Set(Vec<u8>, IVec),
     /// A new partial (key, merged value) pair
-    Merge(Vec<u8>, Vec<u8>),
+    Merge(Vec<u8>, IVec),
     /// A deleted key
     Del(Vec<u8>),
 }
@@ -191,11 +193,11 @@ fn basic_subscription() {
 
     let k2 = vec![];
     let r2 = subs.reserve(&k2).unwrap();
-    r2.complete(Event::Set(k2.clone(), k2.clone()));
+    r2.complete(Event::Set(k2.clone(), IVec::from(k2.clone())));
 
     let k3 = vec![0];
     let r3 = subs.reserve(&k3).unwrap();
-    r3.complete(Event::Set(k3.clone(), k3.clone()));
+    r3.complete(Event::Set(k3.clone(), IVec::from(k3.clone())));
 
     let k4 = vec![0, 1];
     let r4 = subs.reserve(&k4).unwrap();
@@ -203,7 +205,7 @@ fn basic_subscription() {
 
     let k5 = vec![0, 1, 2];
     let r5 = subs.reserve(&k5).unwrap();
-    r5.complete(Event::Merge(k5.clone(), k5.clone()));
+    r5.complete(Event::Merge(k5.clone(), IVec::from(k5.clone())));
 
     let k6 = vec![1, 1, 2];
     let r6 = subs.reserve(&k6).unwrap();
@@ -215,7 +217,7 @@ fn basic_subscription() {
 
     let k8 = vec![1, 2, 2];
     let r8 = subs.reserve(&k8).unwrap();
-    r8.complete(Event::Set(k8.clone(), k8.clone()));
+    r8.complete(Event::Set(k8.clone(), IVec::from(k8.clone())));
 
     assert_eq!(s1.next().unwrap().key(), &*k2);
     assert_eq!(s1.next().unwrap().key(), &*k3);

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -321,11 +321,7 @@ impl Tree {
             return Err(Error::CasFailed(None));
         }
 
-        let new_ivec = if let Some(ref n) = new {
-            Some(IVec::from(&**n))
-        } else {
-            None
-        };
+        let new = new.map(IVec::from);
 
         // we need to retry caps until old != cur, since just because
         // cap fails it doesn't mean our value was changed.
@@ -360,8 +356,8 @@ impl Tree {
                 let node: &Node = leaf_frag.unwrap_base();
                 (node.id, prefix_encode(&node.lo, key.as_ref()))
             };
-            let frag = if let Some(ref n) = new_ivec {
-                Frag::Set(encoded_key, n.clone())
+            let frag = if let Some(ref new) = new {
+                Frag::Set(encoded_key, new.clone())
             } else {
                 Frag::Del(encoded_key)
             };
@@ -372,10 +368,10 @@ impl Tree {
             match link {
                 Ok(_) => {
                     if let Some(res) = subscriber_reservation.take() {
-                        let event = if let Some(n) = new {
+                        let event = if let Some(new) = new {
                             subscription::Event::Set(
                                 key.as_ref().to_vec(),
-                                n.clone(),
+                                new,
                             )
                         } else {
                             subscription::Event::Del(
@@ -415,7 +411,7 @@ impl Tree {
             ));
         }
 
-        let val_ivec: IVec = IVec::from(&*value);
+        let value = IVec::from(value);
 
         loop {
             let tx = self.context.pagecache.begin()?;
@@ -431,7 +427,7 @@ impl Tree {
             let mut subscriber_reservation =
                 self.subscriptions.reserve(&key);
 
-            let frag = Frag::Set(encoded_key, val_ivec.clone());
+            let frag = Frag::Set(encoded_key, value.clone());
             let link = self.context.pagecache.link(
                 node.id,
                 leaf_ptr.clone(),
@@ -444,7 +440,7 @@ impl Tree {
                     if let Some(res) = subscriber_reservation.take() {
                         let event = subscription::Event::Set(
                             key.as_ref().to_vec(),
-                            value.clone(),
+                            value,
                         );
 
                         res.complete(event);
@@ -618,7 +614,7 @@ impl Tree {
             ));
         }
 
-        let val_ivec = IVec::from(&*value);
+        let value = IVec::from(value);
 
         loop {
             let tx = self.context.pagecache.begin()?;
@@ -634,7 +630,7 @@ impl Tree {
                 self.subscriptions.reserve(&key);
 
             let encoded_key = prefix_encode(&node.lo, key.as_ref());
-            let frag = Frag::Merge(encoded_key, val_ivec.clone());
+            let frag = Frag::Merge(encoded_key, value.clone());
 
             let link = self.context.pagecache.link(
                 node.id,
@@ -648,7 +644,7 @@ impl Tree {
                     if let Some(res) = subscriber_reservation.take() {
                         let event = subscription::Event::Merge(
                             key.as_ref().to_vec(),
-                            value.clone(),
+                            value,
                         );
 
                         res.complete(event);


### PR DESCRIPTION
This pull request reduce the number of times a value is cloned in the `set`, `merge` and `cas` Db methods. It can be costly especially for big values.

To fix that I directly put the user value inside of an `IVec` this way cloning is not costly. By the way I changed the `Event::Set/Merge` types to be more consistent with the current Db API, returning the values as `IVec` and not `Vec<u8>`.