### PR TITLE
Skip parent splits in recursive split, since they are handled cooperatively in path_for_key

### DIFF
--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagecache"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "lock-free pagecache and log for high-performance databases"
 license = "MIT/Apache-2.0"

--- a/crates/pagecache/src/metrics.rs
+++ b/crates/pagecache/src/metrics.rs
@@ -91,6 +91,12 @@ pub struct Metrics {
     pub tree_merge: Histo,
     pub tree_start: Histo,
     pub tree_traverse: Histo,
+    pub tree_child_split_attempt: CachePadded<AtomicUsize>,
+    pub tree_child_split_success: CachePadded<AtomicUsize>,
+    pub tree_parent_split_attempt: CachePadded<AtomicUsize>,
+    pub tree_parent_split_success: CachePadded<AtomicUsize>,
+    pub tree_root_split_attempt: CachePadded<AtomicUsize>,
+    pub tree_root_split_success: CachePadded<AtomicUsize>,
     pub page_in: Histo,
     pub rewrite_page: Histo,
     pub merge_page: Histo,
@@ -136,6 +142,30 @@ impl Metrics {
 
     pub fn log_reservation_success(&self) {
         self.log_reservations.fetch_add(1, Relaxed);
+    }
+
+    pub fn tree_child_split_attempt(&self) {
+        self.tree_child_split_attempt.fetch_add(1, Relaxed);
+    }
+
+    pub fn tree_child_split_success(&self) {
+        self.tree_child_split_success.fetch_add(1, Relaxed);
+    }
+
+    pub fn tree_parent_split_attempt(&self) {
+        self.tree_parent_split_attempt.fetch_add(1, Relaxed);
+    }
+
+    pub fn tree_parent_split_success(&self) {
+        self.tree_parent_split_success.fetch_add(1, Relaxed);
+    }
+
+    pub fn tree_root_split_attempt(&self) {
+        self.tree_root_split_attempt.fetch_add(1, Relaxed);
+    }
+
+    pub fn tree_root_split_success(&self) {
+        self.tree_root_split_success.fetch_add(1, Relaxed);
     }
 
     pub fn print_profile(&self) {
@@ -194,6 +224,15 @@ impl Metrics {
             f("scan", &self.tree_scan),
         ]);
         println!("tree contention loops: {}", self.tree_loops.load(Acquire));
+        println!(
+            "tree split success rates: child({}/{}) parent({}/{}) root({}/{})",
+            self.tree_child_split_success.load(Acquire),
+            self.tree_child_split_attempt.load(Acquire),
+            self.tree_parent_split_success.load(Acquire),
+            self.tree_parent_split_attempt.load(Acquire),
+            self.tree_root_split_success.load(Acquire),
+            self.tree_root_split_attempt.load(Acquire),
+        );
 
         println!("{}", std::iter::repeat("-").take(134).collect::<String>());
         println!("pagecache:");

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a modern embedded database"
 license = "MIT/Apache-2.0"

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -843,26 +843,20 @@ impl Tree {
             self.context.blink_node_split_size as u64 * multiplier
         };
 
-        for (height, window) in path.windows(2).rev().enumerate() {
-            let (parent_id, _parent_frag, parent_ptr) = &window[0];
-            let (node_id, node_frag, node_ptr) = &window[1];
+        for (height, node_parts) in path.iter().skip(1).rev().enumerate() {
+            let (node_id, node_frag, node_ptr) = &node_parts;
             let node: &Node = node_frag.unwrap_base();
             if node.should_split(adjusted_max(height)) {
                 // try to child split
-                if let Some(parent_split) =
-                    self.child_split(*node_id, node, node_ptr.clone(), tx)?
-                {
-                    // now try to parent split
-                    let success = self.parent_split(
-                        *parent_id,
-                        parent_ptr.clone(),
-                        parent_split.clone(),
-                        tx,
-                    )?;
+                M.tree_child_split_attempt();
 
-                    if !success {
-                        return Ok(());
-                    }
+                if self
+                    .child_split(*node_id, node, node_ptr.clone(), tx)?
+                    .is_some()
+                {
+                    M.tree_child_split_success();
+                } else {
+                    return Ok(());
                 }
             }
         }
@@ -871,17 +865,21 @@ impl Tree {
         let root_node: &Node = root_frag.unwrap_base();
 
         if root_node.should_split(adjusted_max(path.len())) {
+            M.tree_root_split_attempt();
             if let Some(parent_split) =
                 self.child_split(*root_id, &root_node, root_ptr.clone(), tx)?
             {
-                return self
+                if self
                     .root_hoist(
                         *root_id,
                         parent_split.to,
                         parent_split.at.clone(),
                         tx,
                     )
-                    .map(|_| ());
+                    .is_ok()
+                {
+                    M.tree_root_split_success();
+                }
             }
         }
 
@@ -906,8 +904,11 @@ impl Tree {
         };
 
         // install the new right side
-        let (new_pid, new_ptr) =
-            self.context.pagecache.allocate(Frag::Base(rhs), tx)?;
+        let (new_pid, new_ptr) = self
+            .context
+            .pagecache
+            .allocate(Frag::Base(rhs), tx)
+            .unwrap();
 
         trace!("allocated pid {} in child_split", new_pid);
 
@@ -936,25 +937,6 @@ impl Tree {
         }
 
         Ok(Some(parent_split))
-    }
-
-    fn parent_split<'g>(
-        &self,
-        parent_node_id: usize,
-        parent_cas_key: TreePtr<'g>,
-        parent_split: ParentSplit,
-        tx: &'g Tx,
-    ) -> Result<bool> {
-        // install parent split
-        self.context
-            .pagecache
-            .link(
-                parent_node_id,
-                parent_cas_key,
-                Frag::ParentSplit(parent_split.clone()),
-                tx,
-            )
-            .map(|r| r.is_ok())
     }
 
     fn root_hoist<'g>(
@@ -1132,6 +1114,7 @@ impl Tree {
                     to: cursor,
                 });
 
+                M.tree_parent_split_attempt();
                 let link = self.context.pagecache.link(
                     *parent_id,
                     parent_ptr.clone(),
@@ -1143,6 +1126,7 @@ impl Tree {
                     // new_key in the path, along with updating the
                     // parent's node in the path vec. if we don't do
                     // both, we lose the newly appended parent split.
+                    M.tree_parent_split_success();
                 }
             }
 

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -972,7 +972,7 @@ impl Tree {
             Some(from),
             Some(new_root_pid),
             tx,
-        );
+        )?;
         if cas.is_ok() {
             debug!("root hoist from {} to {} successful", from, new_root_pid);
 

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -904,11 +904,8 @@ impl Tree {
         };
 
         // install the new right side
-        let (new_pid, new_ptr) = self
-            .context
-            .pagecache
-            .allocate(Frag::Base(rhs), tx)
-            .unwrap();
+        let (new_pid, new_ptr) =
+            self.context.pagecache.allocate(Frag::Base(rhs), tx)?;
 
         trace!("allocated pid {} in child_split", new_pid);
 

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -1093,3 +1093,12 @@ fn failpoints_bug_22() {
         false,
     ))
 }
+
+#[test]
+fn failpoints_bug_23() {
+    // postmortem 1: failed to handle allocation failures
+    assert!(prop_tree_crashes_nicely(
+        vec![Set, FailPoint("blob blob write"), Set, Set, Set],
+        false,
+    ))
+}


### PR DESCRIPTION
@Kerollmops this basically makes recursive_split drop off the flamegraph completely during the first few seconds of operation, and it should shave a few seconds off your workload again, but I'd be curious how much!