### PR TITLE
fix up event log and turn it back on during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,7 @@ script:
                osx)
                  pushd tests &&
                  cargo check &&
-                 cargo check --features=all &&
-                 cargo test tree --release
+                 cargo test tree
                  ;;
                qc)
                  pushd tests &&
@@ -133,12 +132,10 @@ script:
                  ;;
                standard)
                  pushd tests &&
-                 cargo check &&
-                 cargo check --features=all &&
-                 popd &&
                  cargo test --release
                  ;;
                concurrent)
+                 pushd tests &&
                  cargo test concurrent --release -- --ignored --nocapture
                  ;;
                *)

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,15 @@ script:
                  ;;
                standard)
                  pushd tests &&
-                 cargo test --release
+                 cargo test --release &&
+                 popd &&
+                 pushd crates/sled &&
+                 echo "testing sled doctests" &&
+                 cargo test &&
+                 popd &&
+                 pushd crates/pagecache &&
+                 echo "testing pagecache doctests" &&
+                 cargo test
                  ;;
                concurrent)
                  pushd tests &&

--- a/crates/pagecache/src/iobuf.rs
+++ b/crates/pagecache/src/iobuf.rs
@@ -507,7 +507,8 @@ impl IoBufs {
 
         intervals.push(interval);
 
-        debug_assert!(
+        #[cfg(feature = "event_log")]
+        assert!(
             intervals.len() < 1000,
             "intervals is getting crazy... {:?}",
             *intervals

--- a/crates/pagecache/src/pagecache.rs
+++ b/crates/pagecache/src/pagecache.rs
@@ -369,11 +369,16 @@ where
     P: 'static + Debug + Clone + Serialize + DeserializeOwned + Send + Sync,
 {
     fn drop(&mut self) {
+        trace!("dropping pagecache");
         use std::collections::HashMap;
         let mut pages_before_restart: HashMap<PageId, Vec<DiskPtr>> =
             HashMap::new();
 
         let tx = Tx::new(&self, 0);
+
+        self.config.event_log.meta_before_restart(
+            self.meta(&tx).expect("should get meta under test").clone(),
+        );
 
         for pid in 0..self.max_pid.load(SeqCst) {
             let pte = self.inner.get(pid, &tx.guard);
@@ -389,16 +394,7 @@ where
             .event_log
             .pages_before_restart(pages_before_restart);
 
-        let space_amplification = self
-            .space_amplification()
-            .expect("should be able to read files and pages");
-        assert!(
-            space_amplification < MAX_SPACE_AMPLIFICATION,
-            "space amplification was measured to be {}, \
-             which is higher than the maximum of {}",
-            space_amplification,
-            MAX_SPACE_AMPLIFICATION
-        );
+        trace!("pagecache dropped");
     }
 }
 
@@ -410,6 +406,8 @@ where
 {
     /// Instantiate a new `PageCache`.
     pub fn start(config: Config) -> Result<PageCache<PM, P>> {
+        trace!("starting pagecache");
+
         config.reset_global_error();
 
         let cache_capacity = config.cache_capacity;
@@ -439,6 +437,30 @@ where
 
         // now we read it back in
         pc.load_snapshot();
+
+        #[cfg(feature = "event_log")]
+        {
+            // NB this must be before idgen/meta are initialized
+            // because they may cas_page on initial page-in.
+            let tx = Tx::new(&pc, 0);
+
+            use std::collections::HashMap;
+            let mut pages_after_restart: HashMap<PageId, Vec<DiskPtr>> =
+                HashMap::new();
+
+            for pid in 0..pc.max_pid.load(SeqCst) {
+                let pte = pc.inner.get(pid, &tx.guard);
+                if pte.is_none() {
+                    continue;
+                }
+                let head =
+                    unsafe { pte.unwrap().deref().stack.head(&tx.guard) };
+                let ptrs = ptrs_from_stack(head, &tx);
+                pages_after_restart.insert(pid, ptrs);
+            }
+
+            pc.config.event_log.pages_after_restart(pages_after_restart);
+        }
 
         let mut was_recovered = true;
 
@@ -492,6 +514,19 @@ where
         }
 
         pc.was_recovered = was_recovered;
+
+        #[cfg(feature = "event_log")]
+        {
+            let tx = Tx::new(&pc, 0);
+
+            pc.config.event_log.meta_after_restart(
+                pc.meta(&tx)
+                    .expect("should be able to get meta under test")
+                    .clone(),
+            );
+        }
+
+        trace!("pagecache started");
 
         Ok(pc)
     }
@@ -1057,7 +1092,7 @@ where
 
     fn logical_size_of_all_pages(&self) -> Result<u64> {
         let tx = self.begin()?;
-        let meta_size = self.get_meta(&tx)?.1.size_in_bytes();
+        let meta_size = self.meta(&tx)?.size_in_bytes();
         let idgen_size = std::mem::size_of::<u64>() as u64;
 
         let mut ret = meta_size + idgen_size;
@@ -1975,30 +2010,6 @@ where
                 not found in recovered page table",
             snapshot_free
         );
-
-        #[cfg(feature = "event_log")]
-        {
-            use std::collections::HashMap;
-            let mut pages_after_restart: HashMap<PageId, Vec<DiskPtr>> =
-                HashMap::new();
-
-            let tx = Tx::new(&self, 0);
-
-            for pid in 0..self.max_pid.load(SeqCst) {
-                let pte = self.inner.get(pid, &tx.guard);
-                if pte.is_none() {
-                    continue;
-                }
-                let head =
-                    unsafe { pte.unwrap().deref().stack.head(&tx.guard) };
-                let ptrs = ptrs_from_stack(head, &tx);
-                pages_after_restart.insert(pid, ptrs);
-            }
-
-            self.config
-                .event_log
-                .pages_after_restart(pages_after_restart);
-        }
     }
 }
 

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -977,7 +977,8 @@ impl SegmentAccountant {
                     .collect::<Vec<_>>()
             );
 
-            debug_assert!(
+            #[cfg(feature = "event_log")]
+            assert!(
                 old_segment.present.contains(&pid),
                 "we expect deferred replacements to provide \
                  all previous segments so we can clean them. \

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -90,29 +90,6 @@ pub(super) struct SegmentAccountant {
     async_truncations: Vec<Oneshot<Result<()>>>,
 }
 
-#[cfg(feature = "event_log")]
-impl Drop for SegmentAccountant {
-    fn drop(&mut self) {
-        let segments: std::collections::HashMap<
-            Lsn,
-            (SegmentState, u8, LogId),
-        > = self
-            .ordering
-            .clone()
-            .into_iter()
-            .map(|(lsn, lid)| {
-                let id = self.lid_to_idx(lid);
-                let segment = &self.segments[id];
-                let live = segment.live_pct();
-                let state = segment.state.clone();
-                (lsn, (state, live, lid))
-            })
-            .collect();
-
-        self.config.event_log.segments_before_restart(segments);
-    }
-}
-
 /// A `Segment` holds the bookkeeping information for
 /// a contiguous block of the disk. It may contain many
 /// fragments from different pages. Over time, we track
@@ -640,27 +617,6 @@ impl SegmentAccountant {
             // this is basically just for when we recover with a single
             // empty-yet-initialized segment
             debug!("recovered no segments so not initializing from any",);
-        }
-
-        #[cfg(feature = "event_log")]
-        {
-            let segments: std::collections::HashMap<
-                Lsn,
-                (SegmentState, u8, LogId),
-            > = self
-                .ordering
-                .iter()
-                .map(|(&lsn, &lid)| {
-                    let id =
-                        assert_usize(lid / self.config.io_buf_size as LogId);
-                    let segment = &self.segments[id];
-                    let live = segment.live_pct();
-                    let state = segment.state.clone();
-                    (lsn, (state, live, lid))
-                })
-                .collect();
-
-            self.config.event_log.segments_after_restart(segments);
         }
 
         Ok(())

--- a/crates/sled/src/context.rs
+++ b/crates/sled/src/context.rs
@@ -34,23 +34,13 @@ impl Drop for Context {
                 e
             );
         }
-
-        #[cfg(feature = "event_log")]
-        {
-            let tx = Tx::new(&self.pagecache, 0);
-
-            self.config.event_log.meta_before_restart(
-                self.pagecache
-                    .meta(&tx)
-                    .expect("should get meta under test")
-                    .clone(),
-            );
-        }
     }
 }
 
 impl Context {
     pub(crate) fn start(config: Config) -> Result<Context> {
+        trace!("starting context");
+
         #[cfg(any(test, feature = "check_snapshot_integrity"))]
         match config.verify_snapshot::<BLinkMaterializer, Frag>() {
             Ok(_) => {}

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -96,15 +96,6 @@ impl Db {
 
         drop(tenants);
 
-        #[cfg(feature = "event_log")]
-        context.event_log.meta_after_restart(
-            context
-                .pagecache
-                .meta(&tx)
-                .expect("should be able to get meta under test")
-                .clone(),
-        );
-
         Ok(ret)
     }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,13 +5,6 @@ authors = ["Tyler Neely <t@jujit.su>"]
 publish = false
 edition = "2018"
 
-[features]
-default = []
-all = ["event_log", "compression"]
-event_log = ["pagecache/event_log", "sled/event_log"]
-compression = ["pagecache/compression", "sled/compression"]
-no_jemalloc = []
-
 [dependencies]
 quickcheck = "0.8"
 rand = "0.6"
@@ -25,9 +18,9 @@ jemallocator = "0.1"
 color-backtrace = "0.1.3"
 
 [dependencies.pagecache]
-features = ["failpoints", "lock_free_delays"]
+features = ["failpoints", "lock_free_delays", "event_log", "no_metrics"]
 path = "../crates/pagecache"
 
 [dependencies.sled]
-features = ["failpoints", "lock_free_delays", "check_snapshot_integrity", "compression"]
+features = ["failpoints", "lock_free_delays", "event_log", "no_metrics", "check_snapshot_integrity", "compression"]
 path = "../crates/sled"


### PR DESCRIPTION
Remove segment-related event log items, as it's not deterministic enough to be useful. Move page-related event logging to the pagecache itself. Update travis config.