### PR TITLE
flexible iobufs. Closes #678. Closes #689.

### DIFF
--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [features]
 default = []
-lock_free_delays = ["rand", "rand_chacha"]
+lock_free_delays = ["rand", "rand_chacha", "rand_distr"]
 compression = ["zstd"]
 failpoints = ["fail", "rand"]
 no_metrics = ["historian/disable"]
@@ -37,6 +37,7 @@ zstd = { version = "0.4.23", optional = true }
 fail = { version = "0.2.1", optional = true }
 rand = { version = "0.7.0-pre.1", optional = true }
 rand_chacha = { version = "0.2.0", optional = true }
+rand_distr = { version = "0.2.0", optional = true }
 crc32fast = "1.2.0"
 log = "0.4.6"
 historian = "4.0.3"
@@ -52,3 +53,4 @@ fs2 = "0.4.3"
 rand = "0.7.0-pre.1"
 model = "0.1.2"
 rand_chacha = "0.2.0"
+rand_distr = "0.2.0"

--- a/crates/pagecache/src/debug_delay.rs
+++ b/crates/pagecache/src/debug_delay.rs
@@ -1,14 +1,13 @@
 use std::cell::UnsafeCell;
-use std::rc::Rc;
 
 use {
     log::warn,
     rand::{
-        distributions::{Distribution, Gamma},
         rngs::{adapter::ReseedingRng, OsRng},
         CryptoRng, Rng, RngCore, SeedableRng,
     },
     rand_chacha::ChaCha20Core as Core,
+    rand_distr::{Distribution, Gamma},
 };
 
 /// This function is useful for inducing random jitter into our atomic
@@ -34,7 +33,7 @@ pub fn debug_delay() {
         );
 
     if rng.gen_bool(1. / 1000.) {
-        let gamma = Gamma::new(0.3, 1_000.0 * intensity);
+        let gamma = Gamma::new(0.3, 1_000.0 * intensity).unwrap();
         let duration = gamma.sample(&mut try_thread_rng().unwrap());
         thread::sleep(Duration::from_micros(duration as u64));
     }

--- a/crates/pagecache/src/debug_delay.rs
+++ b/crates/pagecache/src/debug_delay.rs
@@ -25,7 +25,7 @@ pub fn debug_delay() {
     };
 
     let intensity: f64 = std::env::var("SLED_LOCK_FREE_DELAY_INTENSITY")
-        .unwrap_or("100.0".into())
+        .unwrap_or_else(|_| "100.0".into())
         .parse()
         .expect(
             "SLED_LOCK_FREE_DELAY_INTENSITY must be set to a \

--- a/crates/pagecache/src/ds/lru.rs
+++ b/crates/pagecache/src/ds/lru.rs
@@ -20,12 +20,10 @@ impl Lru {
         let size: usize = 1 << cache_bits;
         let shard_capacity = cache_capacity / size as u64;
 
-        Lru {
-            shards: rep_no_copy![
-                Mutex::new(Shard::new(shard_capacity));
-                size
-            ],
-        }
+        let mut shards = Vec::with_capacity(size);
+        shards.resize_with(size, || Mutex::new(Shard::new(shard_capacity)));
+
+        Lru { shards }
     }
 
     /// Called when a page is accessed. Returns a Vec of pages to

--- a/crates/pagecache/src/iobuf.rs
+++ b/crates/pagecache/src/iobuf.rs
@@ -493,7 +493,7 @@ impl IoBufs {
 
         #[cfg(feature = "event_log")]
         assert!(
-            intervals.len() < 1000,
+            intervals.len() < 10000,
             "intervals is getting crazy... {:?}",
             *intervals
         );

--- a/crates/pagecache/src/iobuf.rs
+++ b/crates/pagecache/src/iobuf.rs
@@ -939,20 +939,6 @@ impl IoBuf {
             Err(res)
         }
     }
-
-    pub(crate) fn cas_lid(
-        &self,
-        old: LogId,
-        new: LogId,
-    ) -> std::result::Result<LogId, LogId> {
-        debug_delay();
-        let res = self.lid.compare_and_swap(old, new, SeqCst);
-        if res == old {
-            Ok(new)
-        } else {
-            Err(res)
-        }
-    }
 }
 
 pub(crate) const fn is_sealed(v: Header) -> bool {

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -87,7 +87,7 @@ use self::metrics::uptime;
 
 use self::{
     blob_io::{gc_blobs, read_blob, remove_blob, write_blob},
-    iobuf::IoBufs,
+    iobuf::{IoBuf, IoBufs},
     iterator::LogIter,
     metrics::{clock, measure},
     pagecache::{LoggedUpdate, Update},

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -18,16 +18,6 @@ macro_rules! maybe_fail {
     };
 }
 
-macro_rules! rep_no_copy {
-    ($e:expr; $n:expr) => {{
-        let mut v = Vec::with_capacity($n);
-        for _ in 0..$n {
-            v.push($e);
-        }
-        v
-    }};
-}
-
 mod blob_io;
 mod config;
 mod constants;

--- a/crates/pagecache/src/logger.rs
+++ b/crates/pagecache/src/logger.rs
@@ -270,7 +270,7 @@ impl Log {
             // try to claim space
             let buf_offset = iobuf::offset(header);
             let prospective_size = buf_offset + inline_buf_len;
-            let would_overflow = prospective_size > iobuf.get_capacity();
+            let would_overflow = prospective_size > iobuf.capacity;
             if would_overflow {
                 // This buffer is too full to accept our write!
                 // Try to seal the buffer, and maybe write it if
@@ -308,7 +308,7 @@ impl Log {
                 continue;
             }
 
-            let lid = iobuf.get_lid();
+            let lid = iobuf.lid;
 
             // if we're giving out a reservation,
             // the writer count should be positive
@@ -317,7 +317,7 @@ impl Log {
             // should never have claimed a sealed buffer
             assert!(!iobuf::is_sealed(claimed));
 
-            let reservation_lsn = iobuf.get_lsn() + buf_offset as Lsn;
+            let reservation_lsn = iobuf.lsn + buf_offset as Lsn;
 
             // MAX is used to signify unreadiness of
             // the underlying IO buffer, and if it's
@@ -409,7 +409,7 @@ impl Log {
                 return Err(e);
             }
 
-            let lsn = iobuf.get_lsn();
+            let lsn = iobuf.lsn;
             if let Some(ref thread_pool) = self.config.thread_pool {
                 trace!(
                     "asynchronously writing iobuf with lsn {} \

--- a/crates/pagecache/src/logger.rs
+++ b/crates/pagecache/src/logger.rs
@@ -201,8 +201,6 @@ impl Log {
     ) -> Result<Reservation<'a>> {
         let _measure = Measure::new(&M.reserve_lat);
 
-        let n_io_bufs = self.config.io_bufs;
-
         let total_buf_len = MSG_HEADER_LEN + buf.len();
 
         M.reserve_sz.measure(total_buf_len as f64);
@@ -260,8 +258,8 @@ impl Log {
                     // we've updated the current_buf counter.
                     let _measure =
                         Measure::new(&M.reserve_current_condvar_wait);
-                    let mut buf_mu = self.iobufs.buf_mu.lock().unwrap();
-                    buf_mu = self.iobufs.buf_updated.wait(buf_mu).unwrap();
+                    let buf_mu = self.iobufs.buf_mu.lock().unwrap();
+                    let _ = self.iobufs.buf_updated.wait(buf_mu).unwrap();
                 } else {
                     backoff.snooze();
                 }

--- a/crates/pagecache/src/metrics.rs
+++ b/crates/pagecache/src/metrics.rs
@@ -43,7 +43,7 @@ pub(crate) fn uptime() -> Duration {
 
 /// Measure the duration of an event, and call `Histo::measure()`.
 pub struct Measure<'h> {
-    start: f64,
+    _start: f64,
     #[cfg(not(feature = "no_metrics"))]
     histo: &'h Histo,
     #[cfg(feature = "no_metrics")]
@@ -53,13 +53,13 @@ pub struct Measure<'h> {
 impl<'h> Measure<'h> {
     /// The time delta from ctor to dtor is recorded in `histo`.
     #[inline(always)]
-    pub fn new(histo: &'h Histo) -> Measure<'h> {
+    pub fn new(_histo: &'h Histo) -> Measure<'h> {
         Measure {
             #[cfg(feature = "no_metrics")]
             _pd: PhantomData,
             #[cfg(not(feature = "no_metrics"))]
-            histo,
-            start: clock(),
+            histo: _histo,
+            _start: clock(),
         }
     }
 }
@@ -68,15 +68,15 @@ impl<'h> Drop for Measure<'h> {
     #[inline(always)]
     fn drop(&mut self) {
         #[cfg(not(feature = "no_metrics"))]
-        self.histo.measure(clock() - self.start);
+        self.histo.measure(clock() - self._start);
     }
 }
 
 /// Measure the time spent on calling a given function in a given `Histo`.
 #[cfg_attr(not(feature = "no_inline"), inline)]
-pub(crate) fn measure<F: FnOnce() -> R, R>(histo: &Histo, f: F) -> R {
+pub(crate) fn measure<F: FnOnce() -> R, R>(_histo: &Histo, f: F) -> R {
     #[cfg(not(feature = "no_metrics"))]
-    let _measure = Measure::new(histo);
+    let _measure = Measure::new(_histo);
     f()
 }
 

--- a/crates/pagecache/src/reservation.rs
+++ b/crates/pagecache/src/reservation.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 /// A pending log reservation which can be aborted or completed.
@@ -6,7 +8,7 @@ use super::*;
 /// buffer to become blocked.
 pub struct Reservation<'a> {
     pub(super) log: &'a Log,
-    pub(super) idx: usize,
+    pub(super) iobuf: Arc<IoBuf>,
     pub(super) buf: &'a mut [u8],
     pub(super) flushed: bool,
     pub(super) ptr: DiskPtr,
@@ -111,7 +113,7 @@ impl<'a> Reservation<'a> {
                 std::mem::size_of::<u32>(),
             );
         }
-        self.log.exit_reservation(self.idx)?;
+        self.log.exit_reservation(&self.iobuf)?;
 
         Ok((self.lsn(), self.ptr()))
     }

--- a/crates/sled/src/flusher.rs
+++ b/crates/sled/src/flusher.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use super::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum ShutdownState {
     Running,
     ShuttingDown,

--- a/crates/sled/src/view.rs
+++ b/crates/sled/src/view.rs
@@ -69,7 +69,7 @@ impl<'a> View<'a> {
                 }
                 Frag::ParentMergeIntention(pid) => {
                     if !last_merge_confirmed {
-                        merging_child = merging_child.or(Some(*pid));
+                        merging_child = merging_child.or_else(|| Some(*pid));
                     }
                 }
                 Frag::ParentMergeConfirm => {
@@ -382,7 +382,7 @@ impl<'a> View<'a> {
                 .expect("leftmost child should never have been merged");
         }
 
-        return (index, items[index].1);
+        (index, items[index].1)
     }
 
     pub(crate) fn removed_children(&self) -> Vec<PageId> {

--- a/tests/tests/test_log.rs
+++ b/tests/tests/test_log.rs
@@ -67,6 +67,8 @@ fn log_writebatch() -> pagecache::Result<()> {
 fn more_log_reservations_than_buffers() {
     let config = ConfigBuilder::new()
         .temporary(true)
+        .io_buf_size(100)
+        .io_bufs(3)
         .segment_mode(SegmentMode::Linear)
         .build();
     let log = Log::start_raw_log(config.clone()).unwrap();
@@ -76,7 +78,7 @@ fn more_log_reservations_than_buffers() {
     let big_msg_overhead = MSG_HEADER_LEN + total_seg_overhead;
     let big_msg_sz = config.io_buf_size - big_msg_overhead;
 
-    for _ in 0..=config.io_bufs {
+    for _ in 0..=config.io_bufs * 1000 {
         reservations.push(log.reserve(&vec![0; big_msg_sz]).unwrap())
     }
     for res in reservations.into_iter().rev() {

--- a/tests/tests/test_log.rs
+++ b/tests/tests/test_log.rs
@@ -85,6 +85,8 @@ fn more_log_reservations_than_buffers() {
         // abort in reverse order
         res.abort();
     }
+
+    log.flush();
 }
 
 #[test]

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -14,3 +14,8 @@ race:crossbeam_epoch::internal::Global::collect
 # Rayon relies on crossbeam stuff which uses raw fences, which are
 # not detected by TSAN.
 race:rayon
+
+# Arc::drop is not properly detected by TSAN due to the use
+# of a raw atomic Acquire fence after the strong-count
+# atomic subtraction with a Release fence in the Drop impl.
+race:Arc*drop


### PR DESCRIPTION
This allows dynamic numbers of io buffers to remain incomplete over long stretches of time, effectively fixing writebatches.