### PR TITLE
debug failpoints

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2098,7 +2098,7 @@ impl Debug for Tree {
         loop {
             let get_res = self.view_for_pid(pid, &guard);
             let node = if let Ok(Some(ref view)) = get_res {
-                view
+                view.deref()
             } else {
                 error!(
                     "Tree::fmt failed to read node {} \

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -1356,3 +1356,12 @@ fn failpoints_bug_29() {
         false,
     ));
 }
+
+#[test]
+fn failpoints_bug_30() {
+    // postmortem 1:
+    assert!(prop_tree_crashes_nicely(
+        vec![Set, FailPoint("buffer write"), Restart, Flush, Id],
+        false,
+    ));
+}

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -147,7 +147,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
     macro_rules! restart {
         () => {
             drop(tree);
-            let tree_res = config.open();
+            let tree_res = config.global_error().and_then(|_| config.open());
             if let Err(ref e) = tree_res {
                 if e == &Error::FailPoint {
                     return true;
@@ -224,6 +224,8 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     // this key had to be present, but we got to the end of the tree without
                     // seeing it
                     println!("tree verification failed: expected {:?} got end", ref_key);
+                    println!("expected: {:?}", ref_expected);
+                    println!("tree: {:?}", tree);
                     return false;
                 }
             }


### PR DESCRIPTION
this is an issue in the failpoints test runner, rather than a bug in error handling code. it was improperly marking state as certain even though an error was encountered while dropping the database.