### PR TITLE
Fix MAX_MSG_HEADER_LEN to be 32, accounting for max varint len

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.31.1"
+version = "0.31.0"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a modern embedded database"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled"
-version = "0.31.0"
+version = "0.31.1"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a modern embedded database"
 license = "MIT/Apache-2.0"

--- a/src/pagecache/constants.rs
+++ b/src/pagecache/constants.rs
@@ -1,12 +1,12 @@
 use super::*;
 
-// kind: u8 1
-// pid: u64 8
-// lsn: i64 8
-// len: u64 8
 // crc: u32 4
+// kind: u8 1
+// seg num: u64 9 (varint)
+// pid: u64 9 (varint)
+// len: u64 9 (varint)
 /// Log messages have a header that might eb up to this length.
-pub const MAX_MSG_HEADER_LEN: usize = 29;
+pub const MAX_MSG_HEADER_LEN: usize = 32;
 
 /// Log segments have a header of this length.
 pub const SEG_HEADER_LEN: usize = 20;

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -488,11 +488,11 @@ impl Drop for Log {
 /// All log messages are prepended with this header
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MessageHeader {
+    pub crc32: u32,
     pub kind: MessageKind,
     pub segment_number: SegmentNumber,
     pub pid: PageId,
     pub len: u64,
-    pub crc32: u32,
 }
 
 /// A number representing a segment number.


### PR DESCRIPTION
luckily 0.31.0 was not yet published to crates.io, so we can just adjust the git tag for the release to this