### PR TITLE
add dyn for boxed traits

### DIFF
--- a/crates/pagecache/src/ds/stack.rs
+++ b/crates/pagecache/src/ds/stack.rs
@@ -114,7 +114,7 @@ impl<T: Clone + Send + Sync + 'static> Stack<T> {
     }
 
     /// Pop the next item off the stack. Returns None if nothing is there.
-    fn _pop<'g>(&self, guard: &'g Guard) -> Option<T> {
+    fn _pop(&self, guard: &Guard) -> Option<T> {
         use std::ptr;
         debug_delay();
         let mut head = self.head(&guard);

--- a/crates/pagecache/src/logger.rs
+++ b/crates/pagecache/src/logger.rs
@@ -132,11 +132,11 @@ impl Log {
     /// Reserve a replacement buffer for a previously written
     /// blob write. This ensures the message header has the
     /// proper blob flag set.
-    pub(super) fn rewrite_blob_ptr<'a>(
-        &'a self,
+    pub(super) fn rewrite_blob_ptr(
+        &self,
         pid: PageId,
         blob_ptr: BlobPointer,
-    ) -> Result<Reservation<'a>> {
+    ) -> Result<Reservation> {
         let lsn_buf: [u8; std::mem::size_of::<BlobPointer>()] =
             u64_to_arr(blob_ptr as u64);
 
@@ -149,12 +149,12 @@ impl Log {
     /// linearizability across CAS operations that may need to
     /// persist part of their operation.
     #[allow(unused)]
-    pub fn reserve<'a>(
-        &'a self,
+    pub fn reserve(
+        &self,
         log_kind: LogKind,
         pid: PageId,
         raw_buf: &[u8],
-    ) -> Result<Reservation<'a>> {
+    ) -> Result<Reservation> {
         let mut _compressed: Option<Vec<u8>> = None;
         let mut buf = raw_buf;
 
@@ -176,13 +176,13 @@ impl Log {
         self.reserve_inner(log_kind, pid, buf, false)
     }
 
-    fn reserve_inner<'a>(
-        &'a self,
+    fn reserve_inner(
+        &self,
         log_kind: LogKind,
         pid: PageId,
         buf: &[u8],
         is_blob_rewrite: bool,
-    ) -> Result<Reservation<'a>> {
+    ) -> Result<Reservation> {
         let _measure = Measure::new(&M.reserve_lat);
 
         let total_buf_len = MSG_HEADER_LEN + buf.len();

--- a/crates/pagecache/src/pagecache.rs
+++ b/crates/pagecache/src/pagecache.rs
@@ -463,7 +463,7 @@ where
     /// to facilitate transactions and write batches when
     /// combined with a concurrency control system in another
     /// component.
-    pub fn pin_log<'a>(&'a self) -> Result<RecoveryGuard<'a>> {
+    pub fn pin_log(&self) -> Result<RecoveryGuard> {
         let batch_res = self.log.reserve(
             LogKind::Skip,
             BATCH_MANIFEST_PID,

--- a/crates/pagecache/src/tx.rs
+++ b/crates/pagecache/src/tx.rs
@@ -112,10 +112,10 @@ where
     /// to maximize underlying `PageTable` pointer density. Returns
     /// the page ID and its pointer for use in future `replace`
     /// and `link` operations.
-    pub fn allocate<'g>(
-        &'g self,
+    pub fn allocate(
+        &self,
         new: P,
-    ) -> TxResult<(PageId, PagePtr<'g, P>)> {
+    ) -> TxResult<(PageId, PagePtr<P>)> {
         unimplemented!()
     }
 
@@ -155,10 +155,10 @@ where
     }
 
     /// Try to retrieve a page by its logical ID.
-    pub fn get<'g>(
-        &'g self,
+    pub fn get(
+        &self,
         pid: PageId,
-    ) -> TxResult<(PagePtr<'g, P>, Vec<&'g P>)> {
+    ) -> TxResult<(PagePtr<P>, Vec<&P>)> {
         unimplemented!()
     }
 

--- a/crates/sled/src/context.rs
+++ b/crates/sled/src/context.rs
@@ -86,7 +86,7 @@ impl Context {
         self.pagecache.generate_id()
     }
 
-    pub(crate) fn pin_log<'a>(&'a self) -> Result<RecoveryGuard<'a>> {
+    pub(crate) fn pin_log(&self) -> Result<RecoveryGuard> {
         self.pagecache.pin_log()
     }
 }

--- a/tests/src/tree.rs
+++ b/tests/src/tree.rs
@@ -100,7 +100,7 @@ impl Arbitrary for Key {
         }
     }
 
-    fn shrink(&self) -> Box<Iterator<Item = Key>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Key>> {
         // we only want to shrink on length, not byte values
         Box::new(
             self.0
@@ -158,7 +158,7 @@ impl Arbitrary for Op {
         }
     }
 
-    fn shrink(&self) -> Box<Iterator<Item = Op>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Op>> {
         match *self {
             Set(ref k, v) => Box::new(k.shrink().map(move |sk| Set(sk, v))),
             Merge(ref k, v) => Box::new(k.shrink().map(move |k| Merge(k, v))),

--- a/tests/tests/test_log.rs
+++ b/tests/tests/test_log.rs
@@ -524,7 +524,7 @@ impl Arbitrary for Op {
         }
     }
 
-    fn shrink(&self) -> Box<Iterator<Item = Op>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Op>> {
         let mut op = self.clone();
         let mut shrunk = false;
         match op {

--- a/tests/tests/test_pagecache.rs
+++ b/tests/tests/test_pagecache.rs
@@ -387,7 +387,7 @@ impl Arbitrary for Op {
         }
     }
 
-    fn shrink(&self) -> Box<Iterator<Item = Op>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Op>> {
         let mut shrunk = false;
         let mut op = self.clone();
         match op {

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -57,7 +57,7 @@ impl Arbitrary for Op {
         }
     }
 
-    fn shrink(&self) -> Box<Iterator<Item = Op>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Op>> {
         match *self {
             Op::Del(ref lid) if *lid > 0 => {
                 Box::new(vec![Op::Del(*lid / 2), Op::Del(*lid - 1)].into_iter())


### PR DESCRIPTION
latest rustc is unhappy about missing dyn`s before boxed traits, and
there are some places where the compiler can auto infer lifetime context.