### PR TITLE
Some fixes for Clippy pedantic lints

### DIFF
--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -310,7 +310,7 @@ impl ConfigBuilder {
 
         if !dir.exists() {
             let res: std::io::Result<()> = std::fs::create_dir_all(dir);
-            res.map_err(|e: std::io::Error| Error::from(e))?;
+            res.map_err(Error::from)?;
         }
 
         self.verify_config_changes_ok()?;
@@ -453,7 +453,7 @@ impl ConfigBuilder {
             );
         }
 
-        Ok(deserialize::<ConfigBuilder>(&*buf).ok())
+        Ok(deserialize::<Self>(&*buf).ok())
     }
 
     // Get the path of the database

--- a/crates/pagecache/src/ds/pagetable.rs
+++ b/crates/pagecache/src/ds/pagetable.rs
@@ -43,15 +43,15 @@ struct Node2<T: Send + 'static> {
 }
 
 impl<T: Send + 'static> Node1<T> {
-    fn new() -> Box<Node1<T>> {
-        let size = size_of::<Node1<T>>();
-        let align = align_of::<Node1<T>>();
+    fn new() -> Box<Self> {
+        let size = size_of::<Self>();
+        let align = align_of::<Self>();
 
         unsafe {
             let layout = Layout::from_size_align_unchecked(size, align);
 
             #[allow(clippy::cast_ptr_alignment)]
-            let ptr = alloc_zeroed(layout) as *mut Node1<T>;
+            let ptr = alloc_zeroed(layout) as *mut Self;
 
             Box::from_raw(ptr)
         }
@@ -59,15 +59,15 @@ impl<T: Send + 'static> Node1<T> {
 }
 
 impl<T: Send + 'static> Node2<T> {
-    fn new() -> Owned<Node2<T>> {
-        let size = size_of::<Node2<T>>();
-        let align = align_of::<Node2<T>>();
+    fn new() -> Owned<Self> {
+        let size = size_of::<Self>();
+        let align = align_of::<Self>();
 
         unsafe {
             let layout = Layout::from_size_align_unchecked(size, align);
 
             #[allow(clippy::cast_ptr_alignment)]
-            let ptr = alloc_zeroed(layout) as *mut Node2<T>;
+            let ptr = alloc_zeroed(layout) as *mut Self;
 
             Owned::from_raw(ptr)
         }
@@ -118,7 +118,7 @@ impl<T> Default for PageTable<T>
 where
     T: 'static + Send + Sync,
 {
-    fn default() -> PageTable<T> {
+    fn default() -> Self {
         let head = Node1::new();
         Self {
             head: Atomic::from(head),

--- a/crates/pagecache/src/ds/stack.rs
+++ b/crates/pagecache/src/ds/stack.rs
@@ -35,7 +35,7 @@ pub struct Stack<T: Send + 'static> {
 }
 
 impl<T: Send + 'static> Default for Stack<T> {
-    fn default() -> Stack<T> {
+    fn default() -> Self {
         Self {
             head: Atomic::null(),
         }

--- a/crates/pagecache/src/lazy.rs
+++ b/crates/pagecache/src/lazy.rs
@@ -13,7 +13,7 @@ pub struct Lazy<T, F> {
 
 impl<T, F> Lazy<T, F> {
     /// Create a new Lazy
-    pub const fn new(init: F) -> Lazy<T, F>
+    pub const fn new(init: F) -> Self
     where
         F: Sized,
     {

--- a/crates/pagecache/src/lib.rs
+++ b/crates/pagecache/src/lib.rs
@@ -180,7 +180,7 @@ impl MessageKind {
 }
 
 impl From<u8> for MessageKind {
-    fn from(byte: u8) -> MessageKind {
+    fn from(byte: u8) -> Self {
         use MessageKind::*;
         match byte {
             0 => Corrupted,
@@ -235,7 +235,7 @@ where
 }
 
 impl From<MessageKind> for LogKind {
-    fn from(kind: MessageKind) -> LogKind {
+    fn from(kind: MessageKind) -> Self {
         use MessageKind::*;
         match kind {
             Free => LogKind::Free,

--- a/crates/pagecache/src/logger.rs
+++ b/crates/pagecache/src/logger.rs
@@ -549,7 +549,7 @@ impl LogRead {
 // data on disk and an lsn or crc32 of 0
 
 impl From<[u8; MSG_HEADER_LEN]> for MessageHeader {
-    fn from(buf: [u8; MSG_HEADER_LEN]) -> MessageHeader {
+    fn from(buf: [u8; MSG_HEADER_LEN]) -> Self {
         let kind = MessageKind::from(buf[0]);
 
         unsafe {
@@ -558,7 +558,7 @@ impl From<[u8; MSG_HEADER_LEN]> for MessageHeader {
             let len = arr_to_u32(buf.get_unchecked(17..21));
             let crc32 = arr_to_u32(buf.get_unchecked(21..)) ^ 0xFFFF_FFFF;
 
-            MessageHeader {
+            Self {
                 kind,
                 pid,
                 lsn,
@@ -607,7 +607,7 @@ impl Into<[u8; MSG_HEADER_LEN]> for MessageHeader {
 }
 
 impl From<[u8; SEG_HEADER_LEN]> for SegmentHeader {
-    fn from(buf: [u8; SEG_HEADER_LEN]) -> SegmentHeader {
+    fn from(buf: [u8; SEG_HEADER_LEN]) -> Self {
         unsafe {
             let crc32_header =
                 arr_to_u32(buf.get_unchecked(0..4)) ^ 0xFFFF_FFFF;
@@ -631,7 +631,7 @@ impl From<[u8; SEG_HEADER_LEN]> for SegmentHeader {
                 );
             }
 
-            SegmentHeader {
+            Self {
                 lsn,
                 max_stable_lsn,
                 ok,

--- a/crates/pagecache/src/pagecache.rs
+++ b/crates/pagecache/src/pagecache.rs
@@ -224,9 +224,9 @@ where
     P: Materializer,
 {
     fn drop(&mut self) {
-        trace!("dropping pagecache");
-
         use std::collections::HashMap;
+
+        trace!("dropping pagecache");
 
         // we can't as easily assert recovery
         // invariants across failpoints for now
@@ -265,7 +265,7 @@ where
     P: Materializer,
 {
     /// Instantiate a new `PageCache`.
-    pub fn start(config: Config) -> Result<PageCache<P>> {
+    pub fn start(config: Config) -> Result<Self> {
         trace!("starting pagecache");
 
         config.reset_global_error();
@@ -905,44 +905,42 @@ where
             } else if pid == CONFIG_PID {
                 let (key, config) = self.get_persisted_config(guard)?;
                 (key, Update::Config(config.clone()))
+            } else if let Some((key, frag, _sz)) = self.get(pid, guard)? {
+                (key, Update::Compact(frag.clone()))
             } else {
-                if let Some((key, frag, _sz)) = self.get(pid, guard)? {
-                    (key, Update::Compact(frag.clone()))
-                } else {
-                    let head_ptr = match self.inner.get(pid, &guard) {
-                        None => panic!(
-                            "expected to find existing stack \
-                             for freed pid {}",
-                            pid
-                        ),
-                        Some(p) => p,
-                    };
+                let head_ptr = match self.inner.get(pid, &guard) {
+                    None => panic!(
+                        "expected to find existing stack \
+                         for freed pid {}",
+                        pid
+                    ),
+                    Some(p) => p,
+                };
 
-                    let head = unsafe { head_ptr.deref().head(&guard) };
+                let head = unsafe { head_ptr.deref().head(&guard) };
 
-                    let mut stack_iter = StackIter::from_ptr(head, &guard);
+                let mut stack_iter = StackIter::from_ptr(head, &guard);
 
-                    match stack_iter.next() {
-                        Some((Some(Update::Free), cache_info)) => (
-                            PagePtr {
-                                cached_ptr: head,
-                                ts: cache_info.ts,
-                            },
-                            Update::Free,
-                        ),
-                        other => {
-                            debug!(
-                                "when rewriting pid {} \
-                                 we encountered a rewritten \
-                                 node with a frag {:?} that \
-                                 we previously witnessed a Free \
-                                 for (PageCache::get returned None), \
-                                 assuming we can just return now since \
-                                 the Free was replace'd",
-                                pid, other
-                            );
-                            return Ok(());
-                        }
+                match stack_iter.next() {
+                    Some((Some(Update::Free), cache_info)) => (
+                        PagePtr {
+                            cached_ptr: head,
+                            ts: cache_info.ts,
+                        },
+                        Update::Free,
+                    ),
+                    other => {
+                        debug!(
+                            "when rewriting pid {} \
+                             we encountered a rewritten \
+                             node with a frag {:?} that \
+                             we previously witnessed a Free \
+                             for (PageCache::get returned None), \
+                             assuming we can just return now since \
+                             the Free was replace'd",
+                            pid, other
+                        );
+                        return Ok(());
                     }
                 }
             };

--- a/crates/pagecache/src/promise.rs
+++ b/crates/pagecache/src/promise.rs
@@ -19,7 +19,7 @@ pub struct PromiseFiller<T> {
 impl<T> Promise<T> {
     /// Create a new PromiseFiller and the Promise
     /// that will be filled by its completion.
-    pub fn pair() -> (PromiseFiller<T>, Promise<T>) {
+    pub fn pair() -> (PromiseFiller<T>, Self) {
         let mu = Arc::new(Mutex::new((false, None)));
         let cv = Arc::new(Condvar::new());
         let future = Self {

--- a/crates/pagecache/src/segment.rs
+++ b/crates/pagecache/src/segment.rs
@@ -142,7 +142,7 @@ pub(crate) enum SegmentState {
 use self::SegmentState::{Free, Active, Inactive, Draining};
 
 impl Default for SegmentState {
-    fn default() -> SegmentState {
+    fn default() -> Self {
         Free
     }
 }
@@ -989,7 +989,7 @@ impl SegmentAccountant {
             && inactive_segs > 5
         {
             let last_index =
-                self.segments.iter().rposition(|s| s.is_inactive()).unwrap();
+                self.segments.iter().rposition(Segment::is_inactive).unwrap();
 
             let segment_start = (last_index * self.config.io_buf_size) as LogId;
 

--- a/crates/sled/src/batch.rs
+++ b/crates/sled/src/batch.rs
@@ -32,7 +32,7 @@ impl<'a> Batch<'a> {
     pub fn apply(self) -> Result<()> {
         let peg = self.tree.context.pin_log()?;
         let cc = self.tree.concurrency_control.write();
-        for (k, v_opt) in self.writes.into_iter() {
+        for (k, v_opt) in self.writes {
             if let Some(v) = v_opt {
                 self.tree.insert_inner(k, v)?;
             } else {

--- a/crates/sled/src/context.rs
+++ b/crates/sled/src/context.rs
@@ -47,20 +47,21 @@ impl Drop for Context {
 }
 
 impl Context {
-    pub(crate) fn start(config: Config) -> Result<Context> {
+    pub(crate) fn start(config: Config) -> Result<Self> {
         trace!("starting context");
 
         #[cfg(any(test, feature = "check_snapshot_integrity"))]
         match config.verify_snapshot() {
+            #[cfg(not(feature = "failpoints"))]
             Ok(_) => {}
             #[cfg(feature = "failpoints")]
-            Err(Error::FailPoint) => {}
+            Ok(_) | Err(Error::FailPoint) => {}
             other => panic!("failed to verify snapshot: {:?}", other),
         }
 
         let pagecache = Arc::new(PageCache::start(config.clone())?);
 
-        Ok(Context {
+        Ok(Self {
             config,
             pagecache,
             _flusher: Arc::new(Mutex::new(None)),

--- a/crates/sled/src/data.rs
+++ b/crates/sled/src/data.rs
@@ -7,7 +7,7 @@ pub(crate) enum Data {
 }
 
 impl Data {
-    pub(crate) fn fmt_keys(&self, prefix: &[u8]) -> Data {
+    pub(crate) fn fmt_keys(&self, prefix: &[u8]) -> Self {
         fn fmt_inner<T>(prefix: &[u8], xs: &[(IVec, T)]) -> Vec<(IVec, T)>
         where
             T: Clone + Ord,
@@ -33,7 +33,7 @@ impl Data {
         }
     }
 
-    pub(crate) fn split(&self, lhs_prefix: &[u8]) -> (IVec, Data) {
+    pub(crate) fn split(&self, lhs_prefix: &[u8]) -> (IVec, Self) {
         fn split_inner<T>(
             xs: &[(IVec, T)],
             lhs_prefix: &[u8],
@@ -69,7 +69,7 @@ impl Data {
         &mut self,
         old_prefix: &[u8],
         new_prefix: &[u8],
-        rhs_data: &Data,
+        rhs_data: &Self,
     ) {
         fn receive_merge_inner<T>(
             old_prefix: &[u8],

--- a/crates/sled/src/flusher.rs
+++ b/crates/sled/src/flusher.rs
@@ -44,7 +44,7 @@ impl Flusher {
         name: String,
         pagecache: Arc<PageCache<Frag>>,
         flush_every_ms: u64,
-    ) -> Flusher {
+    ) -> Self {
         #[allow(clippy::mutex_atomic)] // mutex used in CondVar below
         let shutdown = Arc::new(Mutex::new(ShutdownState::Running));
         let sc = Arc::new(Condvar::new());
@@ -58,7 +58,7 @@ impl Flusher {
             })
             .unwrap();
 
-        Flusher {
+        Self {
             shutdown,
             sc,
             join_handle: Mutex::new(Some(join_handle)),

--- a/crates/sled/src/ivec.rs
+++ b/crates/sled/src/ivec.rs
@@ -21,8 +21,8 @@ type Inner = [u8; CUTOFF];
 pub struct IVec(IVecInner);
 
 impl Default for IVec {
-    fn default() -> IVec {
-        IVec::from(&[])
+    fn default() -> Self {
+        Self::from(&[])
     }
 }
 
@@ -53,7 +53,7 @@ impl<'de> Deserialize<'de> for IVec {
     ) -> StdResult<Self, D::Error> {
         let bytes: StdResult<Box<[u8]>, D::Error> =
             serde_bytes::deserialize(deserializer);
-        bytes.map(IVec::from)
+        bytes.map(Self::from)
     }
 }
 
@@ -62,7 +62,7 @@ const fn is_inline_candidate(length: usize) -> bool {
 }
 
 impl IVec {
-    fn inline(slice: &[u8]) -> IVec {
+    fn inline(slice: &[u8]) -> Self {
         assert!(is_inline_candidate(slice.len()));
 
         let mut data = Inner::default();
@@ -75,64 +75,64 @@ impl IVec {
             );
         }
 
-        IVec(IVecInner::Inline(slice.len() as u8, data))
+        Self(IVecInner::Inline(slice.len() as u8, data))
     }
 
-    fn remote(arc: Arc<[u8]>) -> IVec {
-        IVec(IVecInner::Remote(arc))
+    fn remote(arc: Arc<[u8]>) -> Self {
+        Self(IVecInner::Remote(arc))
     }
 }
 
 impl From<Box<[u8]>> for IVec {
-    fn from(b: Box<[u8]>) -> IVec {
+    fn from(b: Box<[u8]>) -> Self {
         if is_inline_candidate(b.len()) {
-            IVec::inline(&b)
+            Self::inline(&b)
         } else {
             // rely on the Arc From specialization
             // for Box<T>, which may improve
             // over time
-            IVec::remote(Arc::from(b))
+            Self::remote(Arc::from(b))
         }
     }
 }
 
 impl From<&[u8]> for IVec {
-    fn from(slice: &[u8]) -> IVec {
+    fn from(slice: &[u8]) -> Self {
         if is_inline_candidate(slice.len()) {
-            IVec::inline(slice)
+            Self::inline(slice)
         } else {
-            IVec::remote(Arc::from(slice))
+            Self::remote(Arc::from(slice))
         }
     }
 }
 
 impl From<Arc<[u8]>> for IVec {
-    fn from(arc: Arc<[u8]>) -> IVec {
-        IVec::remote(arc)
+    fn from(arc: Arc<[u8]>) -> Self {
+        Self::remote(arc)
     }
 }
 
 impl From<&str> for IVec {
-    fn from(s: &str) -> IVec {
-        IVec::from(s.as_bytes())
+    fn from(s: &str) -> Self {
+        Self::from(s.as_bytes())
     }
 }
 
 impl From<&IVec> for IVec {
-    fn from(v: &IVec) -> IVec {
+    fn from(v: &Self) -> Self {
         v.clone()
     }
 }
 
 impl From<Vec<u8>> for IVec {
-    fn from(v: Vec<u8>) -> IVec {
+    fn from(v: Vec<u8>) -> Self {
         if is_inline_candidate(v.len()) {
-            IVec::inline(&v)
+            Self::inline(&v)
         } else {
             // rely on the Arc From specialization
             // for Vec<T>, which may improve
             // over time
-            IVec::remote(Arc::from(v))
+            Self::remote(Arc::from(v))
         }
     }
 }
@@ -153,8 +153,8 @@ macro_rules! from_array {
     ($($s:expr),*) => {
         $(
             impl From<&[u8; $s]> for IVec {
-                fn from(v: &[u8; $s]) -> IVec {
-                    IVec::from(&v[..])
+                fn from(v: &[u8; $s]) -> Self {
+                    Self::from(&v[..])
                 }
             }
         )*
@@ -197,13 +197,13 @@ impl AsRef<[u8]> for IVec {
 }
 
 impl Ord for IVec {
-    fn cmp(&self, other: &IVec) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_ref().cmp(other.as_ref())
     }
 }
 
 impl PartialOrd for IVec {
-    fn partial_cmp(&self, other: &IVec) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/crates/sled/src/materializer.rs
+++ b/crates/sled/src/materializer.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl Materializer for Frag {
-    fn merge(&mut self, other: &Frag) {
+    fn merge(&mut self, other: &Self) {
         if let Frag::Base(ref mut base) = self {
             base.apply(other);
         } else {

--- a/crates/sled/src/node.rs
+++ b/crates/sled/src/node.rs
@@ -142,9 +142,9 @@ impl Node {
         }
     }
 
-    pub(crate) fn split(mut self) -> (Node, Node) {
+    pub(crate) fn split(mut self) -> (Self, Self) {
         let (split, right_data) = self.data.split(&self.lo);
-        let rhs = Node {
+        let rhs = Self {
             data: right_data,
             next: self.next,
             lo: split,
@@ -164,7 +164,7 @@ impl Node {
         (self, rhs)
     }
 
-    pub(crate) fn receive_merge(&self, rhs: &Node) -> Node {
+    pub(crate) fn receive_merge(&self, rhs: &Self) -> Self {
         let mut merged = self.clone();
         merged.hi = rhs.hi.clone();
         merged.data.receive_merge(
@@ -226,8 +226,7 @@ impl Node {
             records.binary_search_by(|(k, _)| prefix_cmp(k, &predecessor_key));
 
         let idx = match search {
-            Ok(idx) => idx,
-            Err(idx) => idx,
+            Ok(idx) | Err(idx) => idx,
         };
 
         for (k, v) in &records[idx..] {
@@ -253,7 +252,7 @@ impl Node {
         &self,
         bound: &Bound<IVec>,
     ) -> Option<(IVec, IVec)> {
-        assert!(!self.data.is_index());
+        static MAX_IVEC: Lazy<IVec, fn() -> IVec> = Lazy::new(init_max_ivec);
 
         fn init_max_ivec() -> IVec {
             let mut base = vec![255; 1024 * 1024];
@@ -261,7 +260,7 @@ impl Node {
             IVec::from(base)
         }
 
-        static MAX_IVEC: Lazy<IVec, fn() -> IVec> = Lazy::new(init_max_ivec);
+        assert!(!self.data.is_index());
 
         // This encoding happens this way because
         // the rightmost (unbounded) node has

--- a/crates/sled/src/prefix.rs
+++ b/crates/sled/src/prefix.rs
@@ -50,7 +50,7 @@ pub(crate) fn prefix_reencode(
     let max_prefix_len = u8::max_value() as usize;
 
     let mut output = Vec::with_capacity(buf.len());
-    output.push(0u8);
+    output.push(0_u8);
 
     for (i, c) in decoded_key.enumerate() {
         if output[0] as usize == i

--- a/crates/sled/src/subscription.rs
+++ b/crates/sled/src/subscription.rs
@@ -36,7 +36,7 @@ impl Event {
 }
 
 impl Clone for Event {
-    fn clone(&self) -> Event {
+    fn clone(&self) -> Self {
         use self::Event::*;
 
         match self {

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -1272,6 +1272,12 @@ impl Tree {
     where
         K: AsRef<[u8]>,
     {
+        #[cfg(feature = "lock_free_delays")]
+        const MAX_LOOPS: usize = usize::max_value();
+
+        #[cfg(not(feature = "lock_free_delays"))]
+        const MAX_LOOPS: usize = 1_000_000;
+
         let _measure = Measure::new(&M.tree_traverse);
 
         let mut cursor = self.root.load(SeqCst);
@@ -1295,12 +1301,6 @@ impl Tree {
                 continue;
             };
         }
-
-        #[cfg(feature = "lock_free_delays")]
-        const MAX_LOOPS: usize = usize::max_value();
-
-        #[cfg(not(feature = "lock_free_delays"))]
-        const MAX_LOOPS: usize = 1_000_000;
 
         for _ in 0..MAX_LOOPS {
             if cursor == u64::max_value() {

--- a/examples/playground/src/main.rs
+++ b/examples/playground/src/main.rs
@@ -42,7 +42,7 @@ fn merge_operator() -> Result<()> {
         merged_bytes: &[u8],      // the new bytes being merged in
     ) -> Option<Vec<u8>> {
         // set the new value, return None to delete
-        let mut ret = old_value.map(|ov| ov.to_vec()).unwrap_or_else(|| vec![]);
+        let mut ret = old_value.map_or_else(|| vec![], |ov| ov.to_vec());
 
         ret.extend_from_slice(merged_bytes);
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,8 +10,6 @@ pub mod tree;
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 pub fn setup_logger() {
-    color_backtrace::install();
-
     use std::io::Write;
 
     fn tn() -> String {
@@ -20,6 +18,8 @@ pub fn setup_logger() {
             .unwrap_or("unknown")
             .to_owned()
     }
+
+    color_backtrace::install();
 
     let mut builder = env_logger::Builder::new();
     builder


### PR DESCRIPTION
Here's a raft of fixes for #760. I mostly skipped lints about sign loss/truncation on casting, function arguments that could be passed by reference instead, and binding names.