### PR TITLE
replace db::start_default with db::open

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An (alpha) modern embedded database. Doesn't your data deserve an (alpha) beauti
 ```rust
 use sled::Db;
 
-let tree = Db::start_default(path)?;
+let tree = Db::open(path)?;
 
 // set and get
 tree.insert(k, v1);

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -49,6 +49,14 @@ impl std::fmt::Debug for Db {
 
 impl Db {
     /// Load existing or create a new `Db` with a default configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sled::Db;
+    ///
+    /// let t = Db::open("my_db").unwrap();
+    /// ```
     pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Db> {
         let config = ConfigBuilder::new().path(path).build();
         Self::start(config)

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -49,9 +49,15 @@ impl std::fmt::Debug for Db {
 
 impl Db {
     /// Load existing or create a new `Db` with a default configuration.
-    pub fn start_default<P: AsRef<std::path::Path>>(path: P) -> Result<Db> {
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Db> {
         let config = ConfigBuilder::new().path(path).build();
         Self::start(config)
+    }
+
+    /// Load existing or create a new `Db` with a default configuration.
+    #[deprecated(since = "0.24.2", note = "replaced by `Db:open`")]
+    pub fn start_default<P: AsRef<std::path::Path>>(path: P) -> Result<Db> {
+        Self::open(path)
     }
 
     /// Load existing or create a new `Db`.

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -52,7 +52,7 @@ impl Db {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use sled::Db;
     ///
     /// let t = Db::open("my_db").unwrap();

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```
 //! use sled::{Db, IVec};
 //!
-//! let t = Db::start_default("my_db").unwrap();
+//! let t = Db::open("my_db").unwrap();
 //! t.insert(b"yo!", b"v1".to_vec());
 //! assert_eq!(t.get(b"yo!"), Ok(Some(IVec::from(b"v1"))));
 //!

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -43,7 +43,7 @@ impl<'a> IntoIterator for &'a Tree {
 /// ```
 /// use sled::{Db, IVec};
 ///
-/// let t = Db::start_default("db").unwrap();
+/// let t = Db::open("db").unwrap();
 /// t.insert(b"yo!", b"v1".to_vec());
 /// assert_eq!(t.get(b"yo!"), Ok(Some(IVec::from(b"v1"))));
 ///
@@ -181,7 +181,7 @@ impl Tree {
     /// ```
     /// use sled::Db;
     ///
-    /// let db = Db::start_default("batch_db").unwrap();
+    /// let db = Db::open("batch_db").unwrap();
     /// db.insert("key_0", "val_0").unwrap();
     /// let mut batch = db.batch();
     /// batch.insert("key_a", "val_a");


### PR DESCRIPTION
I don't know how everybody is gonna like this. This replaces `db::start_default` with `db::open` to be easier and something that everyone expects from the API, similar to a `std::fs::File`. 

Now, I don't like that there is `db::start(config)` left and it's inconsistent with the `db::open(path)`. I would replace it with something like `db::init(config)` or `db::open_config(config)`. What do you think?

It seems like there is still no func overloading in Rust.