### PR TITLE
Rewrite the Data split method

### DIFF
--- a/crates/sled/src/data.rs
+++ b/crates/sled/src/data.rs
@@ -68,8 +68,7 @@ impl Data {
 
             let mut rhs_data = Vec::with_capacity(rhs.len());
             for (k, v) in rhs {
-                let k = prefix_decode(lhs_prefix, k);
-                let k = prefix_encode(&split, &k);
+                let k = prefix_reencode(lhs_prefix, &split, k);
                 rhs_data.push((k, v.clone()));
             }
 

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -70,7 +70,7 @@ use {
         node::Node,
         prefix::{
             prefix_cmp, prefix_cmp_encoded, prefix_decode,
-            prefix_encode,
+            prefix_encode, prefix_reencode,
         },
         subscription::Subscriptions,
     },

--- a/crates/sled/src/prefix.rs
+++ b/crates/sled/src/prefix.rs
@@ -25,21 +25,13 @@ pub(crate) fn prefix_encode(prefix: &[u8], buf: &[u8]) -> IVec {
 
 pub(crate) fn prefix_decode(prefix: &[u8], buf: &[u8]) -> Vec<u8> {
     assert!(!buf.is_empty());
+
     let prefix_len = buf[0] as usize;
     let mut ret = Vec::with_capacity(prefix_len + buf.len() - 1);
-    unsafe {
-        ret.set_len(prefix_len + buf.len() - 1);
-        std::ptr::copy_nonoverlapping(
-            prefix.as_ptr(),
-            ret.as_mut_ptr(),
-            prefix_len,
-        );
-        std::ptr::copy_nonoverlapping(
-            buf[1..].as_ptr(),
-            ret[prefix_len..].as_mut_ptr(),
-            buf.len() - 1,
-        );
-    }
+
+    ret.extend_from_slice(&prefix[..prefix_len]);
+    ret.extend_from_slice(&buf[1..]);
+
     ret
 }
 


### PR DESCRIPTION
I tested and assumed that the `ptrs` are already sorted and that prefix encoded keys are sorted the same that non encoded ones (is that named "ordering transitivity" ?).

I will rebase on master once #592 is merged, if it is 😄 

So in this rewrite I no longer need to construct a decoded sorted Vec but only need to decode the middle key (`split`) and create a new Vec of half the size of `ptrs` re-encoded using the previously extracted middle key (`split`).

I also rewrite the `prefix_decode` and `prefix_encode` functions removing the unsafe code that doesn't seems to be needed and introduced a new `prefix_reencode` function that `decode` and `encode` using the the old and new prefix.

This update reduced the usage percentage of the `Data::split` method from 46.2% to 25.47% and make my program takes from 25mins (including the #592 patch) to near 16mins.

[flamegraphs-before-after-data-split-patch.zip](https://github.com/spacejam/sled/files/2999752/before-after-data-split-patch.zip)
