### PR TITLE
Properly test the project on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
                osx)
                  pushd tests &&
                  cargo check &&
-                 cargo check --features=all &&
+                 cargo check --all-features &&
                  cargo test tree --release
                  ;;
                qc)
@@ -134,7 +134,7 @@ script:
                standard)
                  pushd tests &&
                  cargo check &&
-                 cargo check --features=all &&
+                 cargo check --all-features &&
                  popd &&
                  cargo test --release
                  ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,16 +65,16 @@ script:
                  pushd tests &&
                  cargo check &&
                  cargo check --all-features &&
-                 cargo test tree --release
+                 cargo test tree --all-features --release
                  ;;
                qc)
                  pushd tests &&
                  echo "qc log" &&
-                 cargo test quickcheck_log_works --release -- --ignored --nocapture &&
+                 cargo test quickcheck_log_works --all-features --release -- --ignored --nocapture &&
                  echo "qc pagecache" &&
-                 cargo test quickcheck_pagecache_works --release -- --ignored --nocapture &&
+                 cargo test quickcheck_pagecache_works --all-features --release -- --ignored --nocapture &&
                  echo "qc tree" &&
-                 cargo test quickcheck_tree_matches_btreemap --release -- --ignored --nocapture
+                 cargo test quickcheck_tree_matches_btreemap --all-features --release -- --ignored --nocapture
                  ;;
                clippy)
                  cargo clippy
@@ -129,17 +129,17 @@ script:
                  ;;
                crash)
                  pushd tests &&
-                 cargo test test_crash_recovery --release -- --nocapture --ignored
+                 cargo test test_crash_recovery --all-features --release -- --nocapture --ignored
                  ;;
                standard)
                  pushd tests &&
                  cargo check &&
                  cargo check --all-features &&
                  popd &&
-                 cargo test --release
+                 cargo test --all-features --release
                  ;;
                concurrent)
-                 cargo test concurrent --release -- --ignored --nocapture
+                 cargo test concurrent --all-features --release -- --ignored --nocapture
                  ;;
                *)
                  echo "unknown TEST value \"$TEST\"";


### PR DESCRIPTION
`--features=all` does actually enable the feature named "all" of all the tested project, I think the expected behavior was more of the one provided by `--all-features`.

Tests were not ran with all features enabled, I changed that too.

Note that travis-ci is expected to fail.