### PR TITLE
fix warning: `description` is deprecated since 1.41.0: use the Display impl or to_string() 

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -117,6 +117,7 @@ impl From<io::Error> for Error {
 }
 
 impl StdError for Error {
+    #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         use self::Error::*;
 


### PR DESCRIPTION
…string()