### PR TITLE
fix some ds mod warns and refactor it a little #795

### DIFF
--- a/crates/pagecache/src/config.rs
+++ b/crates/pagecache/src/config.rs
@@ -204,14 +204,14 @@ impl ConfigBuilder {
             now + seed
         };
 
-        return if cfg!(target_os = "linux") {
+        if cfg!(target_os = "linux") {
             // use shared memory for temporary linux files
             format!("/dev/shm/pagecache.tmp.{}", salt).into()
         } else {
             let mut pb = std::env::temp_dir();
             pb.push(format!("pagecache.tmp.{}", salt));
             pb
-        };
+        }
     }
 
     fn limit_cache_max_memory(&mut self) {
@@ -755,12 +755,12 @@ fn get_available_memory() -> io::Result<u64> {
         return Err(io::Error::last_os_error());
     }
 
-    return Ok((pages as u64) * (page_size as u64));
+    Ok((pages as u64) * (page_size as u64))
 }
 
 fn get_memory_limit() -> u64 {
     // Maximum addressable memory space limit in u64
-    static MAX_USIZE: u64 = std::usize::MAX as u64;
+    static MAX_USIZE: u64 = usize::max_value() as u64;
 
     let mut max: u64 = 0;
 
@@ -775,7 +775,7 @@ fn get_memory_limit() -> u64 {
         // 4k which is a common page size). So we know we are not
         // running in a memory restricted environment.
         // src: https://github.com/dotnet/coreclr/blob/master/src/pal/src/misc/cgroup.cpp#L385-L428
-        if max > 0x7FFFFFFF00000000 {
+        if max > 0x7FFF_FFFF_0000_0000 {
             return 0;
         }
     }
@@ -802,5 +802,5 @@ fn get_memory_limit() -> u64 {
         max = MAX_USIZE;
     }
 
-    return max;
+    max
 }

--- a/crates/pagecache/src/debug/delay.rs
+++ b/crates/pagecache/src/debug/delay.rs
@@ -13,7 +13,7 @@ use {
 
 /// This function is useful for inducing random jitter into our atomic
 /// operations, shaking out more possible interleavings quickly. It gets
-/// fully elliminated by the compiler in non-test code.
+/// fully eliminated by the compiler in non-test code.
 pub fn debug_delay() {
     use std::thread;
     use std::time::Duration;

--- a/crates/pagecache/src/debug/mod.rs
+++ b/crates/pagecache/src/debug/mod.rs
@@ -1,0 +1,13 @@
+/// This module helps test concurrent issues with random jittering and another instruments.
+
+#[cfg(any(test, feature = "lock_free_delays"))]
+mod delay;
+
+#[cfg(any(test, feature = "lock_free_delays"))]
+pub use delay::debug_delay;
+
+/// This function is useful for inducing random jitter into our atomic
+/// operations, shaking out more possible interleavings quickly. It gets
+/// fully eliminated by the compiler in non-test code.
+#[cfg(not(any(test, feature = "lock_free_delays")))]
+pub fn debug_delay() {}

--- a/crates/pagecache/src/ds/dll.rs
+++ b/crates/pagecache/src/ds/dll.rs
@@ -1,11 +1,11 @@
-/// A simple doubly-linked list for use in the `Lru`
 use std::ptr;
 
-use super::*;
+pub type Item = u64;
 
+/// A simple doubly linked list for use in the `Lru`
 #[derive(Debug)]
 pub(crate) struct Node {
-    inner: PageId,
+    inner: Item,
     next: *mut Node,
     prev: *mut Node,
 }
@@ -27,17 +27,17 @@ impl Node {
     }
 }
 
-/// A simple non-cyclical doubly-linked
+/// A simple non-cyclical doubly linked
 /// list where items can be efficiently
 /// removed from the middle, for the purposes
-/// of backing an Lru cache.
-pub struct Dll {
+/// of backing an LRU cache.
+pub struct DoublyLinkedList {
     head: *mut Node,
     tail: *mut Node,
     len: usize,
 }
 
-impl Drop for Dll {
+impl Drop for DoublyLinkedList {
     fn drop(&mut self) {
         let mut cursor = self.head;
         while !cursor.is_null() {
@@ -56,7 +56,7 @@ impl Drop for Dll {
     }
 }
 
-impl Default for Dll {
+impl Default for DoublyLinkedList {
     fn default() -> Self {
         Self {
             head: ptr::null_mut(),
@@ -66,12 +66,12 @@ impl Default for Dll {
     }
 }
 
-impl Dll {
+impl DoublyLinkedList {
     pub(crate) fn len(&self) -> usize {
         self.len
     }
 
-    pub(crate) fn push_head(&mut self, item: PageId) -> *mut Node {
+    pub(crate) fn push_head(&mut self, item: Item) -> *mut Node {
         self.len += 1;
 
         let node = Node {
@@ -98,7 +98,7 @@ impl Dll {
     }
 
     #[cfg(test)]
-    pub(crate) fn push_tail(&mut self, item: PageId) {
+    pub(crate) fn push_tail(&mut self, item: Item) {
         self.len += 1;
 
         let node = Node {
@@ -135,7 +135,7 @@ impl Dll {
     }
 
     #[cfg(test)]
-    pub(crate) fn pop_head(&mut self) -> Option<PageId> {
+    pub(crate) fn pop_head(&mut self) -> Option<Item> {
         if self.head.is_null() {
             return None;
         }
@@ -157,7 +157,7 @@ impl Dll {
         }
     }
 
-    pub(crate) fn pop_tail(&mut self) -> Option<PageId> {
+    pub(crate) fn pop_tail(&mut self) -> Option<Item> {
         if self.tail.is_null() {
             return None;
         }
@@ -179,7 +179,7 @@ impl Dll {
         }
     }
 
-    pub(crate) unsafe fn pop_ptr(&mut self, ptr: *mut Node) -> PageId {
+    pub(crate) unsafe fn pop_ptr(&mut self, ptr: *mut Node) -> Item {
         self.len -= 1;
 
         let mut node = Box::from_raw(ptr);
@@ -198,7 +198,7 @@ impl Dll {
     }
 
     #[cfg(test)]
-    pub(crate) fn into_vec(mut self) -> Vec<PageId> {
+    pub(crate) fn into_vec(mut self) -> Vec<Item> {
         let mut res = vec![];
         while let Some(val) = self.pop_head() {
             res.push(val);
@@ -209,7 +209,7 @@ impl Dll {
 
 #[test]
 fn test_dll() {
-    let mut dll = Dll::default();
+    let mut dll = DoublyLinkedList::default();
     dll.push_head(5);
     dll.push_tail(6);
     dll.push_head(4);

--- a/crates/pagecache/src/ds/lru.rs
+++ b/crates/pagecache/src/ds/lru.rs
@@ -1,9 +1,9 @@
+use super::dll::{DoublyLinkedList, Item, Node};
 use parking_lot::Mutex;
+use std::convert::TryFrom;
 use std::ptr;
 
-use super::*;
-
-/// A simple Lru cache.
+/// A simple LRU cache.
 pub struct Lru {
     shards: Vec<Mutex<Shard>>,
 }
@@ -27,45 +27,48 @@ impl Lru {
         Self { shards }
     }
 
-    /// Called when a page is accessed. Returns a Vec of pages to
-    /// try to page-out. For each one of these, the caller is expected
-    /// to call `page_out_succeeded` if the page-out succeeded.
-    pub fn accessed(&self, pid: PageId, sz: u64) -> Vec<PageId> {
-        let shard_idx = pid % self.shards.len() as u64;
-        let rel_idx = pid / self.shards.len() as u64;
-        let shard_mu = &self.shards[usize::try_from(shard_idx).unwrap()];
+    /// Called when an item is accessed. Returns a Vec of items to be
+    /// evicted.
+    ///
+    /// Items layout:
+    ///   items:   1 2 3 4 5 6 7 8 9 10
+    ///   shards:  1 0 1 0 1 0 1 0 1 0
+    ///   shard 0:   2   4   6   8   10
+    ///   shard 1: 1   3   5   7   9
+    pub fn accessed(&self, id: Item, item_size: u64) -> Vec<Item> {
+        let shards = self.shards.len() as u64;
+        let (shard_idx, item_pos) = (id % shards, id / shards);
+        let shard_mu: &Mutex<Shard> = &self.shards[safe_usize(shard_idx)];
         let mut shard = shard_mu.lock();
-        let mut rel_ids = shard.accessed(rel_idx, sz);
-
-        for rel_id in &mut rel_ids {
-            let real_id = (*rel_id * self.shards.len() as u64) + shard_idx;
-            *rel_id = real_id;
-        }
-
-        rel_ids
+        let mut to_evict = shard.accessed(safe_usize(item_pos), item_size);
+        // map shard internal offsets to global items ids
+        to_evict
+            .iter_mut()
+            .for_each(|pos| *pos = (*pos * shards) + shard_idx);
+        to_evict
     }
 }
 
 #[derive(Clone)]
 struct Entry {
-    ptr: *mut dll::Node,
-    sz: u64,
+    ptr: *mut Node,
+    size: u64,
 }
 
 impl Default for Entry {
     fn default() -> Self {
         Self {
             ptr: ptr::null_mut(),
-            sz: 0,
+            size: 0,
         }
     }
 }
 
 struct Shard {
-    list: Dll,
+    list: DoublyLinkedList,
     entries: Vec<Entry>,
     capacity: u64,
-    sz: u64,
+    size: u64,
 }
 
 impl Shard {
@@ -73,52 +76,56 @@ impl Shard {
         assert!(capacity > 0, "shard capacity must be non-zero");
 
         Self {
-            list: Dll::default(),
+            list: DoublyLinkedList::default(),
             entries: vec![],
             capacity,
-            sz: 0,
+            size: 0,
         }
     }
 
-    fn accessed(&mut self, rel_idx: PageId, sz: u64) -> Vec<PageId> {
-        if PageId::try_from(self.entries.len()).unwrap() <= rel_idx {
-            self.entries.resize(
-                usize::try_from(rel_idx).unwrap() + 1,
-                Entry::default(),
-            );
+    /// Items in the shard list are indexes of the entries.
+    fn accessed(&mut self, pos: usize, size: u64) -> Vec<Item> {
+        if pos >= self.entries.len() {
+            self.entries.resize(pos + 1, Entry::default());
         }
 
         {
-            let entry = &mut self.entries[usize::try_from(rel_idx).unwrap()];
+            let entry = &mut self.entries[pos];
 
-            self.sz -= entry.sz;
-            entry.sz = sz;
-            self.sz += sz;
+            self.size -= entry.size;
+            entry.size = size;
+            self.size += size;
 
             if entry.ptr.is_null() {
-                entry.ptr = self.list.push_head(rel_idx);
+                entry.ptr = self.list.push_head(Item::try_from(pos).unwrap());
             } else {
                 entry.ptr = self.list.promote(entry.ptr);
             }
         }
 
         let mut to_evict = vec![];
-        while self.sz > self.capacity {
+        while self.size > self.capacity {
             if self.list.len() == 1 {
                 // don't evict what we just added
                 break;
             }
 
             let min_pid = self.list.pop_tail().unwrap();
-            self.entries[usize::try_from(min_pid).unwrap()].ptr =
-                ptr::null_mut();
+            let min_pid_idx = safe_usize(min_pid);
+
+            self.entries[min_pid_idx].ptr = ptr::null_mut();
 
             to_evict.push(min_pid);
 
-            self.sz -= self.entries[usize::try_from(min_pid).unwrap()].sz;
-            self.entries[usize::try_from(min_pid).unwrap()].sz = 0;
+            self.size -= self.entries[min_pid_idx].size;
+            self.entries[min_pid_idx].size = 0;
         }
 
         to_evict
     }
+}
+
+#[inline]
+fn safe_usize(value: Item) -> usize {
+    usize::try_from(value).unwrap()
 }

--- a/crates/pagecache/src/ds/mod.rs
+++ b/crates/pagecache/src/ds/mod.rs
@@ -1,12 +1,10 @@
-use super::*;
-
 mod dll;
 mod lru;
 mod pagetable;
 mod stack;
 mod vecset;
 
-pub use self::dll::Dll;
+pub use self::dll::{DoublyLinkedList, Item};
 pub use self::lru::Lru;
 pub use self::pagetable::{PageTable, PAGETABLE_NODE_SZ};
 pub use self::stack::{node_from_frag_vec, Node, Stack, StackIter};

--- a/crates/pagecache/src/ds/vecset.rs
+++ b/crates/pagecache/src/ds/vecset.rs
@@ -1,4 +1,4 @@
-use super::*;
+use serde::{Serialize, Deserialize};
 
 /// A set built on top of `Vec` and binary search,
 /// for use when calling `nth` to iterate over a set

--- a/crates/sled/src/data.rs
+++ b/crates/sled/src/data.rs
@@ -64,7 +64,6 @@ impl Data {
             }
         }
     }
-
     pub(crate) fn receive_merge(
         &mut self,
         old_prefix: &[u8],

--- a/crates/sled/src/iter.rs
+++ b/crates/sled/src/iter.rs
@@ -95,14 +95,14 @@ impl<'a> Iterator for Iter<'a> {
         let guard = unsafe { &*g_ptr as &'a Guard };
 
         let (mut pid, mut node) =
-            match (self.going_forward, self.cached_node.take()) {
-                (true, Some((pid, node))) => (pid, node),
-                _ => {
-                    let view = iter_try!(self
-                        .tree
-                        .node_for_key(self.low_key(), guard));
-                    (view.pid, view.node)
-                }
+            if let (true, Some((pid, node))) =
+                (self.going_forward, self.cached_node.take()) {
+                (pid, node)
+            } else {
+                let view = iter_try!(self
+                    .tree
+                    .node_for_key(self.low_key(), guard));
+                (view.pid, view.node)
             };
 
         for _ in 0..MAX_LOOPS {
@@ -178,14 +178,14 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
         let guard = unsafe { &*g_ptr as &'a Guard };
 
         let (mut pid, mut node) =
-            match (self.going_forward, self.cached_node.take()) {
-                (false, Some((pid, node))) => (pid, node),
-                _ => {
-                    let view = iter_try!(self
-                        .tree
-                        .node_for_key(self.high_key(), guard));
-                    (view.pid, view.node)
-                }
+            if let (false, Some((pid, node))) =
+                (self.going_forward, self.cached_node.take()) {
+                (pid, node)
+            } else {
+                let view = iter_try!(self
+                    .tree
+                    .node_for_key(self.high_key(), guard));
+                (view.pid, view.node)
             };
 
         for _ in 0..MAX_LOOPS {

--- a/crates/sled/src/lib.rs
+++ b/crates/sled/src/lib.rs
@@ -58,10 +58,11 @@
 //!
 //! // Atomic compare-and-swap.
 //! t.cas(
-//!     b"yo!",       // key
-//!     Some(b"v1"),  // old value, None for not present
-//!     Some(b"v2"),  // new value, None for delete
-//! ).unwrap();
+//!     b"yo!",      // key
+//!     Some(b"v1"), // old value, None for not present
+//!     Some(b"v2"), // new value, None for delete
+//! )
+//! .unwrap();
 //!
 //! // Iterates over key-value pairs, starting at the given key.
 //! let scan_key: &[u8] = b"a non-present key before yo!";
@@ -131,8 +132,8 @@ use {
     },
     log::{debug, error, trace},
     pagecache::{
-        debug_delay, pin, threadpool, Materializer, Measure, PageCache, PageId,
-        RecoveryGuard, M,
+        debug::debug_delay, pin, threadpool, Materializer, Measure, PageCache,
+        PageId, RecoveryGuard, M,
     },
     serde::{Deserialize, Serialize},
 };

--- a/crates/sled/src/tree.rs
+++ b/crates/sled/src/tree.rs
@@ -319,10 +319,10 @@ impl Tree {
 
         let View { node, .. } = self.node_for_key(key.as_ref(), &guard)?;
 
-        let kv_opt = node.leaf_pair_for_key(key.as_ref());
-        let v_opt = kv_opt.map(|kv| kv.1.clone());
+        let pair = node.leaf_pair_for_key(key.as_ref());
+        let val = pair.map(|kv| kv.1.clone());
 
-        Ok(v_opt)
+        Ok(val)
     }
 
     #[doc(hidden)]

--- a/crates/sled/src/tx.rs
+++ b/crates/sled/src/tx.rs
@@ -204,7 +204,7 @@ impl<'a> TransactionalTrees<'a> {
         tree_idxs.sort_unstable();
 
         let mut last_idx = usize::max_value();
-        for (_, idx) in tree_idxs.into_iter() {
+        for (_, idx) in tree_idxs {
             if idx == last_idx {
                 // prevents us from double-locking
                 continue;

--- a/tests/check_cross_build.sh
+++ b/tests/check_cross_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eo pipefail
+echo "cross build"
+echo "https://github.com/rust-lang/cargo/issues/4753"
+crates="sled pagecache"
+targets="aarch64-fuchsia aarch64-linux-android"
+targets="$targets i686-linux-android i686-unknown-linux-gnu"
+targets="$targets x86_64-pc-windows-gnu x86_64-linux-android x86_64-fuchsia"
+for crate in $crates; do
+for target in $targets; do
+  pushd crates/$crate
+  echo "setting up $target..."
+  rustup target add $target
+  echo "checking $target..."
+  cargo check --target $target
+  popd
+done
+done

--- a/tests/src/tree.rs
+++ b/tests/src/tree.rs
@@ -72,6 +72,10 @@ pub fn fuzz_then_shrink(buf: &[u8]) {
 }
 
 impl Arbitrary for Key {
+    #![allow(clippy::cast_possible_truncation)]
+    #![allow(clippy::cast_precision_loss)]
+    #![allow(clippy::cast_sign_loss)]
+
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         if g.gen::<bool>() {
             let gs = g.size();


### PR DESCRIPTION
https://github.com/spacejam/sled/issues/760

- fixed some clippy for `ds` mod
- fixed cycle dependency for `ds` mod
- make some ds mod structs names easier
- simplify some code
- removed Node{1,2} drop code dup
- remove PageId abstraction leak to the DLL, LRU
- used inlined `safe_usize` helper instead of `usize::try_from.unwrap`
- add a script that helps to check cross-compilation locally
- split_fanout made more natural to the target types and moved closer to the traversal