### PR TITLE
add order explanation and example to `Tree::get_gt` for multi byte keys

### DIFF
--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -582,6 +582,13 @@ impl Tree {
     /// Retrieve the next key and value from the `Tree` after the
     /// provided key.
     ///
+    /// # Note
+    /// The order follows the Ord implementation for `Vec<u8>`:
+    ///
+    /// `[] < [0] < [255] < [255, 0] < [255, 255] ...`
+    ///
+    /// To retain the ordering of numerical types use big endian reprensentation
+    ///
     /// # Examples
     ///
     /// ```
@@ -598,6 +605,10 @@ impl Tree {
     /// assert_eq!(tree.get_gt(&[1]), Ok(Some((vec![2], IVec::from(vec![2])))));
     /// assert_eq!(tree.get_gt(&[8]), Ok(Some((vec![9], IVec::from(vec![9])))));
     /// assert_eq!(tree.get_gt(&[9]), Ok(None));
+    ///
+    /// tree.set(500u16.to_be_bytes(), vec![10] );
+    /// assert_eq!(tree.get_gt(&499u16.to_be_bytes()), 
+    ///            Ok(Some((500u16.to_be_bytes().to_vec(), IVec::from(vec![10] )))));
     /// ```
     pub fn get_gt<K: AsRef<[u8]>>(
         &self,


### PR DESCRIPTION
Adds the explanation from @spacejam from #661 to the `get_gt` function. I don not know if this is useful for you, if it is not feel free to close this PR. If you would like I will expand this PR to also extend the documentation for `get_lt` and `range` in a similar way.