### PR TITLE
Rudimentary Batch update support

### DIFF
--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -107,7 +107,7 @@ pub use self::{
     materializer::{Materializer, NullMaterializer},
     meta::Meta,
     metrics::M,
-    pagecache::{CacheEntry, PageCache, PagePtr},
+    pagecache::{CacheEntry, PageCache, PagePtr, RecoveryGuard},
     reservation::Reservation,
     result::{CasResult, Error, Result},
     segment::SegmentMode,

--- a/crates/sled/src/batch.rs
+++ b/crates/sled/src/batch.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use super::*;
+
+/// A batch of updates that will
+/// be applied atomically to the
+/// Tree.
+pub struct Batch<'a> {
+    pub(super) tree: &'a Tree,
+    pub(super) writes: HashMap<IVec, Option<IVec>>,
+}
+
+impl<'a> Batch<'a> {
+    /// Set a key to a new value
+    pub fn set<K, V>(&mut self, key: K, value: V)
+    where
+        IVec: From<K>,
+        IVec: From<V>,
+    {
+        self.writes.insert(IVec::from(key), Some(IVec::from(value)));
+    }
+
+    /// Remove a key
+    pub fn del<K>(&mut self, key: K)
+    where
+        IVec: From<K>,
+    {
+        self.writes.insert(IVec::from(key), None);
+    }
+
+    /// Atomically apply the `Batch`
+    pub fn apply_batch(self) -> Result<()> {
+        let peg = self.tree.context.pin_log()?;
+        let cc = self.tree.concurrency_control.write().unwrap();
+        for (k, v_opt) in self.writes.into_iter() {
+            if let Some(v) = v_opt {
+                self.tree.set_inner(k, v)?;
+            } else {
+                self.tree.del_inner(k)?;
+            }
+        }
+        drop(cc);
+
+        // when the peg drops, it ensures all updates
+        // written to the log since its creation are
+        // recovered atomically
+        peg.seal_batch()
+    }
+}

--- a/crates/sled/src/batch.rs
+++ b/crates/sled/src/batch.rs
@@ -29,7 +29,7 @@ impl<'a> Batch<'a> {
     }
 
     /// Atomically apply the `Batch`
-    pub fn apply_batch(self) -> Result<()> {
+    pub fn apply(self) -> Result<()> {
         let peg = self.tree.context.pin_log()?;
         let cc = self.tree.concurrency_control.write().unwrap();
         for (k, v_opt) in self.writes.into_iter() {

--- a/crates/sled/src/context.rs
+++ b/crates/sled/src/context.rs
@@ -83,4 +83,8 @@ impl Context {
     pub fn generate_id(&self) -> Result<u64> {
         self.pagecache.generate_id()
     }
+
+    pub(crate) fn pin_log<'a>(&'a self) -> Result<RecoveryGuard<'a>> {
+        self.pagecache.pin_log()
+    }
 }

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -90,6 +90,7 @@ impl Db {
                 subscriptions: Arc::new(Subscriptions::default()),
                 context: context.clone(),
                 root: Arc::new(AtomicU64::new(root)),
+                concurrency_control: Arc::new(RwLock::new(())),
             };
             tenants.insert(id, Arc::new(tree));
         }

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -88,6 +88,7 @@ impl<'a> Iterator for Iter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_scan);
+        let _ = self.tree.concurrency_control.read().unwrap();
 
         let tx: &'a Tx<'a, _, _> = match self.tx {
             Ok(ref tx) => {
@@ -162,6 +163,7 @@ impl<'a> Iterator for Iter<'a> {
 impl<'a> DoubleEndedIterator for Iter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_reverse_scan);
+        let _ = self.tree.concurrency_control.read().unwrap();
 
         let tx: &'a Tx<'a, _, _> = match self.tx {
             Ok(ref tx) => {

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -34,6 +34,7 @@
 #![cfg_attr(test, deny(clippy::rust_2018_compatibility))]
 #![cfg_attr(test, deny(clippy::rust_2018_idioms))]
 
+mod batch;
 mod binary_search;
 mod context;
 mod data;
@@ -54,6 +55,7 @@ const DEFAULT_TREE_ID: &[u8] = b"__sled__default";
 
 pub use {
     self::{
+        batch::Batch,
         db::Db,
         iter::Iter,
         ivec::IVec,
@@ -81,7 +83,7 @@ use {
     log::{debug, error, trace},
     pagecache::{
         debug_delay, Materializer, Measure, MergeOperator, PageCache, PageId,
-        Tx, M,
+        RecoveryGuard, Tx, M,
     },
     serde::{Deserialize, Serialize},
 };

--- a/crates/sled/src/meta.rs
+++ b/crates/sled/src/meta.rs
@@ -1,4 +1,4 @@
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::{atomic::AtomicU64, Arc, RwLock};
 
 use super::*;
 
@@ -19,6 +19,7 @@ pub(crate) fn open_tree<'a>(
                     context: context.clone(),
                     subscriptions: Arc::new(Subscriptions::default()),
                     root: Arc::new(AtomicU64::new(root_id)),
+                    concurrency_control: Arc::new(RwLock::new(())),
                 });
             }
             Err(Error::CollectionNotFound(_)) => {}
@@ -87,6 +88,7 @@ pub(crate) fn open_tree<'a>(
             subscriptions: Arc::new(Subscriptions::default()),
             context: context.clone(),
             root: Arc::new(AtomicU64::new(root_id)),
+            concurrency_control: Arc::new(RwLock::new(())),
         });
     }
 }

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -174,6 +174,7 @@ impl Tree {
     /// assert_eq!(t.get(&[1]), Ok(None));
     /// ```
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<IVec>> {
+        let _ = self.concurrency_control.read().unwrap();
         let _measure = Measure::new(&M.tree_get);
         trace!("getting key {:?}", key.as_ref());
 
@@ -281,6 +282,8 @@ impl Tree {
     {
         trace!("casing key {:?}", key.as_ref());
         let _measure = Measure::new(&M.tree_cas);
+
+        let _ = self.concurrency_control.read().unwrap();
 
         if self.context.read_only {
             return Err(Error::Unsupported(
@@ -559,6 +562,7 @@ impl Tree {
         K: AsRef<[u8]>,
     {
         let _measure = Measure::new(&M.tree_get);
+        let _ = self.concurrency_control.read().unwrap();
         self.range(..key).next_back().transpose()
     }
 
@@ -598,6 +602,7 @@ impl Tree {
         K: AsRef<[u8]>,
     {
         let _measure = Measure::new(&M.tree_get);
+        let _ = self.concurrency_control.read().unwrap();
         self.range((ops::Bound::Excluded(key), ops::Bound::Unbounded))
             .next()
             .transpose()

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{self, RangeBounds},
     sync::{
         atomic::{AtomicU64, Ordering::SeqCst},
-        Arc,
+        Arc, RwLock,
     },
 };
 
@@ -51,6 +51,7 @@ pub struct Tree {
     pub(crate) context: Context,
     pub(crate) subscriptions: Arc<Subscriptions>,
     pub(crate) root: Arc<AtomicU64>,
+    pub(crate) concurrency_control: Arc<RwLock<()>>,
 }
 
 unsafe impl Send for Tree {}
@@ -72,6 +73,19 @@ impl Tree {
     /// assert_eq!(t.set(&[1,2,3], vec![1]), Ok(Some(IVec::from(&[0]))));
     /// ```
     pub fn set<K, V>(&self, key: K, value: V) -> Result<Option<IVec>>
+    where
+        K: AsRef<[u8]>,
+        IVec: From<V>,
+    {
+        let _ = self.concurrency_control.read().unwrap();
+        self.set_inner(key, value)
+    }
+
+    pub(crate) fn set_inner<K, V>(
+        &self,
+        key: K,
+        value: V,
+    ) -> Result<Option<IVec>>
     where
         K: AsRef<[u8]>,
         IVec: From<V>,
@@ -120,6 +134,32 @@ impl Tree {
         }
     }
 
+    /// Create a new batched update that can be
+    /// atomically applied.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sled::Db;
+    ///
+    /// let db = Db::start_default("batch_db").unwrap();
+    /// db.set("key_0", "val_0").unwrap();
+    /// let mut batch = db.batch();
+    /// batch.set("key_a", "val_a");
+    /// batch.set("key_b", "val_b");
+    /// batch.set("key_c", "val_c");
+    /// batch.del("key_0");
+    /// batch.apply().unwrap();
+    /// // key_0 no longer exists, and key_a, key_b, and key_c
+    /// // now do exist.
+    /// ```
+    pub fn batch(&self) -> Batch {
+        Batch {
+            tree: self,
+            writes: std::collections::HashMap::default(),
+        }
+    }
+
     /// Retrieve a value from the `Tree` if it exists.
     ///
     /// # Examples
@@ -158,6 +198,14 @@ impl Tree {
     /// assert_eq!(t.del(&[1]), Ok(None));
     /// ```
     pub fn del<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<IVec>> {
+        let _ = self.concurrency_control.read().unwrap();
+        self.del_inner(key)
+    }
+
+    pub(crate) fn del_inner<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+    ) -> Result<Option<IVec>> {
         let _measure = Measure::new(&M.tree_del);
 
         if self.context.read_only {
@@ -611,6 +659,15 @@ impl Tree {
     /// assert_eq!(tree.get(k), Ok(Some(IVec::from(vec![4]))));
     /// ```
     pub fn merge<K, V>(&self, key: K, value: V) -> Result<()>
+    where
+        K: AsRef<[u8]>,
+        IVec: From<V>,
+    {
+        let _ = self.concurrency_control.read().unwrap();
+        self.merge_inner(key, value)
+    }
+
+    pub(crate) fn merge_inner<K, V>(&self, key: K, value: V) -> Result<()>
     where
         K: AsRef<[u8]>,
         IVec: From<V>,


### PR DESCRIPTION
This is incomplete for a few reasons:
* causes system to completely stall if all io buffers are filled while the log pin is held
* doesn't support multi-tree batches yet
* doesn't support merge operations yet

None of these things require major engineering effort to fix, but I want to move this into master to keep things rolling quickly.