### PR TITLE
cargo/pagecache: update to fail 0.3

### DIFF
--- a/crates/pagecache/Cargo.toml
+++ b/crates/pagecache/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 default = []
 lock_free_delays = ["rand", "rand_chacha", "rand_distr"]
 compression = ["zstd"]
-failpoints = ["fail", "rand"]
+failpoints = ["fail", "rand", "fail/failpoints"]
 no_metrics = ["historian/disable"]
 no_logs = ["log/max_level_off"]
 no_inline = []
@@ -33,7 +33,7 @@ lazy_static = "1.3.0"
 libc = "0.2.51"
 rayon = "1.0.3"
 zstd = { version = "0.4.23", optional = true }
-fail = { version = "0.2.1", optional = true }
+fail = { version = "0.3.0", optional = true }
 rand = { version = "0.7.0-pre.1", optional = true }
 rand_chacha = { version = "0.2.0", optional = true }
 rand_distr = { version = "0.2.0", optional = true }


### PR DESCRIPTION
Code generation by the underlying library is now disabled by default and
can be opted-in (and re-exported) via the `fail/failpoints` feature.

Ref: https://github.com/pingcap/fail-rs/blob/v0.3.0/CHANGELOG.md