### PR TITLE
0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.26.1
+
+## Improvements
+
+* std::thread is no longer used on platforms other than
+  linux, macos, and windows, which increases portability.
+
 # 0.26
 
 ## New Features

--- a/crates/sled/Cargo.toml
+++ b/crates/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a modern embedded database"
 license = "MIT/Apache-2.0"

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -62,7 +62,7 @@ impl Db {
         Self::start(config)
     }
 
-    /// Load existing or create a new `Db` with a default configuration.
+    #[doc(hidden)]
     #[deprecated(since = "0.24.2", note = "replaced by `Db:open`")]
     pub fn start_default<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
         Self::open(path)

--- a/crates/sled/src/db.rs
+++ b/crates/sled/src/db.rs
@@ -105,8 +105,7 @@ impl Db {
 
         let mut tenants = ret.tenants.write();
 
-        for (id, root) in context.pagecache.meta(&guard)?.tenants()
-        {
+        for (id, root) in context.pagecache.meta(&guard)?.tenants() {
             let tree = Tree {
                 tree_id: id.clone(),
                 subscriptions: Arc::new(Subscriptions::default()),
@@ -136,11 +135,8 @@ impl Db {
         let guard = pin();
 
         let mut tenants = self.tenants.write();
-        let tree = Arc::new(meta::open_tree(
-            &self.context,
-            name.to_vec(),
-            &guard,
-        )?);
+        let tree =
+            Arc::new(meta::open_tree(&self.context, name.to_vec(), &guard)?);
         tenants.insert(name.to_vec(), tree.clone());
         drop(tenants);
         Ok(tree)
@@ -181,12 +177,10 @@ impl Db {
         }
 
         loop {
-            let res = self.context.pagecache.cas_root_in_meta(
-                &name,
-                root_id,
-                None,
-                &guard,
-            )?;
+            let res = self
+                .context
+                .pagecache
+                .cas_root_in_meta(&name, root_id, None, &guard)?;
 
             if let Err(actual_root) = res {
                 root_id = actual_root;

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -1,13 +1,58 @@
-//! `sled` is a flash-sympathetic persistent lock-free B+ tree.
+//! `sled` is a high-performance embedded database with
+//! an API that is similar to a `BTreeMap<[u8], [u8]>`,
+//! but with several additional capabilities for
+//! assisting creators of stateful systems.
+//!
+//! It is fully thread-safe, and all operations are
+//! atomic. Multiple `Tree`s are supported with the
+//! [`Db::open_tree`](struct.Db.html#method.open_tree) method.
+//!
+//! ACID transactions involving reads and writes to
+//! multiple items are supported with the
+//! [`Tree::transaction`](struct.Tree.html#method.transaction)
+//! method. Transactions may also operate over
+//! multiple `Tree`s (see
+//! [`Tree::transaction`](struct.Tree.html#method.transaction)
+//! docs for more info).
+//!
+//! Users may also subscribe to updates on individual
+//! `Tree`s by using the
+//! [`Tree::watch_prefix`](struct.Tree.html#method.watch_prefix)
+//! method, which returns a blocking `Iterator` over
+//! updates to keys that begin with the provided
+//! prefix. You may supply an empty prefix to subscribe
+//! to everything.
+//!
+//! [Merge operators](https://github.com/spacejam/sled/wiki/merge-operators)
+//! (aka read-modify-write operators) are supported. A
+//! merge operator is a function that specifies
+//! how new data can be merged into an existing value
+//! without requiring both a read and a write.
+//! Using the
+//! [`Tree::merge`](struct.Tree.html#method.merge)
+//! method, you may "push" data to a `Tree` value
+//! and have the provided merge operator combine
+//! it with the existing value, if there was one.
+//! They are set on a per-`Tree` basis, and essentially
+//! allow any sort of data structure to be built
+//! using merges as an atomic high-level operation.
+//!
+//! `sled` is built by experienced database engineers
+//! who think users should spend less time tuning and
+//! working against high-friction APIs. Expect
+//! significant ergonomic and performance improvements
+//! over time. Most surprises are bugs, so please
+//! [let us know](mailto:t@jujit.su?subject=sled%20sucks!!!) if something
+//! is high friction.
 //!
 //! # Examples
 //!
 //! ```
-//! use sled::{Db, IVec};
+//! use sled::Db;
 //!
 //! let t = Db::open("my_db").unwrap();
-//! t.insert(b"yo!", b"v1".to_vec());
-//! assert_eq!(t.get(b"yo!"), Ok(Some(IVec::from(b"v1"))));
+//! t.insert(b"yo!", b"v1");
+//! assert_eq!(&t.get(b"yo!").unwrap().unwrap(), b"v1");
 //!
 //! // Atomic compare-and-swap.
 //! t.cas(
@@ -17,9 +62,9 @@
 //! ).unwrap();
 //!
 //! // Iterates over key-value pairs, starting at the given key.
-//! let scan_key: &[u8] = b"a non-present key before yo!";
+//! let scan_key = b"a non-present key before yo!";
 //! let mut iter = t.range(scan_key..);
-//! assert_eq!(iter.next().unwrap(), Ok((IVec::from(b"yo!"), IVec::from(b"v2"))));
+//! assert_eq!(&iter.next().unwrap().unwrap().0, b"yo!");
 //! assert_eq!(iter.next(), None);
 //!
 //! t.remove(b"yo!");

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -62,7 +62,7 @@
 //! ).unwrap();
 //!
 //! // Iterates over key-value pairs, starting at the given key.
-//! let scan_key = b"a non-present key before yo!";
+//! let scan_key: &[u8] = b"a non-present key before yo!";
 //! let mut iter = t.range(scan_key..);
 //! assert_eq!(&iter.next().unwrap().unwrap().0, b"yo!");
 //! assert_eq!(iter.next(), None);

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -80,8 +80,7 @@ unsafe impl Send for Tree {}
 unsafe impl Sync for Tree {}
 
 impl Tree {
-    /// Insert a key to a new value, returning the last value if it
-    /// was set.
+    #[doc(hidden)]
     #[deprecated(since = "0.24.2", note = "replaced by `Tree::insert`")]
     pub fn set<K, V>(&self, key: K, value: V) -> Result<Option<IVec>>
     where
@@ -327,17 +326,7 @@ impl Tree {
         Ok(v_opt)
     }
 
-    /// Delete a value, returning the old value if it existed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let config = sled::ConfigBuilder::new().temporary(true).build();
-    /// let t = sled::Db::start(config).unwrap();
-    /// t.insert(&[1], vec![1]);
-    /// assert_eq!(t.remove(&[1]), Ok(Some(sled::IVec::from(vec![1]))));
-    /// assert_eq!(t.remove(&[1]), Ok(None));
-    /// ```
+    #[doc(hidden)]
     #[deprecated(since = "0.24.2", note = "replaced by `Tree::remove`")]
     pub fn del<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<IVec>> {
         self.remove(key)


### PR DESCRIPTION
* update docs
* release includes a few internal cleanups, as well as a portability improvement by removing reliance on std::thread on targets other than linux, macos, and windows