### PR TITLE
new cas error and cas renamed to compare_and_swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Breaking Changes
 
+* The `cas` is deprecated in favor of `compare_and_swap`.
 * The `io_buf_size` renamed to the `segment_size`.
 * The `io_buf_size` method has been removed from
   ConfigBuilder. This can be manually set by setting

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ assert_eq!(iter.next(), None);
 tree.remove(&k);
 
 // compare and swap
-tree.cas(k, Some(v1), Some(v2));
+tree.compare_and_swap(k, Some(v1), Some(v2));
 
 // block until all operations are stable on disk
 // (flush_async also available to get a Future)
@@ -59,7 +59,7 @@ what's the trade-off? sled uses too much disk space sometimes. this will improve
 
 * [API](https://docs.rs/sled) similar to a threadsafe `BTreeMap<Vec<u8>, Vec<u8>>`
 * fully serializable multi-key and multi-Tree [transactions](https://docs.rs/sled/latest/sled/struct.Tree.html#method.transaction)
-* fully atomic single-key operations, supports [compare and swap](https://docs.rs/sled/latest/sled/struct.Tree.html#method.cas)
+* fully atomic single-key operations, supports [compare and swap](https://docs.rs/sled/latest/sled/struct.Tree.html#method.compare_and_swap)
 * zero-copy reads
 * [write batch support](https://docs.rs/sled/latest/sled/struct.Tree.html#method.batch)
 * [subscription/watch semantics on key prefixes](https://github.com/spacejam/sled/wiki/reactive-semantics)

--- a/benchmarks/stress2/src/main.rs
+++ b/benchmarks/stress2/src/main.rs
@@ -168,8 +168,10 @@ fn run(tree: Arc<sled::Db>, shutdown: Arc<AtomicBool>) {
                     None
                 };
 
-                if let Err(e) = tree.cas(&key, old, new) {
-                    panic!("operational error: {:?}", e);
+                match tree.compare_and_swap(&key, old, new) {
+                    Ok(_) => {}
+                    Err(sled::Error::CompareAndSwap { .. }) => {}
+                    Err(e) => panic!("operational error: {:?}", e),
                 }
             }
             v if v > cas_max && v <= merge_max => {

--- a/bindings/python/rsdb.py
+++ b/bindings/python/rsdb.py
@@ -94,7 +94,8 @@ class Tree:
         if new is None:
             new = b""
 
-        success = sled.sled_cas(self.ptr, key,
+        success = sled.sled_compare_and_swap(
+                                self.ptr, key,
                                 len(key),
                                 old, len(old),
                                 new, len(new),

--- a/bindings/sled-native/Cargo.toml
+++ b/bindings/sled-native/Cargo.toml
@@ -14,5 +14,5 @@ name = "sled_native"
 crate-type = ["dylib"]
 
 [dependencies]
-libc = "0.2"
-sled = {version = "0.15.4", path = "../../crates/sled"}
+libc = "0.2.62"
+sled = {version = "0.28.0", path = "../.."}

--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -16,7 +16,7 @@ fn basic() -> Result<()> {
     assert_eq!(db.get(&k).unwrap().unwrap(), (v1.clone()));
 
     // compare and swap
-    match db.cas(k.clone(), Some(&v1.clone()), Some(v2.clone()))? {
+    match db.compare_and_swap(k.clone(), Some(&v1.clone()), Some(v2.clone()))? {
         Ok(()) => println!("it worked!"),
         Err(actual) => println!("the actual current value is {:?}", actual),
     }

--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -16,9 +16,12 @@ fn basic() -> Result<()> {
     assert_eq!(db.get(&k).unwrap().unwrap(), (v1.clone()));
 
     // compare and swap
-    match db.compare_and_swap(k.clone(), Some(&v1.clone()), Some(v2.clone()))? {
-        Ok(()) => println!("it worked!"),
-        Err(actual) => println!("the actual current value is {:?}", actual),
+    match db.compare_and_swap(k.clone(), Some(&v1.clone()), Some(v2.clone())) {
+        Ok(_) => println!("it worked!"),
+        Err(sled::Error::CompareAndSwap { cur: actual }) => {
+            println!("the actual current value is {:?}", actual)
+        }
+        Err(e) => return Err(e),
     }
 
     // scan forward

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! assert_eq!(&t.get(b"yo!").unwrap().unwrap(), b"v1");
 //!
 //! // Atomic compare-and-swap.
-//! t.cas(
+//! t.compare_and_swap(
 //!     b"yo!",      // key
 //!     Some(b"v1"), // old value, None for not present
 //!     Some(b"v2"), // new value, None for delete

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -50,7 +50,7 @@ impl IntoIterator for &'_ Tree {
 /// assert_eq!(t.get(b"yo!"), Ok(Some(IVec::from(b"v1"))));
 ///
 /// // Atomic compare-and-swap.
-/// t.cas(
+/// t.compare_and_swap(
 ///     b"yo!",      // key
 ///     Some(b"v1"), // old value, None for not present
 ///     Some(b"v2"), // new value, None for delete
@@ -407,6 +407,10 @@ impl Tree {
     /// If both old and new are Some, will modify the value if old is correct.
     /// If Tree is read-only, will do nothing.
     ///
+    /// It will return Unsupported error for the database opened in read-only
+    /// mode. When compare_and_swap fails to update a value it returns a
+    /// CompareAndSwap error with the current value in the tree.
+    ///
     /// # Examples
     ///
     /// ```
@@ -414,21 +418,30 @@ impl Tree {
     /// let t = sled::Db::start(config).unwrap();
     ///
     /// // unique creation
-    /// assert_eq!(t.cas(&[1], None as Option<&[u8]>, Some(&[10])), Ok(Ok(())));
+    /// assert_eq!(
+    ///     t.compare_and_swap(&[1], None as Option<&[u8]>, Some(&[10])),
+    ///     Ok(Ok(()))
+    /// );
     ///
     /// // conditional modification
-    /// assert_eq!(t.cas(&[1], Some(&[10]), Some(&[20])), Ok(Ok(())));
+    /// assert_eq!(
+    ///     t.compare_and_swap(&[1], Some(&[10]), Some(&[20])),
+    ///     Ok(Ok(()))
+    /// );
     ///
     /// // conditional deletion
-    /// assert_eq!(t.cas(&[1], Some(&[20]), None as Option<&[u8]>), Ok(Ok(())));
+    /// assert_eq!(
+    ///     t.compare_and_swap(&[1], Some(&[20]), None as Option<&[u8]>),
+    ///     Ok(Ok(()))
+    /// );
     /// assert_eq!(t.get(&[1]), Ok(None));
     /// ```
-    pub fn cas<K, OV, NV>(
+    pub fn compare_and_swap<K, OV, NV>(
         &self,
         key: K,
         old: Option<OV>,
         new: Option<NV>,
-    ) -> Result<std::result::Result<(), Option<IVec>>>
+    ) -> Result<()>
     where
         K: AsRef<[u8]>,
         OV: AsRef<[u8]>,
@@ -462,7 +475,7 @@ impl Tree {
             };
 
             if !matches {
-                return Ok(Err(current_value));
+                return Err(Error::CompareAndSwap { cur: current_value });
             }
 
             let mut subscriber_reservation = self.subscriptions.reserve(&key);
@@ -485,10 +498,21 @@ impl Tree {
                     res.complete(event);
                 }
 
-                return Ok(Ok(()));
+                return Ok(());
             }
             M.tree_looped();
         }
+    }
+
+    #[deprecated(since = "0.28.1", note = "replaced with compare_and_swap")]
+    #[doc(hidden)]
+    pub fn cas<K, OV, NV>(
+        &self,
+        _key: K,
+        _old: Option<OV>,
+        _new: Option<NV>,
+    ) -> Result<std::result::Result<(), Option<IVec>>> {
+        unimplemented!("cas method is deprecated. use compare_and_swap.");
     }
 
     /// Fetch the value, apply a function to it and return the result.
@@ -550,9 +574,12 @@ impl Tree {
         loop {
             let tmp = current.as_ref().map(AsRef::as_ref);
             let next = f(tmp).map(IVec::from);
-            match self.cas::<_, _, IVec>(key, tmp, next.clone())? {
-                Ok(()) => return Ok(next),
-                Err(new_current) => current = new_current,
+            match self.compare_and_swap::<_, _, IVec>(key, tmp, next.clone()) {
+                Ok(_) => return Ok(next),
+                Err(Error::CompareAndSwap { cur: new_current }) => {
+                    current = new_current;
+                }
+                Err(e) => return Err(e),
             }
         }
     }
@@ -615,9 +642,12 @@ impl Tree {
         loop {
             let tmp = current.as_ref().map(AsRef::as_ref);
             let next = f(tmp);
-            match self.cas(key, tmp, next)? {
+            match self.compare_and_swap(key, tmp, next) {
                 Ok(()) => return Ok(current),
-                Err(new_current) => current = new_current,
+                Err(Error::CompareAndSwap { cur: new_current }) => {
+                    current = new_current;
+                }
+                Err(err) => return Err(err),
             }
         }
     }
@@ -1182,7 +1212,11 @@ impl Tree {
             if let Some(first_res) = self.iter().next_back() {
                 let first = first_res?;
                 if self
-                    .cas::<_, _, &[u8]>(&first.0, Some(&first.1), None)
+                    .compare_and_swap::<_, _, &[u8]>(
+                        &first.0,
+                        Some(&first.1),
+                        None,
+                    )
                     .is_ok()
                 {
                     return Ok(Some(first));
@@ -1223,7 +1257,11 @@ impl Tree {
             if let Some(first_res) = self.iter().next() {
                 let first = first_res?;
                 if self
-                    .cas::<_, _, &[u8]>(&first.0, Some(&first.1), None)
+                    .compare_and_swap::<_, _, &[u8]>(
+                        &first.0,
+                        Some(&first.1),
+                        None,
+                    )
                     .is_ok()
                 {
                     return Ok(Some(first));

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -123,7 +123,7 @@ fn concurrent_tree_ops() {
             let k1 = k.clone();
             let mut k2 = k.clone();
             k2.reverse();
-            tree.cas(&k1, Some(&*k1), Some(k2)).unwrap().unwrap();
+            tree.compare_and_swap(&k1, Some(&*k1), Some(k2)).unwrap();
         }};
 
         drop(t);


### PR DESCRIPTION
this is impl of https://github.com/spacejam/sled/issues/820

@spacejam do you have an idea of how to raise a compile error only when someone calls `cas`?