### PR TITLE
recovery refactor and debugging. closes #851. closes #860.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,9 @@ opt-level = 3
 
 [features]
 default = ["no_metrics"]
-testing = ["lock_free_delays", "check_snapshot_integrity", "compression", "failpoints"]
+testing = ["event_log", "lock_free_delays", "compression", "failpoints"]
 compression = ["zstd"]
 lock_free_delays = ["rand", "rand_chacha", "rand_distr", "parking_lot/deadlock_detection"]
-check_snapshot_integrity = []
 failpoints = ["fail", "rand", "fail/failpoints"]
 event_log = []
 no_metrics = []

--- a/benchmarks/stress2/Cargo.toml
+++ b/benchmarks/stress2/Cargo.toml
@@ -12,7 +12,7 @@ debug = true
 [features]
 default = []
 lock_free_delays = ["sled/lock_free_delays"]
-check_snapshot_integrity = ["sled/check_snapshot_integrity"]
+event_log = ["sled/event_log"]
 compression = ["sled/compression"]
 no_logs = ["sled/no_logs"]
 no_metrics = ["sled/no_metrics"]

--- a/src/context.rs
+++ b/src/context.rs
@@ -49,15 +49,6 @@ impl Context {
     pub(crate) fn start(config: RunningConfig) -> Result<Self> {
         trace!("starting context");
 
-        #[cfg(any(test, feature = "check_snapshot_integrity"))]
-        match config.verify_snapshot() {
-            #[cfg(not(feature = "failpoints"))]
-            Ok(_) => {}
-            #[cfg(feature = "failpoints")]
-            Ok(_) | Err(Error::FailPoint) => {}
-            other => panic!("failed to verify snapshot: {:?}", other),
-        }
-
         let pagecache = Arc::new(PageCache::start(config.clone())?);
 
         Ok(Self {

--- a/src/db.rs
+++ b/src/db.rs
@@ -115,6 +115,9 @@ impl Db {
 
         drop(tenants);
 
+        #[cfg(feature = "event_log")]
+        ret.context.event_log.verify();
+
         Ok(ret)
     }
 

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -44,6 +44,12 @@ pub struct EventLog {
 }
 
 impl EventLog {
+    pub(crate) fn reset(&self) {
+        self.verify();
+        let guard = pin();
+        while let Some(_) = self.inner.pop(&guard) {}
+    }
+
     fn iter<'a>(&self, guard: &'a Guard) -> StackIter<'a, Event> {
         let head = self.inner.head(guard);
         StackIter::from_ptr(head, guard)

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -63,7 +63,7 @@ pub(crate) struct IoBufs {
 /// `IoBufs` is a set of lock-free buffers for coordinating
 /// writes to underlying storage.
 impl IoBufs {
-    pub fn start(config: RunningConfig, snapshot: Snapshot) -> Result<Self> {
+    pub fn start(config: RunningConfig, snapshot: &Snapshot) -> Result<Self> {
         // open file for writing
         let file = &config.file;
 

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -778,7 +778,7 @@ pub(in crate::pagecache) fn maybe_seal_and_write_iobuf(
             }
         });
 
-        #[cfg(any(test, feature = "check_snapshot_integrity"))]
+        #[cfg(test)]
         _result.unwrap();
 
         Ok(())

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -398,7 +398,7 @@ impl Log {
                 }
             });
 
-            #[cfg(any(test, feature = "check_snapshot_integrity"))]
+            #[cfg(test)]
             _result.unwrap();
 
             Ok(())

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -27,7 +27,7 @@ unsafe impl Send for Log {}
 impl Log {
     /// Start the log, open or create the configured file,
     /// and optionally start the periodic buffer flush thread.
-    pub fn start(config: RunningConfig, snapshot: Snapshot) -> Result<Self> {
+    pub fn start(config: RunningConfig, snapshot: &Snapshot) -> Result<Self> {
         let iobufs = Arc::new(IoBufs::start(config.clone(), snapshot)?);
 
         Ok(Self { iobufs, config })
@@ -41,7 +41,7 @@ impl Log {
         let snapshot =
             super::advance_snapshot(log_iter, Snapshot::default(), &config)?;
 
-        Self::start(config, snapshot)
+        Self::start(config, &snapshot)
     }
 
     /// Flushes any pending IO buffers to disk to ensure durability.

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -461,7 +461,7 @@ impl PageCache {
             inner: PageTable::default(),
             next_pid_to_allocate: AtomicU64::new(0),
             free: Arc::new(Mutex::new(BinaryHeap::new())),
-            log: Log::start(config.clone(), snapshot.clone())?,
+            log: Log::start(config.clone(), &snapshot)?,
             lru,
             updates: AtomicU64::new(0),
             last_snapshot: Arc::new(Mutex::new(Some(snapshot))),

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1992,7 +1992,7 @@ impl PageCache {
             result
         });
 
-        #[cfg(any(test, feature = "check_snapshot_integrity"))]
+        #[cfg(test)]
         _result.unwrap()?;
 
         // TODO add future for waiting on the result of this if desired

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -1185,7 +1185,7 @@ impl SegmentAccountant {
             completer.fill(res);
         });
 
-        #[cfg(any(test, feature = "check_snapshot_integrity"))]
+        #[cfg(test)]
         _result.unwrap();
 
         self.async_truncations.push(promise);

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -90,8 +90,6 @@ pub(crate) struct SegmentAccountant {
     pause_rewriting: bool,
     ordering: BTreeMap<Lsn, LogOffset>,
     async_truncations: Vec<OneShot<Result<()>>>,
-    deferred_free_segments: Option<Vec<LogOffset>>,
-    deferred_free_segments_after: Lsn,
 }
 
 /// A `Segment` holds the bookkeeping information for
@@ -405,8 +403,6 @@ impl SegmentAccountant {
             pause_rewriting: false,
             ordering: BTreeMap::default(),
             async_truncations: Vec::default(),
-            deferred_free_segments: None,
-            deferred_free_segments_after: 0,
         };
 
         if let SegmentMode::Linear = ret.config.segment_mode {
@@ -510,7 +506,6 @@ impl SegmentAccountant {
         let cleanup_threshold =
             (self.config.segment_cleanup_threshold * 100.) as usize;
         let drain_sz = segment_size * 100 / cleanup_threshold;
-        let mut deferred_free_segments = vec![];
 
         for (idx, segment) in segments.iter_mut().enumerate() {
             let segment_base = idx as LogOffset * segment_size as LogOffset;
@@ -528,10 +523,10 @@ impl SegmentAccountant {
                 lsn
             } else {
                 // this segment was not used in the recovered
-                // snapshot, so we need to assume it is
-                // free but written at the current max lsn,
-                // so that we don't accidentally
-                deferred_free_segments.push(segment_base);
+                // snapshot, so we can assume it is free
+                let idx = self.segment_id(segment_base);
+                self.segments[idx].state = Free;
+                self.free_segment(segment_base, false);
                 continue;
             };
 
@@ -551,26 +546,6 @@ impl SegmentAccountant {
                         segment.state = Free;
                         self.free_segment(segment_base, true);
                     }
-
-                    // NB we corrupt the segment header to cause this
-                    // segment to be skipped on subsequent recovery
-                    // attempts, which guarantees that no two segments
-                    // ever contain the same LSN. If we didn't do this,
-                    // we would need to ensure through other means
-                    // that empty segments with a written segment header
-                    // but no other data get reused.
-                    trace!(
-                        "zeroing segment with lid {} during SA initialization",
-                        segment_base
-                    );
-                    maybe_fail!("segment initial free zero");
-                    self.config.file.pwrite_all(
-                        &*vec![MessageKind::Corrupted.into(); SEG_HEADER_LEN],
-                        segment_base,
-                    )?;
-                    if !self.config.temporary {
-                        self.config.file.sync_all()?;
-                    }
                 } else if segment_sizes[idx] <= drain_sz {
                     trace!(
                         "SA draining segment at {} during startup \
@@ -583,17 +558,6 @@ impl SegmentAccountant {
                     self.to_clean.insert(segment_base);
                 }
             }
-        }
-
-        if !deferred_free_segments.is_empty() {
-            trace!(
-                "setting self.deferred_free_segments to {:?} to be \
-                 freed after lsn {}",
-                deferred_free_segments,
-                snapshot.last_lsn,
-            );
-            self.deferred_free_segments = Some(deferred_free_segments);
-            self.deferred_free_segments_after = snapshot.last_lsn;
         }
 
         trace!("initialized self.segments to {:?}", segments);
@@ -885,18 +849,6 @@ impl SegmentAccountant {
             return Ok(());
         }
 
-        if self.deferred_free_segments.is_some()
-            && lsn > self.deferred_free_segments_after
-        {
-            let deferred_free_segments =
-                self.deferred_free_segments.take().unwrap();
-            for segment_base in deferred_free_segments {
-                let idx = self.segment_id(segment_base);
-                self.segments[idx].state = Free;
-                self.free_segment(segment_base, false);
-            }
-        }
-
         let bounds = (
             std::ops::Bound::Excluded(self.max_stabilized_lsn),
             std::ops::Bound::Included(lsn),
@@ -1101,25 +1053,18 @@ impl SegmentAccountant {
 
         self.ordering.insert(lsn, lid);
 
-        // this is the upper limit of overshoot between
-        // the current lsn and the lid of a new segment.
-        // in a stable situation, the system should never
-        // allocate a section of the file that is greater
-        // than the lsn, but this can happen when we have
-        // cautiously skipped a few segments that no longer
-        // contain recent page fragments.
-        let lid_slack = self
-            .deferred_free_segments
-            .as_ref()
-            .map_or(0, |dfs| dfs.len() * self.config.segment_size);
-
         debug!(
             "segment accountant returning offset: {} \
-             paused: {} on deck: {:?} lid_slack: {}",
-            lid, self.pause_rewriting, self.free, lid_slack
+             paused: {} on deck: {:?}",
+            lid, self.pause_rewriting, self.free,
         );
 
-        assert!(lsn + lid_slack as Lsn >= lid as Lsn);
+        assert!(
+            lsn >= lid as Lsn,
+            "lsn {} should always be greater than or equal to lid {}",
+            lsn,
+            lid
+        );
 
         Ok(lid)
     }

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -392,7 +392,7 @@ impl SegmentAccountant {
     /// Create a new SegmentAccountant from previously recovered segments.
     pub(super) fn start(
         config: RunningConfig,
-        snapshot: Snapshot,
+        snapshot: &Snapshot,
     ) -> Result<Self> {
         let mut ret = Self {
             config,
@@ -481,7 +481,7 @@ impl SegmentAccountant {
         Ok((segments, segment_sizes))
     }
 
-    fn initialize_from_snapshot(&mut self, snapshot: Snapshot) -> Result<()> {
+    fn initialize_from_snapshot(&mut self, snapshot: &Snapshot) -> Result<()> {
         let segment_size = self.config.segment_size;
         let (mut segments, segment_sizes) = self.initial_segments(&snapshot)?;
 

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -165,6 +165,9 @@ pub(crate) fn advance_snapshot(
 
     trace!("generated new snapshot: {:?}", snapshot);
 
+    #[cfg(feature = "event_log")]
+    config.event_log.recovered_lsn(snapshot.last_lsn);
+
     Ok(snapshot)
 }
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -109,8 +109,8 @@ impl<T: Clone + Send + Sync + 'static> Stack<T> {
     }
 
     /// Pop the next item off the stack. Returns None if nothing is there.
-    #[cfg(test)]
-    fn pop(&self, guard: &Guard) -> Option<T> {
+    #[cfg(any(test, feature = "event_log"))]
+    pub(crate) fn pop(&self, guard: &Guard) -> Option<T> {
         use std::ptr;
         use std::sync::atomic::Ordering::SeqCst;
         debug_delay();

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -324,7 +324,6 @@ fn test_crash_recovery_no_runtime_snapshot() {
 }
 
 #[test]
-#[ignore]
 fn test_crash_batches_with_runtime_snapshot() {
     let dir = "test_batches_with_snapshot";
     cleanup(dir);
@@ -347,7 +346,6 @@ fn test_crash_batches_with_runtime_snapshot() {
 }
 
 #[test]
-#[ignore]
 fn test_crash_batches_no_runtime_snapshot() {
     let dir = "test_batches";
     cleanup(dir);

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -12,6 +12,7 @@ use rand::Rng;
 
 use sled::Config;
 
+const N_TESTS: usize = 100;
 const CYCLE: usize = 256;
 const BATCH_SIZE: u32 = 8;
 
@@ -282,7 +283,7 @@ fn run_batches_with_snapshot(dir: &str) {
 fn test_crash_recovery_with_runtime_snapshot() {
     let dir = "test_crashes_with_snapshot";
     cleanup(dir);
-    for _ in 0..100 {
+    for _ in 0..N_TESTS {
         let child = unsafe { libc::fork() };
         if child == 0 {
             run_with_snapshot(dir)
@@ -304,7 +305,7 @@ fn test_crash_recovery_with_runtime_snapshot() {
 fn test_crash_recovery_no_runtime_snapshot() {
     let dir = "test_crashes";
     cleanup(dir);
-    for _ in 0..100 {
+    for _ in 0..N_TESTS {
         let child = unsafe { libc::fork() };
         if child == 0 {
             run_without_snapshot(dir)
@@ -327,7 +328,7 @@ fn test_crash_recovery_no_runtime_snapshot() {
 fn test_crash_batches_with_runtime_snapshot() {
     let dir = "test_batches_with_snapshot";
     cleanup(dir);
-    for _ in 0..100 {
+    for _ in 0..N_TESTS {
         let child = unsafe { libc::fork() };
         if child == 0 {
             run_batches_with_snapshot(dir)
@@ -350,7 +351,7 @@ fn test_crash_batches_with_runtime_snapshot() {
 fn test_crash_batches_no_runtime_snapshot() {
     let dir = "test_batches";
     cleanup(dir);
-    for _ in 0..100 {
+    for _ in 0..N_TESTS {
         let child = unsafe { libc::fork() };
         if child == 0 {
             run_batches_without_snapshot(dir)


### PR DESCRIPTION
@divergentdave this makes one of the bugs you hit (#860) unrepresentable by totally ripping out a difficult-to-test and error prone aspect of recovery relating to "dangling segments" that were not immediately freed during recovery. Here, only one part of the code is now responsible for ever zeroing skipped segment headers (parts that were written but there was a gap due to race conditions before their write location so they were past the recovered tip of the log).  Also, we no longer try to test snapshot correctness by deleting the old snapshot and regenerating it. We now consider the snapshot to be an important aspect of system correctness that should not be deleted, because it encodes the previous best known recovered tail of the log. If it is deleted, our only evidence of the previous recovery site is lost. This can be changed over time to just include some sort of "last recovery" log message/special page or something. 

At first I wrote this to directly address #860, but it made me quite happy to learn that by simplifying things and ripping out certain bug-prone areas, it just made the batch bug that you found in #851 go away as well (I believe this is due to deleting the snapshot possibly causing a previous writebatch to fail to be fully recovered. 

However, I believe this is an incomplete sense of security (although the situation may be fine for most people most of the time) because as soon as we support fine-grained locking for transactions and batches we'll have multiple threads writing batches that interleave, and the current recovery situation is unsound if 2 threads can ever interleave their batches. It has taken me a while to realize this but we need to have a batch-aware logging system if we want to increase the transactional concurrency, instead of just writing future locations into the log that it should stop recovery at if that future location isn't present (the current approach, which is incorrect when multiple transactions may piggy-back each other's writebatches down to effectively make 0 segments actually recoverable as long as some of them overlap always, and the last one is cut by a crash). Anyway, this is just a braindump for future work that will drive correctness around concurrent transactions.

To currently break this, I think we just need to have a test that performs writebatches on different trees concurrently. But, I'm quite happy that we have pushed the correctness boundary a bit with this :)