### PR TITLE
Improve the IVec bytes de/serializing

### DIFF
--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -35,3 +35,4 @@ version = "0.4"
 [dependencies]
 pagecache = { path = "../pagecache", version = "0.12" }
 futures = "0.1"
+serde_bytes = "0.10"


### PR DESCRIPTION
I rewrote the De/Serialize impls of the `IVec` type, in the old one the `serialize_bytes` method was only called for the `Remote` variant and not the `Inline` one (which would call `serialize_seq` with `u8`).

This PR makes my code takes from 16mins (with the #593 patch) to 13mins 30secs by reducing the `Node::serialize` usage from 17.29% to 3.71%.

I now that serde will be removed as soon as flatbuffer land.

Let me rebase on master when #593 is merged 😄 

[flamegraphs-before-after-ivec-de-serialize.zip](https://github.com/spacejam/sled/files/2999802/before-after-ivec-de-serialize.zip)
