### PR TITLE
Add better support for zero-allocation serialization

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -587,17 +587,6 @@ impl Default for Data {
 }
 
 impl Data {
-    pub(crate) fn serialized_size(&self) -> usize {
-        match self {
-            Data::Index(ref pointers) => {
-                pointers.iter().map(|(k, _)| 16 + k.len()).sum()
-            }
-            Data::Leaf(ref items) => {
-                items.iter().map(|(k, v)| 16 + k.len() + v.len()).sum()
-            }
-        }
-    }
-
     pub(crate) fn len(&self) -> usize {
         match *self {
             Data::Index(ref pointers) => pointers.len(),

--- a/src/pagecache/io_uring.rs
+++ b/src/pagecache/io_uring.rs
@@ -43,10 +43,10 @@ impl<T> Uring<T> {
     /// `size` queue length and `flags` specified properties.
     ///
     /// Available flags from `io_uring.h`:
-    /// - `IORING_SETUP_IOPOLL`	(1U << 0)  /* `io_context` is polled */
-    /// - `IORING_SETUP_SQPOLL`	(1U << 1)  /* SQ poll thread */
-    /// - `IORING_SETUP_SQ_AFF`	(1U << 2)  /* `sq_thread_cpu` is valid */
-    /// - `IORING_SETUP_CQSIZE`	(1U << 3)  /* app defines CQ size */
+    /// - `IORING_SETUP_IOPOLL` (1U << 0)  /* `io_context` is polled */
+    /// - `IORING_SETUP_SQPOLL` (1U << 1)  /* SQ poll thread */
+    /// - `IORING_SETUP_SQ_AFF` (1U << 2)  /* `sq_thread_cpu` is valid */
+    /// - `IORING_SETUP_CQSIZE` (1U << 3)  /* app defines CQ size */
     pub fn new(
         file: Arc<File>,
         size: usize,

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1798,15 +1798,17 @@ impl PageCache {
 
         let deserialize_latency = Measure::new(&M.deserialize);
         let update_res = match header.kind {
-            Counter => u64::deserialize(&bytes).map(Update::Counter),
+            Counter => {
+                u64::deserialize(&mut bytes.as_slice()).map(Update::Counter)
+            }
             BlobMeta | InlineMeta => {
-                Meta::deserialize(&bytes).map(Update::Meta)
+                Meta::deserialize(&mut bytes.as_slice()).map(Update::Meta)
             }
             BlobLink | InlineLink => {
-                Link::deserialize(&bytes).map(Update::Link)
+                Link::deserialize(&mut bytes.as_slice()).map(Update::Link)
             }
             BlobNode | InlineNode => {
-                Node::deserialize(&bytes).map(Update::Node)
+                Node::deserialize(&mut bytes.as_slice()).map(Update::Node)
             }
             Free => Ok(Update::Free),
             Corrupted | Cancelled | Pad | BatchManifest => {

--- a/src/pagecache/reservation.rs
+++ b/src/pagecache/reservation.rs
@@ -66,7 +66,7 @@ impl<'a> Reservation<'a> {
     }
 
     /// Returns the length of the on-log reservation.
-    pub fn reservation_len(&self) -> usize {
+    pub const fn reservation_len(&self) -> usize {
         self.buf.len()
     }
 

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -270,7 +270,7 @@ fn read_snapshot(config: &RunningConfig) -> std::io::Result<Option<Snapshot>> {
     #[cfg(not(feature = "zstd"))]
     let bytes = buf;
 
-    Ok(Snapshot::deserialize(&*bytes).ok())
+    Ok(Snapshot::deserialize(&mut bytes.as_slice()).ok())
 }
 
 fn write_snapshot(config: &RunningConfig, snapshot: &Snapshot) -> Result<()> {


### PR DESCRIPTION
This moves toward applying optimizations where we can serialize our data directly into a concurrent IO buffer without allocating first.