### PR TITLE
Flush operation in failpoint tests

### DIFF
--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -170,7 +170,8 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 // make sure the tree value is in there
                 while let Some((ref_key, ref_expected)) = ref_iter.next() {
                     match ref_expected {
-                        Expected::Certain(_ref_value) => {
+                        Expected::Certain(None) => continue,
+                        Expected::Certain(Some(_ref_value)) => {
                             // tree MUST match reference if we have a certain reference
                             if t != ref_key {
                                 println!(

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -291,19 +291,6 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
 
                 fp_crash!(tree.insert(&[hi, lo], val));
 
-                // make sure we keep the disk and reference in-sync
-                // maybe in the future put pending things in their own
-                // reference and have a Flush op that syncs them.
-                // just because the set above didn't hit a failpoint,
-                // it doesn't mean this flush won't hit one, so we
-                // also use the fp_crash macro here for handling it.
-                fp_crash!(tree.flush());
-
-                // now we should be certain the thing is in there, overwrite
-                // with certain
-                reference
-                    .insert(set_counter, Expected::Certain(Some(set_counter)));
-
                 set_counter += 1;
             }
             Del(k) => {
@@ -325,10 +312,6 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     .or_insert(Expected::Certain(None));
 
                 fp_crash!(tree.remove(&*vec![0, k]));
-                fp_crash!(tree.flush());
-
-                // now certain, remove it from the reference
-                reference.remove(&u16::from(k));
             }
             Id => {
                 let id = fp_crash!(tree.generate_id());

--- a/tests/tests/test_tree_failpoints.rs
+++ b/tests/tests/test_tree_failpoints.rs
@@ -249,7 +249,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     vec![hi, lo]
                 };
 
-                // insert false certainty until it fully completes
+                // insert uncertain value until it fully completes
                 reference
                     .entry(set_counter)
                     .and_modify(|v| {
@@ -283,15 +283,15 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 // also use the fp_crash macro here for handling it.
                 fp_crash!(tree.flush());
 
-                // now we should be certain the thing is in there, set certainty
-                // to true
+                // now we should be certain the thing is in there, overwrite
+                // with certain
                 reference
                     .insert(set_counter, Expected::Certain(Some(set_counter)));
 
                 set_counter += 1;
             }
             Del(k) => {
-                // insert false certainty before completes
+                // insert uncertain before it completes
                 reference
                     .entry(u16::from(k))
                     .and_modify(|v| {
@@ -315,6 +315,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 fp_crash!(tree.remove(&*vec![0, k]));
                 fp_crash!(tree.flush());
 
+                // now certain, remove it from the reference
                 reference.remove(&u16::from(k));
             }
             Id => {


### PR DESCRIPTION
This PR adds a separate Flush operation to the `test_tree_failpoints.rs` quickcheck tests. The idea for this was in one of the comments in the file. The reference data structure no longer holds a `(u16, bool)` indicating the last value, and whether it's certain or not, rather, it now it holds a `Vec<Option<u16>>` of possible values. The Set and Del operations add to the list of possible values, while the new Flush operation discards all but the last possible value.

I didn't discover any new bugs with this change. I'd welcome input on the probability distribution in `Op::arbitrary`. BTW, feel free to squash this PR, it was a real garden path, and I committed frequently along the way.