### PR TITLE
Macro, impl Transactional on more tuples of trees

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -344,18 +344,6 @@ macro_rules! repeat_type {
     };
 }
 
-macro_rules! expr {
-    ($x:expr) => {
-        ($x)
-    };
-}
-
-macro_rules! tuple_index {
-    ($tuple:expr, $idx:tt) => {
-        expr!($tuple.$idx)
-    };
-}
-
 macro_rules! impl_transactional_tuple_trees {
     ($($indices:tt),+) => {
         impl Transactional for repeat_type!(&Tree, ($($indices),+)) {
@@ -366,7 +354,7 @@ macro_rules! impl_transactional_tuple_trees {
                     inner: vec![
                         $(
                             TransactionalTree {
-                                tree: tuple_index!(self, $indices).clone(),
+                                tree: self.$indices.clone(),
                                 writes: Default::default(),
                                 read_cache: Default::default(),
                             }


### PR DESCRIPTION
This is parallel to #858, but uses a macro to implement Transactional on tuples of two to ten trees. The design of the macro was largely driven by the syntax for indexing into tuples, which requires literals. As such, the main macro takes sequential numbers as arguments. The `repeat_type!` macro uses recursion to turn the list of numbers into a list of a type, repeated that many times. This is used to define the tuple for which the trait is implemented, as well as the `View` associated type.