### PR TITLE
some write optimizations

### DIFF
--- a/crates/pagecache/src/logger.rs
+++ b/crates/pagecache/src/logger.rs
@@ -437,7 +437,6 @@ impl Log {
         let mut header = iobuf.get_header();
 
         // Decrement writer count, retrying until successful.
-        let backoff = Backoff::new();
         loop {
             let new_hv = iobuf::decr_writers(header);
             match iobuf.cas_header(header, new_hv) {
@@ -448,7 +447,6 @@ impl Log {
                 Err(new) => {
                     // we failed to decr, retry
                     header = new;
-                    backoff.spin();
                 }
             }
         }

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -861,7 +861,7 @@ impl Tree {
                     )?;
 
                     if !success {
-                        continue;
+                        return Ok(());
                     }
                 }
             }
@@ -1204,7 +1204,7 @@ impl Tree {
                         return Err(Error::ReportableBug(format!(
                             "got non-base node while GC'ing tree: {:?}",
                             broken
-                        )))
+                        )));
                     }
                 };
 


### PR DESCRIPTION
@Kerollmops for workloads I tried with larger values (800 bytes+), this caused a really major speedup. Basically, we were doing a ton of wasted work trying to split nodes even when we detected that we were failing some of the recursive tree splits. Now we bail as soon as we fail once, because it's incredibly likely that we will not win any others either.