### PR TITLE
release linearizing mutexes before notifying condvars

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -698,6 +698,7 @@ impl Config {
         if ge.is_null() {
             Ok(())
         } else {
+            #[cold]
             #[allow(unsafe_code)]
             unsafe {
                 Err(ge.deref().clone())

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -135,7 +135,7 @@ fn run(
 
         let sleep_duration = flush_every
             .checked_sub(before.elapsed())
-            .unwrap_or(Duration::from_millis(1));
+            .unwrap_or_else(|| Duration::from_millis(1));
 
         let _ = sc.wait_for(&mut shutdown, sleep_duration);
     }

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -94,6 +94,11 @@ fn run(
                 pagecache.set_failpoint(e);
 
                 *shutdown = ShutdownState::ShutDown;
+
+                // having held the mutex makes this linearized
+                // with the notify below.
+                drop(shutdown);
+
                 let _notified = sc.notify_all();
                 return;
             }
@@ -115,6 +120,11 @@ fn run(
                     pagecache.set_failpoint(e);
 
                     *shutdown = ShutdownState::ShutDown;
+
+                    // having held the mutex makes this linearized
+                    // with the notify below.
+                    drop(shutdown);
+
                     let _notified = sc.notify_all();
                     return;
                 }
@@ -130,6 +140,11 @@ fn run(
         let _ = sc.wait_for(&mut shutdown, sleep_duration);
     }
     *shutdown = ShutdownState::ShutDown;
+
+    // having held the mutex makes this linearized
+    // with the notify below.
+    drop(shutdown);
+
     let _notified = sc.notify_all();
 }
 

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -99,6 +99,10 @@ impl<T> OneShotFiller<T> {
         state.filled = true;
         state.item = Some(inner);
 
+        // having held the mutex makes this linearized
+        // with the notify below.
+        drop(state);
+
         let _notified = self.cv.notify_all();
     }
 }
@@ -116,6 +120,10 @@ impl<T> Drop for OneShotFiller<T> {
         }
 
         state.filled = true;
+
+        // having held the mutex makes this linearized
+        // with the notify below.
+        drop(state);
 
         let _notified = self.cv.notify_all();
     }

--- a/src/pagecache/io_uring.rs
+++ b/src/pagecache/io_uring.rs
@@ -13,8 +13,8 @@ use crate::{Error, Result};
 
 use liburing::*;
 
-/// TODO: support for SQPOLL with idle timeout
-/// TODO: support for SYNC_FILE_RANGE
+/// TODO: support for `SQPOLL` with idle timeout
+/// TODO: support for `SYNC_FILE_RANGE`
 pub(crate) struct Uring<T> {
     /// Mutable unsafe FFI struct from liburing::
     ring: io_uring,

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -195,8 +195,7 @@ impl Segment {
         self.state = Inactive;
 
         // now we can push any deferred blob removals to the removed set
-        let deferred_rm_blob =
-            mem::replace(&mut self.deferred_rm_blob, FastSet8::default());
+        let deferred_rm_blob = mem::take(&mut self.deferred_rm_blob);
         for ptr in deferred_rm_blob {
             trace!(
                 "removing blob {} while transitioning \
@@ -207,8 +206,7 @@ impl Segment {
             remove_blob(ptr, config)?;
         }
 
-        let deferred_replacements =
-            mem::replace(&mut self.deferred_replacements, FastSet8::default());
+        let deferred_replacements = mem::take(&mut self.deferred_replacements);
 
         Ok(deferred_replacements)
     }

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -195,7 +195,8 @@ impl Segment {
         self.state = Inactive;
 
         // now we can push any deferred blob removals to the removed set
-        let deferred_rm_blob = mem::take(&mut self.deferred_rm_blob);
+        let deferred_rm_blob =
+            mem::replace(&mut self.deferred_rm_blob, FastSet8::default());
         for ptr in deferred_rm_blob {
             trace!(
                 "removing blob {} while transitioning \
@@ -206,7 +207,8 @@ impl Segment {
             remove_blob(ptr, config)?;
         }
 
-        let deferred_replacements = mem::take(&mut self.deferred_replacements);
+        let deferred_replacements =
+            mem::replace(&mut self.deferred_replacements, FastSet8::default());
 
         Ok(deferred_replacements)
     }

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -49,6 +49,11 @@ impl Queue {
     fn send(&self, work: Work) {
         let mut queue = self.mu.lock();
         queue.push_back(work);
+
+        // having held the mutex makes this linearized
+        // with the notify below.
+        drop(queue);
+
         self.cv.notify_one();
     }
 }


### PR DESCRIPTION
This reduces contention by dropping the associated mutex before notifying its condvar. It is safe because anything that is waiting is waiting on specific state to materialize, which is guaranteed to happen before the condvar is pinged.