### PR TITLE
further code improvements related to basic db primitives naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Breaking Changes
 
+* The `io_buf_size` renamed to the `segment_size`.
 * The `io_buf_size` method has been removed from
   ConfigBuilder. This can be manually set by setting
   the attribute directly on the ConfigBuilder, but

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -24,34 +24,34 @@
 
 use std::collections::HashMap;
 
+use crate::pagecache::{DiskPtr, LogOffset, Lsn};
 use crate::*;
-use crate::pagecache::{LogId, DiskPtr, Lsn};
 
 /// A thing that happens at a certain time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum Event {
     SegmentAllocate {
         lsn: Lsn,
-        lid: LogId,
+        lid: LogOffset,
     },
     SegmentFree {
         lsn: Lsn,
-        lid: LogId,
+        lid: LogOffset,
     },
     SegmentZero {
         lsn: Lsn,
-        lid: LogId,
+        lid: LogOffset,
     },
     Replace {
         pid: PageId,
         lsn: Lsn,
-        lid: LogId,
-        old_lids: Vec<LogId>,
+        lid: LogOffset,
+        old_lids: Vec<LogOffset>,
     },
     Link {
         pid: PageId,
         lsn: Lsn,
-        lid: LogId,
+        lid: LogOffset,
     },
     PagesBeforeRestart {
         pages: HashMap<PageId, Vec<DiskPtr>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub use {
                 MAX_SPACE_AMPLIFICATION, MINIMUM_ITEMS_PER_SEGMENT,
                 MSG_HEADER_LEN, SEG_HEADER_LEN,
             },
-            DiskPtr, Log, LogId, LogKind, LogRead, Lsn, Materializer,
+            DiskPtr, Log, LogKind, LogOffset, LogRead, Lsn, Materializer,
             PageCache, PageId, SegmentMode,
         },
         pagetable::PAGETABLE_NODE_SZ,

--- a/src/pagecache/diskptr.rs
+++ b/src/pagecache/diskptr.rs
@@ -1,5 +1,5 @@
+use super::{BlobPointer, LogOffset};
 use crate::*;
-use super::{LogId, BlobPointer};
 
 /// A pointer to a location on disk or an off-log blob.
 #[derive(
@@ -7,17 +7,17 @@ use super::{LogId, BlobPointer};
 )]
 pub enum DiskPtr {
     /// Points to a value stored in the single-file log.
-    Inline(LogId),
+    Inline(LogOffset),
     /// Points to a value stored off-log in the blob directory.
-    Blob(LogId, BlobPointer),
+    Blob(LogOffset, BlobPointer),
 }
 
 impl DiskPtr {
-    pub(crate) fn new_inline(l: LogId) -> Self {
+    pub(crate) fn new_inline(l: LogOffset) -> Self {
         DiskPtr::Inline(l)
     }
 
-    pub(crate) fn new_blob(lid: LogId, ptr: BlobPointer) -> Self {
+    pub(crate) fn new_blob(lid: LogOffset, ptr: BlobPointer) -> Self {
         DiskPtr::Blob(lid, ptr)
     }
 
@@ -35,7 +35,7 @@ impl DiskPtr {
         }
     }
 
-    pub(crate) fn blob(&self) -> (LogId, BlobPointer) {
+    pub(crate) fn blob(&self) -> (LogOffset, BlobPointer) {
         match self {
             DiskPtr::Blob(lid, ptr) => (*lid, *ptr),
             DiskPtr::Inline(_) => {
@@ -45,7 +45,7 @@ impl DiskPtr {
     }
 
     #[doc(hidden)]
-    pub fn lid(&self) -> LogId {
+    pub fn lid(&self) -> LogOffset {
         match self {
             DiskPtr::Blob(lid, _) | DiskPtr::Inline(lid) => *lid,
         }

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -59,19 +59,19 @@ pub use self::{
     segment::SegmentMode,
 };
 
-/// A segment id == Segment.LogOffset / Config.SegmentSize.
+/// The offset of a segment. This equals its LogOffset (or the offset of any
+/// item contained inside it) divided by the configured segment_size.
 pub type SegmentId = usize;
 
-/// An offset in the file storage sometimes called LogId (lid).
+/// A file offset in the database log.
 pub type LogOffset = u64;
 
 /// A pointer to an blob blob.
 pub type BlobPointer = Lsn;
 
-/// A logical sequence number of a log entry ==
-/// aligned log entry LogOffset ==
-/// Segment.LogOffset & ~SegmentSize
-/// Represent an Id of a log segment.
+/// A logical sequence number of a log entry.
+/// A segment lsn equals to an aligned LogOffset that is
+/// Segment.LogOffset & ~SegmentSize.
 pub type Lsn = i64;
 
 /// A page identifier.

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -59,16 +59,19 @@ pub use self::{
     segment::SegmentMode,
 };
 
-/// An offset for a storage file segment.
+/// A segment id == Segment.LogOffset / Config.SegmentSize.
 pub type SegmentId = usize;
 
-/// A log file offset.
-pub type LogId = u64;
+/// An offset in the file storage sometimes called LogId (lid).
+pub type LogOffset = u64;
 
 /// A pointer to an blob blob.
 pub type BlobPointer = Lsn;
 
-/// A logical sequence number.
+/// A logical sequence number of a log entry ==
+/// aligned log entry LogOffset ==
+/// Segment.LogOffset & ~SegmentSize
+/// Represent an Id of a log segment.
 pub type Lsn = i64;
 
 /// A page identifier.

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -69,9 +69,7 @@ pub type LogOffset = u64;
 /// A pointer to an blob blob.
 pub type BlobPointer = Lsn;
 
-/// A logical sequence number of a log entry.
-/// A segment lsn equals to an aligned LogOffset that is
-/// Segment.LogOffset & ~SegmentSize.
+/// The logical sequence number of an item in the database log.
 pub type Lsn = i64;
 
 /// A page identifier.

--- a/src/pagecache/pagecache.rs
+++ b/src/pagecache/pagecache.rs
@@ -311,7 +311,7 @@ where
                 was_recovered = false;
 
                 let config_update = Update::Config(PersistedConfig {
-                    io_buf_size: config.io_buf_size,
+                    segment_size: config.segment_size,
                     use_compression: config.use_compression,
                     version: config.version,
                 });
@@ -677,8 +677,8 @@ where
                     assert_ne!(previous_head_lsn, 0);
 
                     let previous_lsn_segment =
-                        previous_head_lsn / self.config.io_buf_size as i64;
-                    let new_lsn_segment = lsn / self.config.io_buf_size as i64;
+                        previous_head_lsn / self.config.segment_size as i64;
+                    let new_lsn_segment = lsn / self.config.segment_size as i64;
 
                     let to_clean = if previous_lsn_segment == new_lsn_segment {
                         // can skip mark_link because we've
@@ -907,7 +907,7 @@ where
     pub fn space_amplification(&self) -> Result<f64> {
         let on_disk_bytes = self.size_on_disk()? as f64;
         let logical_size = self.logical_size_of_all_pages()? as f64;
-        let discount = self.config.io_buf_size as f64 * 8.;
+        let discount = self.config.segment_size as f64 * 8.;
 
         Ok(on_disk_bytes / (logical_size + discount))
     }
@@ -1704,7 +1704,7 @@ where
             iobufs.with_sa(SegmentAccountant::pause_rewriting);
 
             let last_lsn = last_snapshot.last_lsn;
-            let start_lsn = last_lsn - (last_lsn % config.io_buf_size as Lsn);
+            let start_lsn = last_lsn - (last_lsn % config.segment_size as Lsn);
 
             let iter = iobufs.iter_from(start_lsn);
 

--- a/src/pagecache/reservation.rs
+++ b/src/pagecache/reservation.rs
@@ -46,7 +46,7 @@ impl<'a> Reservation<'a> {
     }
 
     /// Get the log file offset for reading this buffer in the future.
-    pub fn lid(&self) -> LogId {
+    pub fn lid(&self) -> LogOffset {
         self.ptr.lid()
     }
 

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -4,8 +4,8 @@ use zstd::block::{compress, decompress};
 use crate::*;
 
 use super::{
-    arr_to_u32, raw_segment_iter_from, u32_to_arr, u64_to_arr, DiskPtr, LogId,
-    LogIter, LogKind, Lsn, MSG_HEADER_LEN,
+    arr_to_u32, raw_segment_iter_from, u32_to_arr, u64_to_arr, DiskPtr,
+    LogIter, LogKind, LogOffset, Lsn, MSG_HEADER_LEN,
 };
 
 /// A snapshot of the state required to quickly restart
@@ -15,7 +15,7 @@ pub struct Snapshot {
     /// The last read message lsn
     pub last_lsn: Lsn,
     /// The last read message lid
-    pub last_lid: LogId,
+    pub last_lid: LogOffset,
     /// the mapping from pages to (lsn, lid)
     pub pt: FastMap8<PageId, PageState>,
     /// The highest stable offset persisted

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -217,7 +217,7 @@ fn run_without_snapshot(dir: &str) {
         .path(dir.to_string())
         .snapshot_after_ops(1 << 56);
 
-    config_builder.io_buf_size = 1024;
+    config_builder.segment_size = 1024;
 
     let config = config_builder.build();
 
@@ -237,7 +237,7 @@ fn run_with_snapshot(dir: &str) {
         .path(dir.to_string())
         .snapshot_after_ops(5000);
 
-    config_builder.io_buf_size = 1024;
+    config_builder.segment_size = 1024;
 
     let config = config_builder.build();
 
@@ -257,7 +257,7 @@ fn run_batches_without_snapshot(dir: &str) {
         .path(dir.to_string())
         .snapshot_after_ops(1 << 56);
 
-    config_builder.io_buf_size = 1024;
+    config_builder.segment_size = 1024;
 
     let config = config_builder.build();
 
@@ -277,7 +277,7 @@ fn run_batches_with_snapshot(dir: &str) {
         .path(dir.to_string())
         .snapshot_after_ops(5000);
 
-    config_builder.io_buf_size = 1024;
+    config_builder.segment_size = 1024;
 
     let config = config_builder.build();
 

--- a/tests/test_pagecache.rs
+++ b/tests/test_pagecache.rs
@@ -53,7 +53,7 @@ fn pagecache_monotonic_idgen() {
         .flush_every_ms(None)
         .snapshot_after_ops(1_000_000);
 
-    config_builder.io_buf_size = 16384;
+    config_builder.segment_size = 16384;
 
     let config = config_builder.build();
 
@@ -83,7 +83,7 @@ fn pagecache_caching() {
         .flush_every_ms(None)
         .snapshot_after_ops(1_000_000);
 
-    config_builder.io_buf_size = 16384;
+    config_builder.segment_size = 16384;
 
     let config = config_builder.build();
 
@@ -120,7 +120,7 @@ fn concurrent_pagecache() -> sled::Result<()> {
         .flush_every_ms(Some(10))
         .snapshot_after_ops(100_000_000);
 
-    config_builder.io_buf_size = 256;
+    config_builder.segment_size = 256;
 
     let config = config_builder.build();
 
@@ -241,7 +241,7 @@ fn pagecache_strange_crash_1() {
         .flush_every_ms(None)
         .snapshot_after_ops(1_000_000);
 
-    config_builder.io_buf_size = 16384;
+    config_builder.segment_size = 16384;
 
     let config = config_builder.build();
 
@@ -282,7 +282,7 @@ fn pagecache_strange_crash_2() {
             .flush_every_ms(None)
             .snapshot_after_ops(1_000_000);
 
-        config_builder.io_buf_size = 16384;
+        config_builder.segment_size = 16384;
 
         let config = config_builder.build();
 
@@ -321,7 +321,7 @@ fn basic_pagecache_recovery() {
     let mut config_builder =
         ConfigBuilder::new().temporary(true).flush_every_ms(None);
 
-    config_builder.io_buf_size = 1024;
+    config_builder.segment_size = 1024;
 
     let config = config_builder.build();
 
@@ -438,7 +438,7 @@ fn prop_pagecache_works(ops: Vec<Op>, flusher: bool) -> bool {
         .flush_every_ms(if flusher { Some(1) } else { None })
         .cache_capacity(256);
 
-    config_builder.io_buf_size = 1024;
+    config_builder.segment_size = 1024;
 
     let config = config_builder.build();
 

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -38,7 +38,7 @@ fn concurrent_tree_ops() {
             .temporary(true)
             .flush_every_ms(None)
             .snapshot_after_ops(100_000_000);
-        config_builder.io_buf_size = 256;
+        config_builder.segment_size = 256;
 
         let config = config_builder.build();
 
@@ -682,7 +682,7 @@ fn recover_tree() {
         .temporary(true)
         .flush_every_ms(None)
         .snapshot_after_ops(N_PER_THREAD as u64);
-    config_builder.io_buf_size = 4096;
+    config_builder.segment_size = 4096;
 
     let config = config_builder.build();
 

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -125,7 +125,7 @@ fn prop_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
 fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
     common::setup_logger();
 
-    let io_buf_size = 256;
+    let segment_size = 256;
 
     let mut config_builder = ConfigBuilder::new()
         .temporary(true)
@@ -134,7 +134,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
         .cache_capacity(256)
         .idgen_persist_interval(1);
 
-    config_builder.io_buf_size = io_buf_size;
+    config_builder.segment_size = segment_size;
 
     let config = config_builder.build();
 
@@ -262,7 +262,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     let mut val = vec![hi, lo];
                     val.extend(vec![
                         lo;
-                        hi as usize * io_buf_size / 4
+                        hi as usize * segment_size / 4
                             * set_counter as usize
                     ]);
                     val

--- a/tests/tree/mod.rs
+++ b/tests/tree/mod.rs
@@ -211,7 +211,7 @@ pub fn prop_tree_matches_btreemap(
         .cache_capacity(256)
         .idgen_persist_interval(1);
 
-    config_builder.io_buf_size = 8192;
+    config_builder.segment_size = 8192;
 
     let config = config_builder.build();
 


### PR DESCRIPTION
- LogOffset makes code much much more readable and easier to understand
- because it now always divides the LSN or OFFSET by the SegmentSize