### PR TITLE
Merging nodes

### DIFF
--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -53,6 +53,8 @@ pub struct ConfigBuilder {
     #[doc(hidden)]
     pub blink_node_split_size: usize,
     #[doc(hidden)]
+    pub blink_node_merge_ratio: usize,
+    #[doc(hidden)]
     pub cache_bits: usize,
     #[doc(hidden)]
     pub cache_capacity: u64,
@@ -104,6 +106,7 @@ impl Default for ConfigBuilder {
             io_bufs: 3,
             io_buf_size: 2 << 22, // 8mb
             blink_node_split_size: 4096,
+            blink_node_merge_ratio: 4,
             page_consolidation_threshold: 10,
             path: PathBuf::from(DEFAULT_PATH),
             read_only: false,

--- a/crates/sled/src/data.rs
+++ b/crates/sled/src/data.rs
@@ -83,10 +83,19 @@ impl Data {
         }
     }
 
-    pub(crate) fn receive_merge(&mut self, old_prefix: &[u8], new_prefix: &[u8], rhs_data: &Data) {
-        fn receive_merge_inner<T>(old_prefix: &[u8], new_prefix: &[u8], lhs_data: &mut Vec<(IVec, T)>, rhs_data: &[(IVec, T)])
-        where
-            T: Clone
+    pub(crate) fn receive_merge(
+        &mut self,
+        old_prefix: &[u8],
+        new_prefix: &[u8],
+        rhs_data: &Data,
+    ) {
+        fn receive_merge_inner<T>(
+            old_prefix: &[u8],
+            new_prefix: &[u8],
+            lhs_data: &mut Vec<(IVec, T)>,
+            rhs_data: &[(IVec, T)],
+        ) where
+            T: Clone,
         {
             for (k, v) in rhs_data {
                 let k = prefix_reencode(old_prefix, new_prefix, k);
@@ -96,12 +105,22 @@ impl Data {
 
         match (self, rhs_data) {
             (Data::Index(ref mut lh_ptrs), Data::Index(ref rh_ptrs)) => {
-                receive_merge_inner(old_prefix, new_prefix, lh_ptrs, rh_ptrs.as_ref());
+                receive_merge_inner(
+                    old_prefix,
+                    new_prefix,
+                    lh_ptrs,
+                    rh_ptrs.as_ref(),
+                );
             }
             (Data::Leaf(ref mut lh_items), Data::Leaf(ref rh_items)) => {
-                receive_merge_inner(old_prefix, new_prefix, lh_items, rh_items.as_ref());
+                receive_merge_inner(
+                    old_prefix,
+                    new_prefix,
+                    lh_items,
+                    rh_items.as_ref(),
+                );
             }
-            _ => panic!("Can't merge incompatible Data!")
+            _ => panic!("Can't merge incompatible Data!"),
         }
     }
 

--- a/crates/sled/src/frag.rs
+++ b/crates/sled/src/frag.rs
@@ -16,6 +16,9 @@ pub(crate) enum Frag {
     Base(Node),
     ChildSplit(ChildSplit),
     ParentSplit(ParentSplit),
+    ParentMergeIntention(PageId),
+    ParentMergeConfirm,
+    ChildMergeCap,
 }
 
 impl Frag {

--- a/crates/sled/src/meta.rs
+++ b/crates/sled/src/meta.rs
@@ -31,6 +31,8 @@ pub(crate) fn open_tree<'a>(
             next: None,
             lo: vec![].into(),
             hi: vec![].into(),
+            merging_child: None,
+            merging: false,
         });
 
         let (leaf_id, leaf_ptr) = context.pagecache.allocate(leaf, &tx)?;
@@ -51,6 +53,8 @@ pub(crate) fn open_tree<'a>(
             next: None,
             lo: vec![].into(),
             hi: vec![].into(),
+            merging_child: None,
+            merging: false,
         });
 
         let (root_id, root_ptr) = context.pagecache.allocate(root, &tx)?;

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -172,4 +172,11 @@ impl Node {
             merging: false,
         }
     }
+
+    pub(crate) fn receive_merge(&self, rhs: &Node) -> Node {
+        let mut merged = self.clone();
+        merged.hi = rhs.hi.clone();
+        merged.data.receive_merge(rhs.lo.as_ref(), merged.lo.as_ref(), &rhs.data);
+        merged
+    }
 }

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -8,6 +8,8 @@ pub(crate) struct Node {
     pub(crate) next: Option<PageId>,
     pub(crate) lo: IVec,
     pub(crate) hi: IVec,
+    pub(crate) merging_child: Option<PageId>,
+    pub(crate) merging: bool,
 }
 
 impl Node {
@@ -74,6 +76,9 @@ impl Node {
                 }
             }
             Base(_) => panic!("encountered base page in middle of chain"),
+            ParentMergeIntention(_pid) => unimplemented!(),
+            ParentMergeConfirm => unimplemented!(),
+            ChildMergeCap => unimplemented!(),
         }
     }
 
@@ -153,7 +158,7 @@ impl Node {
     }
 
     pub(crate) fn should_split(&self, max_sz: u64) -> bool {
-        self.data.len() > 2 && self.size_in_bytes() > max_sz
+        self.data.len() > 2 && self.size_in_bytes() > max_sz && self.merging_child.is_none() && !self.merging
     }
 
     pub(crate) fn split(&self) -> Node {
@@ -163,6 +168,8 @@ impl Node {
             next: self.next,
             lo: split,
             hi: self.hi.clone(),
+            merging_child: None,
+            merging: false,
         }
     }
 }

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -83,11 +83,11 @@ impl Node {
             ParentMergeConfirm => {
                 assert!(self.merging_child.is_some());
                 self.merging_child = None;
-            },
+            }
             ChildMergeCap => {
                 assert!(!self.merging);
                 self.merging = true;
-            },
+            }
         }
     }
 
@@ -167,11 +167,16 @@ impl Node {
     }
 
     pub(crate) fn should_split(&self, max_sz: u64) -> bool {
-        self.data.len() > 2 && self.size_in_bytes() > max_sz && self.merging_child.is_none() && !self.merging
+        self.data.len() > 2
+            && self.size_in_bytes() > max_sz
+            && self.merging_child.is_none()
+            && !self.merging
     }
 
     pub(crate) fn should_merge(&self, min_sz: u64) -> bool {
-        self.size_in_bytes() < min_sz && self.merging_child.is_none() && !self.merging
+        self.size_in_bytes() < min_sz
+            && self.merging_child.is_none()
+            && !self.merging
     }
 
     pub(crate) fn split(&self) -> Node {
@@ -189,7 +194,11 @@ impl Node {
     pub(crate) fn receive_merge(&self, rhs: &Node) -> Node {
         let mut merged = self.clone();
         merged.hi = rhs.hi.clone();
-        merged.data.receive_merge(rhs.lo.as_ref(), merged.lo.as_ref(), &rhs.data);
+        merged.data.receive_merge(
+            rhs.lo.as_ref(),
+            merged.lo.as_ref(),
+            &rhs.data,
+        );
         merged
     }
 }

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -76,9 +76,18 @@ impl Node {
                 }
             }
             Base(_) => panic!("encountered base page in middle of chain"),
-            ParentMergeIntention(_pid) => unimplemented!(),
-            ParentMergeConfirm => unimplemented!(),
-            ChildMergeCap => unimplemented!(),
+            ParentMergeIntention(pid) => {
+                assert!(self.merging_child.is_none());
+                self.merging_child = Some(pid);
+            }
+            ParentMergeConfirm => {
+                assert!(self.merging_child.is_some());
+                self.merging_child = None;
+            },
+            ChildMergeCap => {
+                assert!(!self.merging);
+                self.merging = true;
+            },
         }
     }
 

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -161,6 +161,10 @@ impl Node {
         self.data.len() > 2 && self.size_in_bytes() > max_sz && self.merging_child.is_none() && !self.merging
     }
 
+    pub(crate) fn should_merge(&self, min_sz: u64) -> bool {
+        self.size_in_bytes() < min_sz && self.merging_child.is_none() && !self.merging
+    }
+
     pub(crate) fn split(&self) -> Node {
         let (split, right_data) = self.data.split(&self.lo);
         Node {

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -1388,7 +1388,7 @@ impl Tree {
                 }
             };
 
-            let mut child_node = child_frag.unwrap_base();
+            let child_node = child_frag.unwrap_base();
             if child_node.merging {
                 break child_node;
             }
@@ -1396,7 +1396,7 @@ impl Tree {
             let install_frag = self.context.pagecache.link(child_pid, child_cas_key, Frag::ChildMergeCap, tx)?;
             match install_frag {
                 Ok(_) => break child_node,
-                Err(Some((ptr, frag))) => continue,
+                Err(Some((_, _))) => continue,
                 Err(None) => return Ok(()),
             }
         };

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -1401,7 +1401,37 @@ impl Tree {
             }
         };
 
+        let index = parent.data.index_ref().unwrap();
+        let merge_index = index.iter().position(|(_, pid)| pid == &child_pid).unwrap();
 
+        let cursor_page_get = self.context.pagecache.get((index[merge_index - 1]).1, tx)?;
+
+        // The only way this child could have been freed is if the original merge has
+        // already been handled. Only in that case can this child have been freed
+        if cursor_page_get.is_free() {
+            return Ok(());
+        }
+
+        let (cursor_frag, _cursor_cas_key) = match cursor_page_get {
+            PageGet::Materialized(node, cas_key) => (node, cas_key),
+            broken => {
+                return Err(Error::ReportableBug(format!(
+                    "got non-base node while traversing tree: {:?}",
+                    broken
+                )));
+            }
+        };
+
+        let mut cursor_node = cursor_frag.unwrap_base();
+
+        // ...
+        while cursor_node.lo < child_node.lo {
+
+            // This means that `cursor_node` is the node we want to replace
+            if cursor_node.next == Some(child_pid) {
+
+            }
+        }
 
 
         Ok(())


### PR DESCRIPTION
This implements a function to merge nodes.

1. Install `MergeIntetion` in a parent, pointing at a child
2. Install a `MergeCap` at the child, preventing writes to it
3. Merge child node into left sibling
4. Complete merge and swap parent pointers