### PR TITLE
limit cache size by cgroup memory limit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,29 +71,23 @@ steps:
     displayName: doctests
     condition: eq( variables['testKind'], 'doctests' )
   - script: |
-      echo "cross build" &&
-      echo "https://github.com/rust-lang/cargo/issues/4753" &&
-      rustup target add aarch64-fuchsia &&
-      rustup target add aarch64-linux-android &&
-      rustup target add i686-linux-android &&
-      rustup target add i686-unknown-linux-gnu &&
-      rustup target add x86_64-pc-windows-gnu &&
-      rustup target add x86_64-linux-android &&
-      rustup target add x86_64-fuchsia &&
-      pushd crates/sled      && cargo check --target aarch64-fuchsia && popd &&
-      pushd crates/sled      && cargo check --target aarch64-linux-android && popd &&
-      pushd crates/sled      && cargo check --target i686-linux-android && popd &&
-      pushd crates/sled      && cargo check --target i686-unknown-linux-gnu && popd &&
-      pushd crates/sled      && cargo check --target x86_64-pc-windows-gnu  && popd &&
-      pushd crates/sled      && cargo check --target x86_64-linux-android  && popd &&
-      pushd crates/sled      && cargo check --target x86_64-fuchsia && popd &&
-      pushd crates/pagecache && cargo check --target aarch64-fuchsia && popd &&
-      pushd crates/pagecache && cargo check --target aarch64-linux-android && popd &&
-      pushd crates/pagecache && cargo check --target i686-linux-android && popd &&
-      pushd crates/pagecache && cargo check --target i686-unknown-linux-gnu && popd &&
-      pushd crates/pagecache && cargo check --target x86_64-pc-windows-gnu  && popd &&
-      pushd crates/pagecache && cargo check --target x86_64-linux-android && popd &&
-      pushd crates/pagecache && cargo check --target x86_64-fuchsia && popd
+      set -eo pipefail
+      echo "cross build"
+      echo "https://github.com/rust-lang/cargo/issues/4753"
+      crates="sled pagecache"
+      targets="aarch64-fuchsia aarch64-linux-android"
+      targets="$targets i686-linux-android i686-unknown-linux-gnu"
+      targets="$targets x86_64-pc-windows-gnu x86_64-linux-android x86_64-fuchsia"
+      for crate in $crates; do
+      for target in $targets; do
+        pushd crates/$crate
+        echo "setting up $target..."
+        rustup target add $target
+        echo "checking $target..."
+        cargo check --target $target
+        popd
+      done
+      done
     displayName: cross-build
     condition: eq( variables['testKind'], 'cross-compile' )
   - script: |

--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -318,8 +318,7 @@ impl ConfigBuilder {
 
         match options.open(&path) {
             Ok(file) => {
-                #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
-                {
+                if cfg!(any(windows, target_os = "linux", target_os = "macos")) {
                     let try_lock = if self.read_only {
                         file.try_lock_shared()
                     } else {
@@ -328,11 +327,11 @@ impl ConfigBuilder {
 
                     if let Err(e) = try_lock {
                         return Err(Error::Io(io::Error::new(
-                            io::ErrorKind::Other,
+                            io::ErrorKind::WouldBlock,
                             format!("could not acquire appropriate file lock on {:?}: {:?}", path, e),
                             )));
                     }
-                }
+                };
 
                 Ok(file)
             }

--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -316,7 +316,7 @@ impl ConfigBuilder {
         }
 
         if !dir.exists() {
-            let res: std::io::Result<()> = fs::create_dir_all(dir);
+            let res: io::Result<()> = fs::create_dir_all(dir);
             res.map_err(Error::from)?;
         }
 
@@ -447,7 +447,7 @@ impl ConfigBuilder {
         buf.split_off(len - 4);
 
         let mut crc_arr = [0_u8; 4];
-        f.seek(std::io::SeekFrom::End(-4)).unwrap();
+        f.seek(io::SeekFrom::End(-4)).unwrap();
         f.read_exact(&mut crc_arr).unwrap();
         let crc_expected = arr_to_u32(&crc_arr);
 
@@ -586,7 +586,7 @@ impl Config {
 
     // returns the snapshot file paths for this system
     #[doc(hidden)]
-    pub fn get_snapshot_files(&self) -> std::io::Result<Vec<PathBuf>> {
+    pub fn get_snapshot_files(&self) -> io::Result<Vec<PathBuf>> {
         let mut prefix = self.snapshot_prefix();
 
         prefix.push("snap.");
@@ -599,7 +599,7 @@ impl Config {
             abs_path
         };
 
-        let filter = |dir_entry: std::io::Result<fs::DirEntry>| {
+        let filter = |dir_entry: io::Result<fs::DirEntry>| {
             if let Ok(de) = dir_entry {
                 let path_buf = de.path();
                 let path = path_buf.as_path();
@@ -731,7 +731,7 @@ fn read_u64_from(mut file: File) -> io::Result<u64> {
 /// Returns the maximum size of total available memory of the process, in bytes.
 /// If this limit is exceeded, the malloc() and mmap() functions shall fail with errno set
 /// to [ENOMEM].
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn get_rlimit_as() -> io::Result<libc::rlimit> {
     let mut limit = std::mem::MaybeUninit::<libc::rlimit>::uninit();
 
@@ -744,7 +744,7 @@ fn get_rlimit_as() -> io::Result<libc::rlimit> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn get_available_memory() -> io::Result<u64> {
     let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
     if pages == -1 {
@@ -781,7 +781,7 @@ fn get_memory_limit() -> u64 {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         if let Ok(rlim) = get_rlimit_as() {
             let rlim_cur = rlim.rlim_cur as u64;


### PR DESCRIPTION
Implementation of https://github.com/spacejam/sled/issues/685: a cgroup memory limit is in place and bound cache based on that.

Do we need tests here? (at least if cgroup sys fs is present on the host)