### PR TITLE
Add check to transaction test after writers finish

### DIFF
--- a/tests/tests/test_tree.rs
+++ b/tests/tests/test_tree.rs
@@ -406,6 +406,10 @@ fn concurrent_tree_transactions() {
     for thread in threads.into_iter() {
         thread.join().unwrap();
     }
+
+    let v1 = db.get(b"k1").unwrap().unwrap();
+    let v2 = db.get(b"k2").unwrap().unwrap();
+    assert_eq!([v1, v2], [b"cats", b"dogs"]);
 }
 
 #[test]


### PR DESCRIPTION
This adds one more assert to the `concurrent_tree_transactions` test, after all the reader and writer threads have joined. It checks that the entries have returned to their original values (since they get swapped an even number of times). If any of the swapping transactions gets lost, and their durability isn't maintained, this assert will catch the issue.