### PR TITLE
Link to import/export docs where README.md mentions manual migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ for a more detailed overview of where we're at and where we see things going!
 * if reliability is your primary constraint, use SQLite. sled is beta.
 * if storage price performance is your primary constraint, use RocksDB. sled uses too much space sometimes.
 * quite young, should be considered unstable for the time being.
-* the on-disk format is going to change in ways that require manual migrations before the `1.0.0` release!
+* the on-disk format is going to change in ways that require [manual migrations](https://docs.rs/sled/latest/sled/struct.Db.html#method.export) before the `1.0.0` release!
 * until `1.0.0`, sled targets the *current* stable version of rust. after `1.0.0`, we will aim to trail current by at least one version. If this is an issue for your business, please consider helping us reach `1.0.0` sooner by financially supporting our efforts to get there.
 
 # plans


### PR DESCRIPTION
The import/export names aren't super discoverable in and of themselves given the description in the readme.