### PR TITLE
Add max stable lsn to segment trailers

### DIFF
--- a/crates/pagecache/src/constants.rs
+++ b/crates/pagecache/src/constants.rs
@@ -30,7 +30,7 @@ pub const MSG_HEADER_LEN: usize = 17;
 pub const SEG_HEADER_LEN: usize = 12;
 
 /// Log segments have a trailer of this length.
-pub const SEG_TRAILER_LEN: usize = 12;
+pub const SEG_TRAILER_LEN: usize = 20;
 
 /// Log messages that are stored as external blobs
 /// contain a value (in addition to their header)

--- a/crates/pagecache/src/logger.rs
+++ b/crates/pagecache/src/logger.rs
@@ -532,6 +532,7 @@ pub(crate) struct SegmentHeader {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) struct SegmentTrailer {
     pub(crate) lsn: Lsn,
+    pub(crate) highest_known_stable_lsn: Lsn,
     pub(crate) ok: bool,
 }
 
@@ -742,10 +743,16 @@ impl From<[u8; SEG_TRAILER_LEN]> for SegmentTrailer {
             let xor_lsn = arr_to_u64(buf.get_unchecked(4..12)) as Lsn;
             let lsn = xor_lsn ^ 0x7FFF_FFFF_FFFF_FFFF;
 
-            let crc32_tested = crc32(&buf[4..12]);
+            let xor_highest_known_stable_lsn =
+                arr_to_u64(buf.get_unchecked(12..20)) as Lsn;
+            let highest_known_stable_lsn =
+                xor_highest_known_stable_lsn ^ 0x7FFF_FFFF_FFFF_FFFF;
+
+            let crc32_tested = crc32(&buf[4..20]);
 
             SegmentTrailer {
                 lsn,
+                highest_known_stable_lsn,
                 ok: crc32_tested == crc32_header,
             }
         }
@@ -758,20 +765,16 @@ impl Into<[u8; SEG_TRAILER_LEN]> for SegmentTrailer {
 
         let xor_lsn = self.lsn ^ 0x7FFF_FFFF_FFFF_FFFF;
         let lsn_arr = u64_to_arr(xor_lsn as u64);
-        let crc32 = u32_to_arr(crc32(&lsn_arr) ^ 0xFFFF_FFFF);
+        buf[4..12].copy_from_slice(&lsn_arr);
 
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                crc32.as_ptr(),
-                buf.as_mut_ptr(),
-                std::mem::size_of::<u32>(),
-            );
-            std::ptr::copy_nonoverlapping(
-                lsn_arr.as_ptr(),
-                buf.as_mut_ptr().add(4),
-                std::mem::size_of::<u64>(),
-            );
-        }
+        let xor_highest_known_stable_lsn =
+            self.highest_known_stable_lsn ^ 0x7FFF_FFFF_FFFF_FFFF;
+        let highest_known_stable_lsn_arr =
+            u64_to_arr(xor_highest_known_stable_lsn as u64);
+        buf[12..20].copy_from_slice(&highest_known_stable_lsn_arr);
+
+        let crc32 = u32_to_arr(crc32(&buf[4..]) ^ 0xFFFF_FFFF);
+        buf[..4].copy_from_slice(&crc32);
 
         buf
     }

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -232,7 +232,13 @@ impl Segment {
         config: &Config,
     ) -> Result<FastSet8<(PageId, usize)>> {
         trace!("setting Segment with lsn {:?} to Inactive", self.lsn());
-        assert_eq!(self.state, Active);
+        assert_eq!(
+            self.state,
+            Active,
+            "segment {} should have been \
+             Active before deactivating",
+            self.lsn()
+        );
         if from_recovery {
             assert!(lsn >= self.lsn());
         } else {
@@ -261,7 +267,12 @@ impl Segment {
 
     fn inactive_to_draining(&mut self, lsn: Lsn) {
         trace!("setting Segment with lsn {:?} to Draining", self.lsn());
-        assert_eq!(self.state, Inactive);
+        assert_eq!(
+            self.state, Inactive,
+            "segment with lsn {:?} should have been \
+             Inactive before draining",
+            self.lsn
+        );
         assert!(lsn >= self.lsn());
         self.state = Draining;
     }


### PR DESCRIPTION
This splits the physical implications away from the recovery logic changes in #606 