### PR TITLE
Add new `create_new` option to `Config`, allowing the user to specify…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.29.2
+
+## New Features
+
+* The `create_new` option has been added
+  to `Config`, allowing the user to specify
+  that a database should only be freshly
+  created, rather than re-opened.
+
+# 0.29.1
+
+## Bugfixes
+
+* Fixed a bug where prefix encoding could be
+  incorrectly handled when merging nodes together
+
 # 0.29
 
 ## New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.29.1"
+version = "0.29.2"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a modern embedded database"
 license = "MIT/Apache-2.0"

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -244,14 +244,14 @@ fn concurrent_tree_iter() -> Result<()> {
                             loop {
                                 if let Some(Ok(k)) = keys.next() {
                                     assert!(
-                                    &*k >= *expect,
-                                    "witnessed key is {:?} but we expected \
-                                     one >= {:?}, so we overshot due to a \
-                                     concurrent modification\n{:?}",
-                                    k,
-                                    expect,
-                                    *t,
-                                );
+                                        &*k >= *expect,
+                                        "witnessed key is {:?} but we expected \
+                                         one >= {:?}, so we overshot due to a \
+                                         concurrent modification\n{:?}",
+                                        k,
+                                        expect,
+                                        *t,
+                                    );
                                     if &*k == *expect {
                                         break;
                                     }
@@ -706,6 +706,23 @@ fn recover_tree() {
         let k = kv(i as usize);
         assert_eq!(t.get(&*k), Ok(None));
     }
+}
+
+#[test]
+fn create_tree() {
+    common::setup_logger();
+
+    let path = "create_exclusive_db";
+    std::fs::remove_dir_all(path);
+
+    {
+        let config = Config::new().create_new(true).path(path);
+        config.open().unwrap();
+    }
+
+    let config = Config::new().create_new(true).path(path);
+    config.open().unwrap_err();
+    std::fs::remove_dir_all(path);
 }
 
 #[test]


### PR DESCRIPTION
… that a database should only be created for the first time, rather than re-opened. This directly corresponds to the `create_new` option on std::fs::OpenOptions.