### PR TITLE
Add test for CPU usage with no DB operations

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,3 +36,11 @@ pub fn setup_logger() {
 
     let _r = builder.try_init();
 }
+
+#[allow(dead_code)]
+pub fn cleanup(dir: &str) {
+    let dir = std::path::Path::new(dir);
+    if dir.exists() {
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -2,15 +2,15 @@
 
 mod common;
 
-use std::fs;
 use std::mem::size_of;
-use std::path::Path;
 use std::thread;
 use std::time::Duration;
 
 use rand::Rng;
 
 use sled::Config;
+
+use common::cleanup;
 
 const N_TESTS: usize = 100;
 const CYCLE: usize = 256;
@@ -367,11 +367,4 @@ fn test_crash_batches_no_runtime_snapshot() {
         }
     }
     cleanup(dir);
-}
-
-fn cleanup(dir: &str) {
-    let dir = Path::new(dir);
-    if dir.exists() {
-        fs::remove_dir_all(dir).unwrap();
-    }
 }

--- a/tests/test_quiescent.rs
+++ b/tests/test_quiescent.rs
@@ -1,0 +1,70 @@
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::cleanup;
+
+#[test]
+fn test_quiescent_cpu_time() {
+    const DB_DIR: &str = "sleeper";
+    cleanup(DB_DIR);
+
+    fn run() {
+        let start = Instant::now();
+        let db = sled::Db::open(DB_DIR).unwrap();
+        std::thread::sleep(Duration::from_secs(10));
+        drop(db);
+        let end = Instant::now();
+
+        let (user_cpu_time, system_cpu_time) = unsafe {
+            let mut resource_usage: libc::rusage = std::mem::zeroed();
+            let return_value = libc::getrusage(
+                libc::RUSAGE_SELF,
+                (&mut resource_usage) as *mut libc::rusage,
+            );
+            if return_value != 0 {
+                panic!("error {} from getrusage()", *libc::__errno_location());
+            }
+            (resource_usage.ru_utime, resource_usage.ru_stime)
+        };
+
+        let user_cpu_seconds =
+            user_cpu_time.tv_sec as f64 + user_cpu_time.tv_usec as f64 * 1e-6;
+        let system_cpu_seconds = system_cpu_time.tv_sec as f64
+            + system_cpu_time.tv_usec as f64 * 1e-6;
+        let real_time_elapsed = end.duration_since(start);
+
+        if user_cpu_seconds + system_cpu_seconds > 1.0 {
+            panic!(
+                "Database used too much CPU during a quiescent workload. User: {}s, system: {}s (wall clock: {}s)",
+                user_cpu_seconds,
+                system_cpu_seconds,
+                real_time_elapsed.as_secs_f64(),
+            );
+        }
+    }
+
+    let child = unsafe { libc::fork() };
+    if child == 0 {
+        common::setup_logger();
+        if let Err(e) = std::thread::spawn(run).join() {
+            println!("test failed: {:?}", e);
+            std::process::exit(15);
+        } else {
+            std::process::exit(0);
+        }
+    } else {
+        let mut status = 0;
+        unsafe {
+            libc::waitpid(child, &mut status as *mut libc::c_int, 0);
+        }
+        if status != 0 {
+            cleanup(DB_DIR);
+            panic!("child exited abnormally");
+        }
+    }
+
+    cleanup(DB_DIR);
+}


### PR DESCRIPTION
Fixes #911. This adds a new test executable that forks, opens a database, waits ten seconds, and drops it. The child process checks its own CPU usage using `libc`, and exits with an error code if it used more than one second. I tested it by making the flusher spawn an infinite loop in a new thread, and here's what the error messages look like.

```
running 1 test
thread '<unnamed>' panicked at 'Database used too much CPU during a quiescent workload. User: 10.262479s, system: 0.015997s (wall clock: 10.262207544s)', tests/test_quiescent.rs:36:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
test test_quiescent_cpu_time ... FAILED

failures:

---- test_quiescent_cpu_time stdout ----
thread 'test_quiescent_cpu_time' panicked at 'child exited abnormally', tests/test_quiescent.rs:61:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    test_quiescent_cpu_time

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```