### PR TITLE
Make the IVec type safer for library users

### DIFF
--- a/crates/sled/src/ivec.rs
+++ b/crates/sled/src/ivec.rs
@@ -125,6 +125,15 @@ impl From<Vec<u8>> for IVec {
     }
 }
 
+impl Into<Arc<[u8]>> for IVec {
+    fn into(self) -> Arc<[u8]> {
+        match self.0 {
+            IVecInner::Inline(..) => Arc::from(self.as_ref()),
+            IVecInner::Remote(arc) => arc,
+        }
+    }
+}
+
 impl Deref for IVec {
     type Target = [u8];
 


### PR DESCRIPTION
Hiding the inner enum making it impossible to read the raw inline array value therefore avoiding user mistakes (reading out of bound bytes form the `IVec::Inline` variant).