### PR TITLE
Fix the flusher to not drop when a Tree is drop

### DIFF
--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -14,7 +14,7 @@ pub struct Db {
     default: Arc<Tree>,
     tenants: Arc<RwLock<FastMap8<Vec<u8>, Arc<Tree>>>>,
     /// Periodically flushes dirty data.
-    _flusher: Option<flusher::Flusher>,
+    _flusher: Option<Arc<flusher::Flusher>>,
 }
 
 unsafe impl Send for Db {}
@@ -52,11 +52,11 @@ impl Db {
 
         let flusher_context = context.clone();
         let flusher = context.flush_every_ms.map(move |fem| {
-            flusher::Flusher::new(
+            Arc::new(flusher::Flusher::new(
                 "log flusher".to_owned(),
                 flusher_context,
                 fem,
-            )
+            ))
         });
 
         let ret = Db {

--- a/crates/sled/src/flusher.rs
+++ b/crates/sled/src/flusher.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use super::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct Flusher {
     shutdown: Arc<Mutex<bool>>,
     sc: Arc<Condvar>,


### PR DESCRIPTION
This closes #619.

I just saw that you forget to put the `Flusher` into an `Arc` this way it is not dropped on the first `Tree` drop. By the way I removed the derived `Clone` on the `Flusher` to make it clear that it can't be cloned :)

By the way, would it make sense to yank the 0.21.3 version, it can make users to loose data.