### PR TITLE
Check if the compression feature is enabled

### DIFF
--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -34,7 +34,6 @@ impl Deref for Config {
 /// let _config = pagecache::ConfigBuilder::default()
 ///     .path("/path/to/data".to_owned())
 ///     .cache_capacity(10_000_000_000)
-///     .use_compression(true)
 ///     .flush_every_ms(Some(1000))
 ///     .snapshot_after_ops(100_000);
 /// ```
@@ -106,7 +105,7 @@ impl Default for ConfigBuilder {
             read_only: false,
             cache_bits: 0,                      // 1 shard
             cache_capacity: 1024 * 1024 * 1024, // 1gb
-            use_compression: true,
+            use_compression: false,
             compression_factor: 5,
             flush_every_ms: Some(500),
             snapshot_after_ops: 1_000_000,
@@ -308,6 +307,12 @@ impl ConfigBuilder {
             self.segment_cleanup_skew < 99,
             "segment_cleanup_skew cannot be greater than 99%"
         );
+        if self.use_compression {
+            supported!(
+                cfg!(feature = "compression"),
+                "the compression feature must be enabled"
+            );
+        }
         supported!(
             self.compression_factor >= 1,
             "compression_factor must be >= 1"


### PR DESCRIPTION
This pull request change two things, it enables the pagecache compression feature checks if the compression feature has been set when `use_compression` is set to `true`.

I faced the problem of running sled without the `compression` feature active but with the `use_compression` config builder param set to `true` (the default value) and sled didn't tell me anything.

Even worst: I created a database with the `compression` feature and tried to read it, get values from trees, with another program without the `compression` feature active, sled did not say anything but did not returned any entry, like they were empty.

So there is two solutions to fix this problem:
  - keeping the `use_compression` param set to `true` by default **but** make the `compression` feature enabled by default or
  - set the `use_compression` to `false` by default and keep the `compression` feature disabled

In this PR, the first solution has been chosen.

EDIT: The second solution is preferable.