### PR TITLE
Rewrite the Iter types

### DIFF
--- a/crates/sled/src/binary_search.rs
+++ b/crates/sled/src/binary_search.rs
@@ -87,7 +87,7 @@ where
 #[inline]
 pub(crate) fn binary_search_lub<'a, T, F>(s: &'a [T], f: F) -> Option<usize>
 where
-    F: FnMut(&'a T) -> ::std::cmp::Ordering,
+    F: FnMut(&'a T) -> Ordering,
 {
     match s.binary_search_by(f) {
         Ok(i) => Some(i),

--- a/crates/sled/src/data.rs
+++ b/crates/sled/src/data.rs
@@ -41,14 +41,17 @@ impl Data {
     }
 
     pub(crate) fn len(&self) -> usize {
-        match *self {
-            Data::Index(ref ptrs) => ptrs.len(),
-            Data::Leaf(ref items) => items.len(),
+        match self {
+            Data::Index(ptrs) => ptrs.len(),
+            Data::Leaf(items) => items.len(),
         }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.len() == 0
+        match self {
+            Data::Index(ptrs) => ptrs.is_empty(),
+            Data::Leaf(items) => items.is_empty(),
+        }
     }
 
     pub(crate) fn split(&self, lhs_prefix: &[u8]) -> (IVec, Data) {
@@ -94,7 +97,7 @@ impl Data {
         }
     }
 
-    pub(crate) fn leaf_ref(&self) -> Option<&Vec<(IVec, IVec)>> {
+    pub(crate) fn leaf_ref(&self) -> Option<&[(IVec, IVec)]> {
         match *self {
             Data::Index(_) => None,
             Data::Leaf(ref items) => Some(items),

--- a/crates/sled/src/frag.rs
+++ b/crates/sled/src/frag.rs
@@ -20,10 +20,9 @@ pub(crate) enum Frag {
 
 impl Frag {
     pub(super) fn unwrap_base(&self) -> &Node {
-        if let Frag::Base(base, ..) = self {
-            base
-        } else {
-            panic!("called unwrap_base_ptr on non-Base Frag!")
+        match self {
+            Frag::Base(node) => node,
+            _ => panic!("called unwrap_base_ptr on non-Base Frag!"),
         }
     }
 }

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -36,8 +36,8 @@ pub struct Iter<'a> {
 
 impl<'a> Iter<'a> {
     /// Iterate over the keys of this Tree
-    pub fn keys(self) -> impl 'a + DoubleEndedIterator<Item = Result<Vec<u8>>> {
-        self.map(|r| r.map(|(k, _v)| k))
+    pub fn keys(self) -> Keys<'a> {
+        Keys(self)
     }
 
     /// Iterate over the values of this Tree
@@ -415,6 +415,31 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
             }
 
             self.last_id = Some(next_id);
+        }
+    }
+}
+
+/// An iterator over keys in a `Tree`.
+pub struct Keys<'a>(Iter<'a>);
+
+impl<'a> Iterator for Keys<'a> {
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.next() {
+            Some(Ok((key, _))) => Some(Ok(key)),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for Keys<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.0.next_back() {
+            Some(Ok((key, _))) => Some(Ok(key)),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
         }
     }
 }

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -41,8 +41,8 @@ impl<'a> Iter<'a> {
     }
 
     /// Iterate over the values of this Tree
-    pub fn values(self) -> impl 'a + DoubleEndedIterator<Item = Result<IVec>> {
-        self.map(|r| r.map(|(_k, v)| v))
+    pub fn values(self) -> Values<'a> {
+        Values(self)
     }
 }
 
@@ -438,6 +438,31 @@ impl<'a> DoubleEndedIterator for Keys<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self.0.next_back() {
             Some(Ok((key, _))) => Some(Ok(key)),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
+        }
+    }
+}
+
+/// An iterator over values in a `Tree`.
+pub struct Values<'a>(Iter<'a>);
+
+impl<'a> Iterator for Values<'a> {
+    type Item = Result<IVec>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.next() {
+            Some(Ok((_, value))) => Some(Ok(value)),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for Values<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.0.next_back() {
+            Some(Ok((_, value))) => Some(Ok(value)),
             Some(Err(err)) => Some(Err(err)),
             None => None,
         }

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -20,21 +20,154 @@ fn upper_bound_includes(bound: &Bound<Vec<u8>>, item: &[u8]) -> bool {
     }
 }
 
+fn node_of_key<'a>(tree: &Tree, key: &[u8], tx: &'a Tx) -> Result<(PageId, &'a Node)> {
+    let (page_id, frag, _tree_ptr) =
+        tree.path_for_key(key, tx)?
+            .pop()
+            .expect("path should never be empty");
+
+    let node = frag.unwrap_base();
+
+    Ok((page_id, node))
+}
+
+fn node_of_pageid<'a>(tree: &Tree, page_id: PageId, tx: &'a Tx) -> Result<&'a Node> {
+    let res = tree
+        .context
+        .pagecache
+        .get(page_id, tx)
+        .map(|page_get| page_get.unwrap());
+
+    let frag = res.map(|(frag, _ptr)| frag)?;
+    let node = frag.unwrap_base();
+
+    Ok(node)
+}
+
+fn biggest_node<'a>(tree: &Tree, tx: &'a Tx) -> Result<(PageId, &'a Node)> {
+    let (mut page_id, mut node) = node_of_key(tree, b"", tx)?;
+
+    while let Some(next_page_id) = node.next {
+        let next_node = node_of_pageid(tree, next_page_id, tx)?;
+        page_id = next_page_id;
+        node = next_node;
+    }
+
+    Ok((page_id, node))
+}
+
+fn possible_predecessor(s: &[u8]) -> Option<Vec<u8>> {
+    let mut ret = s.to_vec();
+    match ret.pop() {
+        None => None,
+        Some(i) if i == 0 => Some(ret),
+        Some(i) => {
+            ret.push(i - 1);
+            for _ in 0..4 {
+                ret.push(255);
+            }
+            Some(ret)
+        }
+    }
+}
+
+fn left_node<'a>(tree: &Tree, search_node: &Node, tx: &'a Tx) -> Result<Option<(PageId, &'a Node)>> {
+    let pred = match possible_predecessor(&search_node.lo) {
+        Some(pred) => pred,
+        None => return Ok(None),
+    };
+
+    let (mut page_id, mut node) = node_of_key(tree, &pred, tx)?;
+    let mut previous_node = (page_id, node);
+
+    if node.lo == search_node.lo { return Ok(None) }
+
+    while let Some(next_page_id) = node.next {
+        let next_node = node_of_pageid(tree, next_page_id, tx)?;
+        if next_node.lo >= search_node.lo { break }
+
+        previous_node = (page_id, node);
+        page_id = next_page_id;
+        node = next_node;
+    }
+
+    Ok(Some(previous_node))
+}
+
+fn seek_to_node_with_key<'a>(
+    tree: &Tree,
+    from: (PageId, &'a Node),
+    key: &[u8],
+    tx: &'a Tx,
+) -> Result<Option<(PageId, &'a Node)>> {
+    let (mut next_id, mut next_node) = from;
+
+    // If we detected a split, we need to seek until
+    // the new node that contains our last key.
+    while next_node.hi.as_ref() < key {
+        let next_page_id = match next_node.next {
+            Some(page_id) => page_id,
+            None => return Ok(None),
+        };
+
+        let node = node_of_pageid(tree, next_page_id, tx)?;
+
+        next_id = next_page_id;
+        next_node = node;
+    }
+
+    Ok(Some((next_id, next_node)))
+}
+
 /// An iterator over keys and values in a `Tree`.
-pub struct Iter<'a> {
-    pub(super) tree: &'a Tree,
-    pub(super) hi: Bound<Vec<u8>>,
-    pub(super) lo: Bound<Vec<u8>>,
-    pub(super) last_id: Option<PageId>,
-    pub(super) last_key: Option<Key>,
-    pub(super) broken: Option<Error>,
-    pub(super) done: bool,
-    pub(super) tx: Tx,
-    pub(super) is_scan: bool,
+pub struct Iter<'a>(InnerIter<'a>);
+
+enum InnerIter<'a> {
+    Valid(ValidIter<'a>),
+    Errorneous(Option<Error>),
+}
+
+struct ValidIter<'a> {
+    tree: &'a Tree,
+    hi: Bound<Vec<u8>>,
+    lo: Bound<Vec<u8>>,
+    last_forward_id: Option<PageId>,
+    last_forward_key: Option<Key>,
+    last_backward_id: Option<PageId>,
+    last_backward_key: Option<Key>,
+    tx: Tx,
+    is_scan: bool,
     // TODO we have to refactor this in light of pages being deleted
 }
 
 impl<'a> Iter<'a> {
+    pub(crate) fn new(
+        tree: &'a Tree,
+        lo: Bound<Vec<u8>>,
+        hi: Bound<Vec<u8>>,
+        is_scan: bool,
+    ) -> Iter<'a>
+    {
+        let tx = match tree.context.pagecache.begin() {
+            Ok(tx) => tx,
+            Err(e) => return Iter(InnerIter::Errorneous(Some(e))),
+        };
+
+        let iter = ValidIter {
+            tree,
+            hi,
+            lo,
+            last_forward_id: None,
+            last_forward_key: None,
+            last_backward_id: None,
+            last_backward_key: None,
+            is_scan,
+            tx,
+        };
+
+        Iter(InnerIter::Valid(iter))
+    }
+
     /// Iterate over the keys of this Tree
     pub fn keys(self) -> Keys<'a> {
         Keys(self)
@@ -52,15 +185,17 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_scan);
 
-        if self.done {
-            return None;
-        } else if let Some(broken) = self.broken.take() {
-            self.done = true;
-            return Some(Err(broken));
+        let iter = match &mut self.0 {
+            InnerIter::Valid(iter) => iter,
+            InnerIter::Errorneous(error) => {
+                match error.take() {
+                    Some(error) => return Some(Err(error)),
+                    None => return None,
+                }
+            },
         };
 
-        let start_bound = &self.lo;
-        let start = match start_bound {
+        let start = match &iter.lo {
             Included(start) | Excluded(start) => start.as_slice(),
             Unbounded => b"",
         };
@@ -76,94 +211,78 @@ impl<'a> Iterator for Iter<'a> {
                  with start_bound {:?} \
                  on tree: \n \
                  {:?}",
-                self.last_key, start, self.tree,
+                iter.last_forward_key, start, iter.tree,
             );
 
-            if self.last_id.is_none() {
-                // initialize iterator based on valid bound
-                let path_res = self.tree.path_for_key(start, &self.tx);
-                if let Err(e) = path_res {
-                    error!("iteration failed: {:?}", e);
-                    self.done = true;
-                    return Some(Err(e));
+            let node = match iter.last_forward_id {
+                Some(page_id) => match node_of_pageid(iter.tree, page_id, &iter.tx) {
+                    Ok(node) => node,
+                    Err(e) => {
+                        error!("iteration failed: {:?}", e);
+                        self.0 = InnerIter::Errorneous(None);
+                        return Some(Err(e));
+                    },
+                },
+                None => {
+                    match node_of_key(iter.tree, start, &iter.tx) {
+                        Ok((page_id, node)) => {
+                            iter.last_forward_id = Some(page_id);
+                            node
+                        },
+                        Err(e) => {
+                            error!("iteration failed: {:?}", e);
+                            self.0 = InnerIter::Errorneous(None);
+                            return Some(Err(e));
+                        },
+                    }
                 }
-
-                let path = path_res.unwrap();
-
-                let (last_id, _last_frag, _tree_ptr) =
-                    path.last().expect("path should never be empty");
-
-                self.last_id = Some(*last_id);
-            }
-
-            let last_id = self.last_id.unwrap();
-
-            let inclusive = match self.lo {
-                Unbounded | Included(_) => true,
-                Excluded(_) => false,
             };
-
-            let res = self
-                .tree
-                .context
-                .pagecache
-                .get(last_id, &self.tx)
-                .map(|page_get| page_get.unwrap());
-
-            if let Err(e) = res {
-                error!("iteration failed: {:?}", e);
-                self.done = true;
-                return Some(Err(e));
-            }
 
             // TODO (when implementing merge support) this could
             // be None if the node was removed since the last
             // iteration, and we need to just get the inner
             // node again...
-            let (frag, _ptr) = res.unwrap();
-            let node = frag.unwrap_base();
             let leaf = node.data.leaf_ref().expect("node should be a leaf");
             let prefix = &node.lo;
+            let last_key = iter.last_forward_key.as_ref().map(|s| s.as_slice());
 
-            let search = if inclusive && self.last_key.is_none() {
-                leaf.binary_search_by(|&(ref k, _)| {
-                    prefix_cmp_encoded(k, start, prefix)
-                })
-                .ok()
-                .or_else(|| {
-                    binary_search_gt(leaf, |&(ref k, _)| {
-                        prefix_cmp_encoded(k, start, prefix)
-                    })
-                })
-            } else {
-                let last_key = &self.last_key;
-                let search_key = match last_key {
-                    Some(lk) => lk.as_slice(),
-                    None => start,
-                };
-
-                binary_search_gt(leaf, |&(ref k, _)| {
-                    prefix_cmp_encoded(k, search_key, prefix)
-                })
+            let is_inclusive = match &iter.lo {
+                Unbounded | Included(_) => true,
+                Excluded(_) => false,
             };
 
-            if let Some(idx) = search {
-                let (k, v) = &leaf[idx];
+            let entry = if is_inclusive && last_key.is_none() {
+                let index = leaf.binary_search_by(|(ref k, _)| {
+                    prefix_cmp_encoded(k, start, prefix)
+                });
+
+                match index {
+                    Ok(index) => Some(&leaf[index]),
+                    Err(index) => leaf.get(index),
+                }
+
+            } else {
+                let search_key = last_key.unwrap_or(start);
+                let index = binary_search_gt(leaf, |(ref k, _)| {
+                    prefix_cmp_encoded(k, search_key, prefix)
+                });
+
+                index.map(|index| &leaf[index])
+            };
+
+            if let Some((k, v)) = entry {
                 let decoded_k = prefix_decode(prefix, &k);
 
-                if !upper_bound_includes(&self.hi, &*decoded_k) {
+                if !upper_bound_includes(&iter.hi, &decoded_k) {
                     // we've overshot our bounds
                     return None;
                 }
 
-                self.last_key = Some(decoded_k.clone());
-
-                let ret = Ok((decoded_k, v.clone()));
-                return Some(ret);
+                iter.last_forward_key = Some(decoded_k.clone());
+                return Some(Ok((decoded_k, v.clone())));
             }
 
-            if !node.hi.is_empty() && !upper_bound_includes(&self.hi, &node.hi)
-            {
+            if !node.hi.is_empty() && !upper_bound_includes(&iter.hi, &node.hi) {
                 // we've overshot our bounds
                 return None;
             }
@@ -172,11 +291,10 @@ impl<'a> Iterator for Iter<'a> {
             // key that is greater than our last key (or
             // the start bound)
             match node.next {
-                Some(id) => self.last_id = Some(id),
+                Some(id) => iter.last_forward_id = Some(id),
                 None => {
-                    assert_eq!(
-                        node.hi,
-                        vec![],
+                    assert!(
+                        node.hi.is_empty(),
                         "if a node has no right sibling, \
                          it must be the upper-bound node"
                     );
@@ -191,27 +309,14 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_reverse_scan);
 
-        if self.done {
-            return None;
-        } else if let Some(broken) = self.broken.take() {
-            self.done = true;
-            return Some(Err(broken));
-        };
-
-        // try to get a high key
-        let end_bound = &self.hi;
-        let start_bound = &self.lo;
-
-        let (end, unbounded): (&[u8], bool) = if self.is_scan {
-            match start_bound {
-                Included(start) | Excluded(start) => (start.as_ref(), false),
-                Unbounded => (&[255; 100], true),
-            }
-        } else {
-            match end_bound {
-                Included(start) | Excluded(start) => (start.as_ref(), false),
-                Unbounded => (&[255; 100], true),
-            }
+        let iter = match &mut self.0 {
+            InnerIter::Valid(iter) => iter,
+            InnerIter::Errorneous(error) => {
+                match error.take() {
+                    Some(error) => return Some(Err(error)),
+                    None => return None,
+                }
+            },
         };
 
         let mut spins = 0;
@@ -220,201 +325,137 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
             spins += 1;
             debug_assert_ne!(
                 spins, 100,
-                "reverse iterator stuck in loop \
+                "backward iterator stuck in loop \
                  looking for key before {:?} \
-                 with end_bound {:?} and \
-                 start bound {:?} on tree: \n \
+                 with end_bound {:?} \
+                 on tree: \n \
                  {:?}",
-                self.last_key, end, start_bound, self.tree,
+                iter.last_backward_key, iter.hi, iter.tree,
             );
 
-            if self.last_id.is_none() {
-                // initialize iterator based on valid bound
-
-                let path_res = self.tree.path_for_key(end, &self.tx);
-                if let Err(e) = path_res {
-                    error!("iteration failed: {:?}", e);
-                    self.done = true;
-                    return Some(Err(e));
-                }
-
-                let path = path_res.unwrap();
-
-                let (last_id, last_frag, _tree_ptr) =
-                    path.last().expect("path should never be empty");
-                let mut last_node = last_frag.unwrap_base();
-
-                // (when hi is empty, it means it's the rightmost node)
-                while unbounded && !last_node.hi.is_empty() {
-                    // if we're unbounded, scan to the end
-                    let res = self
-                        .tree
-                        .context
-                        .pagecache
-                        .get(last_node.next.unwrap(), &self.tx)
-                        .map(|page_get| page_get.unwrap());
-
-                    if let Err(e) = res {
-                        error!("iteration failed: {:?}", e);
-                        self.done = true;
-                        return Some(Err(e));
+            let (last_backward_id, node) = match iter.last_backward_id {
+                Some(page_id) => {
+                    match node_of_pageid(iter.tree, page_id, &iter.tx) {
+                        Ok(node) => (page_id, node),
+                        Err(e) => {
+                            error!("next_back iteration failed: {:?}", e);
+                            self.0 = InnerIter::Errorneous(None);
+                            return Some(Err(e));
+                        },
                     }
-                    let (frag, _ptr) = res.unwrap();
-                    last_node = frag.unwrap_base();
+                },
+                None => {
+                    match biggest_node(iter.tree, &iter.tx) {
+                        Ok((page_id, node)) => {
+                            iter.last_backward_id = Some(page_id);
+                            (page_id, node)
+                        },
+                        Err(e) => {
+                            error!("next_back iteration failed: {:?}", e);
+                            self.0 = InnerIter::Errorneous(None);
+                            return Some(Err(e));
+                        },
+                    }
                 }
-
-                self.last_id = Some(*last_id);
-            }
-
-            let last_id = self.last_id.unwrap();
-
-            let inclusive = match self.hi {
-                Unbounded | Included(_) => true,
-                Excluded(_) => false,
             };
-
-            let res = self
-                .tree
-                .context
-                .pagecache
-                .get(last_id, &self.tx)
-                .map(|page_get| page_get.unwrap());
-
-            if let Err(e) = res {
-                error!("iteration failed: {:?}", e);
-                self.done = true;
-                return Some(Err(e));
-            }
 
             // TODO (when implementing merge support) this could
             // be None if the node was removed since the last
             // iteration, and we need to just get the inner
             // node again...
-            let (frag, _ptr) = res.unwrap();
-            let node = frag.unwrap_base();
             let leaf = node.data.leaf_ref().expect("node should be a leaf");
             let prefix = &node.lo;
-            let mut split_detected = false;
-            let mut split_key: &[u8] = &[];
+            let mut split_detected = None;
 
-            let search = if inclusive && self.last_key.is_none() {
-                if unbounded {
-                    if leaf.is_empty() {
+            let entry = match (&iter.hi, &iter.last_backward_key) {
+                (Included(search_key), None) => {
+                    let index = binary_search_lub(leaf, |(ref k, _)| {
+                        prefix_cmp_encoded(k, search_key, prefix)
+                    });
+
+                    index.map(|index| &leaf[index])
+                },
+                (Unbounded, None) => {
+                    leaf.last()
+                },
+                | (Excluded(search_key), None)
+                | (Included(_), Some(search_key))
+                | (Excluded(_), Some(search_key))
+                | (Unbounded,   Some(search_key)) => {
+                    if !node.hi.is_empty() && node.hi.as_ref() < search_key {
+                        // the node has been split since we saw it,
+                        // and we need to scan forward
+                        split_detected = Some(search_key.as_slice());
                         None
                     } else {
-                        Some(leaf.len() - 1)
+                        let index = binary_search_lt(leaf, |(ref k, _)| {
+                            prefix_cmp_encoded(k, search_key, prefix)
+                        });
+
+                        index.map(|index| &leaf[index])
                     }
-                } else {
-                    binary_search_lub(leaf, |&(ref k, _)| {
-                        prefix_cmp_encoded(k, end, prefix)
-                    })
-                }
-            } else {
-                let last_key = &self.last_key;
-
-                let search_key: &[u8] = if let Some(lk) = last_key {
-                    lk.as_ref()
-                } else {
-                    end
-                };
-
-                if !node.hi.is_empty() && *node.hi < *search_key {
-                    // the node has been split since we saw it,
-                    // and we need to scan forward
-                    split_detected = true;
-                    split_key = search_key;
-
-                    None
-                } else {
-                    binary_search_lt(leaf, |&(ref k, _)| {
-                        prefix_cmp_encoded(k, search_key, prefix)
-                    })
-                }
+                },
             };
 
-            if let Some(idx) = search {
-                let (k, v) = &leaf[idx];
+            if let Some((k, v)) = entry {
                 let decoded_k = prefix_decode(prefix, &k);
 
-                if !self.is_scan && !lower_bound_includes(&self.lo, &*decoded_k)
-                {
+                if !lower_bound_includes(&iter.lo, &decoded_k) {
                     // we've overshot our bounds
                     return None;
                 }
 
-                self.last_key = Some(decoded_k.clone());
-
-                let ret = Ok((decoded_k, v.clone()));
-                return Some(ret);
+                iter.last_backward_key = Some(decoded_k.clone());
+                return Some(Ok((decoded_k, v.clone())));
             }
 
-            if !self.is_scan && !lower_bound_includes(&self.lo, &node.lo) {
+            if !lower_bound_includes(&iter.lo, &node.lo) {
                 // we've overshot our bounds
                 return None;
             }
 
-            let (mut next_id, mut next_node) = if split_detected {
-                // we need to skip ahead to get to the node
-                // where our last key resided
-                (last_id, node)
-            } else {
-                // we need to get the node to the left of ours by
-                // guessing a key that might land on it, and then
-                // fast-forwarding through the right child pointers
-                // if we went too far to the left.
-                let pred = possible_predecessor(prefix)?;
-                match self.tree.path_for_key(pred, &self.tx) {
+            if let Some(split_key) = split_detected {
+                // If we detected a split, we need to seek until
+                // the new node that contains our last key.
+                // We need to skip ahead to get to the node
+                // where our last key resided.
+                let from = (last_backward_id, node);
+                let result = seek_to_node_with_key(iter.tree, from, split_key, &iter.tx);
+
+                let (next_id, next_node) = match result {
+                    Ok(Some((page_id, node))) => (page_id, node),
+                    Ok(None) => return None,
                     Err(e) => {
                         error!("next_back iteration failed: {:?}", e);
-                        self.done = true;
+                        self.0 = InnerIter::Errorneous(None);
                         return Some(Err(e));
-                    }
-                    Ok(path) => {
-                        let (id, base, _ptr) = path.last().unwrap();
-                        (*id, base.unwrap_base())
-                    }
+                    },
+                };
+
+                if next_node.data.is_empty() {
+                    // we want to mark this node's lo key as our last key
+                    // to prevent infinite search loops, by enforcing
+                    // reverse progress.
+                    iter.last_backward_key = Some(next_node.lo.to_vec());
                 }
-            };
 
-            // If we did not detect a split, we need to
-            // seek until the node that points to our last one.
-            // If we detected a split, we need to seek until
-            // the new node that contains our last key.
-            while (!split_detected
-                && (next_node.next != Some(last_id))
-                && next_node.lo < node.lo)
-                || (split_detected && *next_node.hi < *split_key)
-            {
-                let res = self
-                    .tree
-                    .context
-                    .pagecache
-                    .get(next_node.next?, &self.tx)
-                    .map(|page_get| page_get.unwrap());
+                iter.last_backward_id = Some(next_id);
 
-                if let Err(e) = res {
-                    error!("iteration failed: {:?}", e);
-                    self.done = true;
-                    return Some(Err(e));
-                }
-                let (frag, _ptr) = res.unwrap();
-                next_id = next_node.next.unwrap();
-                next_node = frag.unwrap_base();
+            } else {
+                // we need to get the node to the left of ours.
+                let next_id = match left_node(iter.tree, &node, &iter.tx) {
+                    Ok(Some((page_id, _))) => page_id,
+                    Ok(None) => return None,
+                    Err(e) => {
+                        error!("next_back iteration failed: {:?}", e);
+                        self.0 = InnerIter::Errorneous(None);
+                        return Some(Err(e));
+                    },
+                };
+
+                iter.last_backward_key = Some(node.lo.to_vec());
+                iter.last_backward_id = Some(next_id);
             }
-
-            if split_detected && next_node.data.is_empty() {
-                // we want to mark this node's lo key
-                // as our last key to prevent infinite
-                // search loops, by enforcing reverse
-                // progress.
-                self.last_key = Some(next_node.lo.to_vec());
-            }
-
-            if !split_detected {
-                self.last_key = Some(node.lo.to_vec());
-            }
-
-            self.last_id = Some(next_id);
         }
     }
 }
@@ -469,41 +510,31 @@ impl<'a> DoubleEndedIterator for Values<'a> {
     }
 }
 
-fn possible_predecessor(s: &[u8]) -> Option<Vec<u8>> {
-    let mut ret = s.to_vec();
-    match ret.pop() {
-        None => None,
-        Some(i) if i == 0 => Some(ret),
-        Some(i) => {
-            ret.push(i - 1);
-            for _ in 0..4 {
-                ret.push(255);
-            }
-            Some(ret)
-        }
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_possible_predecessor() {
-    assert_eq!(possible_predecessor(b""), None);
-    assert_eq!(possible_predecessor(&[0]), Some(vec![]));
-    assert_eq!(possible_predecessor(&[0, 0]), Some(vec![0]));
-    assert_eq!(
-        possible_predecessor(&[0, 1]),
-        Some(vec![0, 0, 255, 255, 255, 255])
-    );
-    assert_eq!(
-        possible_predecessor(&[0, 2]),
-        Some(vec![0, 1, 255, 255, 255, 255])
-    );
-    assert_eq!(possible_predecessor(&[1, 0]), Some(vec![1]));
-    assert_eq!(
-        possible_predecessor(&[1, 1]),
-        Some(vec![1, 0, 255, 255, 255, 255])
-    );
-    assert_eq!(
-        possible_predecessor(&[155]),
-        Some(vec![154, 255, 255, 255, 255])
-    );
+    #[test]
+    fn test_possible_predecessor() {
+        assert_eq!(possible_predecessor(b""), None);
+        assert_eq!(possible_predecessor(&[0]), Some(vec![]));
+        assert_eq!(possible_predecessor(&[0, 0]), Some(vec![0]));
+        assert_eq!(
+            possible_predecessor(&[0, 1]),
+            Some(vec![0, 0, 255, 255, 255, 255])
+        );
+        assert_eq!(
+            possible_predecessor(&[0, 2]),
+            Some(vec![0, 1, 255, 255, 255, 255])
+        );
+        assert_eq!(possible_predecessor(&[1, 0]), Some(vec![1]));
+        assert_eq!(
+            possible_predecessor(&[1, 1]),
+            Some(vec![1, 0, 255, 255, 255, 255])
+        );
+        assert_eq!(
+            possible_predecessor(&[155]),
+            Some(vec![154, 255, 255, 255, 255])
+        );
+    }
 }

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -195,6 +195,12 @@ impl<'a> Iterator for Iter<'a> {
             },
         };
 
+        if let (Some(forward), Some(backward)) = (&iter.last_forward_key, &iter.last_backward_key) {
+            if forward >= backward {
+                return None
+            }
+        }
+
         let start = match &iter.lo {
             Included(start) | Excluded(start) => start.as_slice(),
             Unbounded => b"",
@@ -279,6 +285,13 @@ impl<'a> Iterator for Iter<'a> {
                 }
 
                 iter.last_forward_key = Some(decoded_k.clone());
+
+                if let Some(backward) = &iter.last_backward_key {
+                    if &decoded_k >= backward {
+                        return None
+                    }
+                }
+
                 return Some(Ok((decoded_k, v.clone())));
             }
 
@@ -318,6 +331,12 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
                 }
             },
         };
+
+        if let (Some(forward), Some(backward)) = (&iter.last_forward_key, &iter.last_backward_key) {
+            if forward >= backward {
+                return None
+            }
+        }
 
         let mut spins = 0;
 
@@ -406,6 +425,13 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
                 }
 
                 iter.last_backward_key = Some(decoded_k.clone());
+
+                if let Some(forward) = &iter.last_forward_key {
+                    if &decoded_k <= forward {
+                        return None
+                    }
+                }
+
                 return Some(Ok((decoded_k, v.clone())));
             }
 

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -1,4 +1,5 @@
 use std::ops::{Bound, Bound::{Included, Excluded, Unbounded}};
+use std::iter::FusedIterator;
 
 use pagecache::{Measure, M};
 
@@ -486,6 +487,8 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     }
 }
 
+impl<'a> FusedIterator for Iter<'a> { }
+
 /// An iterator over keys in a `Tree`.
 pub struct Keys<'a>(Iter<'a>);
 
@@ -511,6 +514,8 @@ impl<'a> DoubleEndedIterator for Keys<'a> {
     }
 }
 
+impl<'a> FusedIterator for Keys<'a> { }
+
 /// An iterator over values in a `Tree`.
 pub struct Values<'a>(Iter<'a>);
 
@@ -535,6 +540,8 @@ impl<'a> DoubleEndedIterator for Values<'a> {
         }
     }
 }
+
+impl<'a> FusedIterator for Values<'a> { }
 
 #[cfg(test)]
 mod tests {

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -53,7 +53,7 @@ const DEFAULT_TREE_ID: &[u8] = b"__sled__default";
 pub use {
     self::{
         db::Db,
-        iter::{Iter, Keys},
+        iter::{Iter, Keys, Values},
         ivec::IVec,
         subscription::{Event, Subscriber},
         tree::Tree,

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -53,7 +53,7 @@ const DEFAULT_TREE_ID: &[u8] = b"__sled__default";
 pub use {
     self::{
         db::Db,
-        iter::Iter,
+        iter::{Iter, Keys},
         ivec::IVec,
         subscription::{Event, Subscriber},
         tree::Tree,

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -934,10 +934,7 @@ impl Tree {
     /// assert_eq!(iter.next().unwrap(), Ok(vec![3]));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn keys<'a, K>(
-        &'a self,
-        key: K,
-    ) -> impl 'a + DoubleEndedIterator<Item = Result<Vec<u8>>>
+    pub fn keys<'a, K>(&'a self, key: K) -> Keys<'a>
     where
         K: AsRef<[u8]>,
     {

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -957,10 +957,7 @@ impl Tree {
     /// assert_eq!(iter.next().unwrap(), Ok(IVec::from(vec![3])));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn values<'a, K>(
-        &'a self,
-        key: K,
-    ) -> impl 'a + DoubleEndedIterator<Item = Result<IVec>>
+    pub fn values<'a, K>(&'a self, key: K) -> Values<'a>
     where
         K: AsRef<[u8]>,
     {

--- a/tests/tests/test_tree.rs
+++ b/tests/tests/test_tree.rs
@@ -571,7 +571,7 @@ fn tree_range() {
     assert_eq!(r.next().unwrap().unwrap().0, b"5");
     assert_eq!(r.next(), None);
 
-    let mut r = t.scan(b"2").rev();
+    let mut r = t.backward_scan(b"2");
     assert_eq!(r.next().unwrap().unwrap().0, b"2");
     assert_eq!(r.next().unwrap().unwrap().0, b"1");
     assert_eq!(r.next().unwrap().unwrap().0, b"0");

--- a/tests/tests/test_tree.rs
+++ b/tests/tests/test_tree.rs
@@ -251,21 +251,29 @@ fn parallel_tree_iterators() -> Result<()> {
 
                     for expect in expected {
                         loop {
-                            if let Some(Ok(k)) = keys.next() {
-                                assert!(
-                                    &*k >= *expect,
-                                    "witnessed key is {:?} but we expected \
-                                     one >= {:?}, so we overshot due to a \
-                                     concurrent modification\n{:?}",
-                                    k,
-                                    expect,
-                                    *t,
-                                );
-                                if &*k == *expect {
-                                    break;
-                                }
-                            } else {
-                                panic!("undershot key on tree: \n{:?}", *t);
+
+                            match keys.next() {
+                                Some(Ok(k)) => {
+                                    assert!(
+                                        &*k >= *expect,
+                                        "witnessed key is {:?} but we expected \
+                                         one >= {:?}, so we overshot due to a \
+                                         concurrent modification\n{:?}",
+                                        k,
+                                        expect,
+                                        *t,
+                                    );
+                                    if &*k == *expect {
+                                        break;
+                                    }
+                                },
+                                Some(Err(e)) => panic!("{:?}", e),
+                                None => {
+                                    panic!("expected {:?}, undershot key on tree: \n{:?}",
+                                        expect,
+                                        *t,
+                                    );
+                                },
                             }
                         }
                     }


### PR DESCRIPTION
I was rewriting the `Iter` type because I saw #524 and found out that the `DoubleEndedIterator` implementation was wrong, [according to the standard library](https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) forward and reverse iteration must never cross:

 > It is important to note that both back and forth work on the same range, and do not cross: iteration is over when they meet in the middle.

The current implementation seems more like some sort of cursor, if a call to `next` is followed by a call to `next_back` the iterator will return to its original position, which is not expected according to the description above. The iterator must have yielded an element from the end of the specified range when called with `next_back`.

In other words, `next` and `next_back` should consume the start or the end of the specified range and not move the same "cursor" around. Therefore having two cursors internally, one indicating the forward direction and one the backward, when one crosses the other, the iteration must stop.

Also, I was asking myself why `scan` even exists, isn't it just a `range(k..)`?
If a reverse `scan` must exists in the sense that you implement it (i.e. starts at the key but goes backward from it) it could be just something called `backward_scan(k)` which internally is just an `range(..=k)`.