### PR TITLE
io_uring: async segment write path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ no_logs = ["log/max_level_off"]
 no_inline = []
 measure_allocs = []
 pretty_backtrace = ["color-backtrace"]
+io_uring = ["liburing"]
 
 [dependencies]
 serde_bytes = "0.11.2"
@@ -45,7 +46,8 @@ rand_distr = { version = "0.2.2", optional = true }
 crc32fast = "1.2.0"
 log = "0.4.8"
 parking_lot = "0.9.0"
-color-backtrace = { version = "0.2.3", optional = true }
+color-backtrace = {version = "0.2.3", optional = true }
+liburing = { version = "0.0.2", optional = true }
 
 [dependencies.serde]
 version = "1.0.101"

--- a/benchmarks/stress2/Cargo.toml
+++ b/benchmarks/stress2/Cargo.toml
@@ -12,6 +12,7 @@ debug = true
 [features]
 default = []
 lock_free_delays = ["sled/lock_free_delays"]
+io_uring = ["sled/io_uring"]
 event_log = ["sled/event_log"]
 compression = ["sled/compression"]
 no_logs = ["sled/no_logs"]

--- a/src/pagecache/io_uring.rs
+++ b/src/pagecache/io_uring.rs
@@ -1,0 +1,244 @@
+#![cfg(all(unix, feature = "io_uring"))]
+
+use libc::off_t;
+use std::convert::TryFrom;
+use std::fs::File;
+use std::io;
+use std::mem;
+use std::os::unix::io::AsRawFd;
+use std::sync::Arc;
+
+use crate::LogOffset;
+use crate::{Error, Result};
+
+use liburing::*;
+
+/// TODO: support for SQPOLL with idle timeout
+pub(crate) struct URing<T> {
+    /// Mutable unsafe FFI struct from liburing::
+    ring: io_uring,
+
+    /// File
+    file: Arc<File>,
+
+    /// IOVec structures that hold information about buffers
+    /// used in SQEs.
+    iovecs: Vec<libc::iovec>,
+
+    /// iovec buffs. this is specifically needed to preserve buf
+    /// ptr lifetime because all write operations are async.
+    buf: Vec<Option<Arc<T>>>,
+
+    /// List of free slots: iovecs, user data, etc.
+    free_slots: Vec<usize>,
+}
+
+/// Pointers can't be passed safely through threads boundaries.
+/// URing must enforce it, yet it is not Sync.
+#[allow(unsafe_code)]
+unsafe impl<T> Send for URing<T> {}
+
+impl<T> URing<T> {
+    /// Create and initialize new io_uring structure with
+    /// `size` queue length and `flags` specified properties.
+    ///
+    /// Available flags from io_uring.h:
+    ///     - IORING_SETUP_IOPOLL	(1U << 0)	/* io_context is polled */
+    ///     - IORING_SETUP_SQPOLL	(1U << 1)	/* SQ poll thread */
+    ///     - IORING_SETUP_SQ_AFF	(1U << 2)	/* sq_thread_cpu is valid */
+    ///     - IORING_SETUP_CQSIZE	(1U << 3)	/* app defines CQ size */
+    pub fn new(
+        file: Arc<File>,
+        size: usize,
+        flags: libc::c_uint,
+    ) -> Result<Self> {
+        if size & 1 != 0 || size < 2 {
+            return Err(Error::Unsupported("invalid queue size".into()));
+        }
+
+        let ring = unsafe {
+            let mut s = mem::MaybeUninit::<io_uring>::uninit();
+            let ret = io_uring_queue_init(
+                u32::try_from(size).unwrap(),
+                s.as_mut_ptr(),
+                flags,
+            );
+            if ret < 0 {
+                return Err(Error::Io(io::Error::from_raw_os_error(ret)));
+            }
+
+            s.assume_init()
+        };
+
+        let mut uring = URing::<T> {
+            ring,
+            file,
+            iovecs: Vec::with_capacity(size),
+            buf: Vec::with_capacity(size),
+            free_slots: Vec::with_capacity(size),
+        };
+
+        unsafe {
+            let ret = io_uring_register_files(
+                &mut uring.ring,
+                [uring.file.as_raw_fd()].as_ptr(),
+                1,
+            );
+            if ret < 0 {
+                return Err(Error::Io(io::Error::from_raw_os_error(ret)));
+            }
+        };
+
+        uring.iovecs.resize(
+            size,
+            libc::iovec { iov_base: std::ptr::null_mut(), iov_len: 0 },
+        );
+        uring.buf.resize(size, None);
+
+        // index free elements
+        for i in 0..size {
+            uring.free_slots.push(i);
+        }
+
+        Ok(uring)
+    }
+
+    unsafe fn drain_cqe(&mut self) -> Result<()> {
+        loop {
+            let mut cqe: *mut io_uring_cqe = std::mem::zeroed();
+            let ret = io_uring_peek_cqe(&mut self.ring, &mut cqe);
+            if ret == -libc::EAGAIN {
+                // peek found nothing, no completions to drain
+                return Ok(());
+            }
+            if ret < 0 {
+                return Err(Error::Io(io::Error::from_raw_os_error(ret)));
+            }
+            let i = (*cqe).user_data as usize;
+            if i < self.free_slots.capacity() {
+                self.free_slots.push(i);
+                // release
+                self.iovecs[i].iov_base = std::ptr::null_mut();
+                self.iovecs[i].iov_len = 0;
+                // drop arc buf
+                self.buf[i] = None;
+            }
+            io_uring_cqe_seen(&mut self.ring, cqe);
+        }
+    }
+
+    pub fn pwrite_all(
+        &mut self,
+        buf: &mut [u8],
+        data: Arc<T>,
+        offset: LogOffset,
+        fsync: bool,
+    ) -> Result<()> {
+        unsafe {
+            // 1. drain completed operations
+            self.drain_cqe()?;
+
+            // it is easier to track queue len if num
+            // of iovecs will be the same as sqes
+            let mut reserve = 1;
+            if fsync {
+                reserve += 1;
+            }
+
+            // 2. reserve SQE slots
+            if self.free_slots.len() < reserve {
+                let ret = io_uring_submit_and_wait(
+                    &mut self.ring,
+                    reserve as libc::c_uint,
+                );
+                if ret < 0 {
+                    return Err(Error::Io(io::Error::from_raw_os_error(ret)));
+                }
+                self.drain_cqe()?;
+                if self.free_slots.len() < reserve {
+                    return Err(Error::Io(io::Error::new(
+                        io::ErrorKind::Other,
+                        "wait for free sqes",
+                    )));
+                }
+            }
+
+            // 3. build write() SQE
+            {
+                let sqe = io_uring_get_sqe(&mut self.ring);
+                if sqe == std::ptr::null_mut() {
+                    return Err(Error::Io(io::Error::new(
+                        io::ErrorKind::Other,
+                        "unexpected lack of sqes",
+                    )));
+                }
+
+                let i = self.free_slots.pop().unwrap();
+                self.buf[i] = Some(data);
+                self.iovecs[i].iov_base =
+                    buf.as_mut_ptr() as *mut std::ffi::c_void;
+                self.iovecs[i].iov_len = buf.len();
+
+                io_uring_prep_writev(
+                    sqe,
+                    self.file.as_raw_fd(),
+                    &mut self.iovecs[i],
+                    1,
+                    offset as off_t,
+                );
+                (*sqe).user_data = u64::try_from(i).unwrap();
+            }
+
+            // 4. build fsync() SQE
+            if fsync {
+                let sqe = io_uring_get_sqe(&mut self.ring);
+                if sqe == std::ptr::null_mut() {
+                    return Err(Error::Io(io::Error::new(
+                        io::ErrorKind::Other,
+                        "unexpected lack of sqes",
+                    )));
+                }
+
+                let i = self.free_slots.pop().unwrap();
+
+                io_uring_prep_fsync(
+                    sqe,
+                    self.file.as_raw_fd(),
+                    IORING_FSYNC_DATASYNC,
+                );
+                io_uring_sqe_set_flags(sqe, IOSQE_IO_DRAIN);
+                (*sqe).user_data = u64::try_from(i).unwrap();
+            }
+
+            // 5. submit
+            let ret = io_uring_submit(&mut self.ring);
+            if ret < 0 {
+                return Err(Error::Io(io::Error::from_raw_os_error(ret)));
+            }
+        };
+
+        Ok(())
+    }
+}
+
+impl<T> Drop for URing<T> {
+    fn drop(&mut self) {
+        unsafe {
+            // flush unfinished ops
+            if self.free_slots.len() < self.iovecs.len() {
+                let ret = io_uring_submit_and_wait(
+                    &mut self.ring,
+                    (self.iovecs.len() - self.free_slots.len()) as u32,
+                );
+                if ret < 0 {
+                    panic!(Error::Io(io::Error::from_raw_os_error(ret)));
+                }
+            }
+
+            self.drain_cqe().unwrap();
+
+            io_uring_unregister_files(&mut self.ring);
+            io_uring_queue_exit(&mut self.ring);
+        };
+    }
+}

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -22,9 +22,6 @@ pub struct Log {
     pub(crate) config: RunningConfig,
 }
 
-#[allow(unsafe_code)]
-unsafe impl Send for Log {}
-
 impl Log {
     /// Start the log, open or create the configured file,
     /// and optionally start the periodic buffer flush thread.
@@ -399,7 +396,7 @@ impl Log {
             let iobufs = self.iobufs.clone();
             let iobuf = iobuf.clone();
             let _result = threadpool::spawn(move || {
-                if let Err(e) = iobufs.write_to_log(&iobuf) {
+                if let Err(e) = iobufs.write_to_log(iobuf) {
                     error!(
                         "hit error while writing iobuf with lsn {}: {:?}",
                         lsn, e

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -6,6 +6,7 @@ pub mod constants;
 pub mod logger;
 
 mod blob_io;
+mod io_uring;
 mod disk_pointer;
 mod iobuf;
 mod iterator;


### PR DESCRIPTION
At least save 1 syscall on the segment write path. Don't wait for fsync.

Implementation:
- separate write uring queue for writes
- writes usually require 2 SQE per write (write+fsync)
- fsyncs are issued with DRAIN and not waited
- URing uses preallocated iovecs structs and keep Arcs for used bufs
- when submit queue exhausts write() will wait for minimum empty slots
- uring is used via my custom binding to liburing similar to https://github.com/sitano/liburing

URing.pwrite_all(buf, data, offset, fsync) implementation is as follows:
- take lock
- drain completion queue to retain free slots
- reserve required number of SQEs
- if not enought SQE stlots, wait (1 syscall), then drain
- build write
- build fsync if needed
- submit

ISSUE: https://github.com/spacejam/sled/issues/571

TODO:
- configuration
- sqpoll support
- CI for io_uring on linux

FUTURE:
- fixed buffers + buffer pool for write path
- SQPOLL?