### PR TITLE
significant contention reduction for file GC

### DIFF
--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -1,6 +1,8 @@
 use std::{
-    cell::UnsafeCell, sync::atomic::AtomicBool, sync::atomic::Ordering::SeqCst,
+    cell::UnsafeCell,
+    sync::atomic::AtomicBool,
     sync::Arc,
+    sync::{atomic::Ordering::SeqCst, mpsc::Receiver},
 };
 
 use crate::{pagecache::*, *};
@@ -63,6 +65,7 @@ pub(crate) struct IoBufs {
     pub max_reserved_lsn: AtomicLsn,
     pub max_header_stable_lsn: Arc<AtomicLsn>,
     pub segment_accountant: Mutex<SegmentAccountant>,
+    pub clean_receiver: Mutex<Receiver<(PageId, LogOffset)>>,
     deferred_segment_ops: stack::Stack<SegmentOp>,
     #[cfg(feature = "io_uring")]
     pub submission_mutex: Mutex<()>,
@@ -83,8 +86,10 @@ impl IoBufs {
         let snapshot_last_lid = snapshot.last_lid;
         let snapshot_max_header_stable_lsn = snapshot.max_header_stable_lsn;
 
+        let (clean_sender, clean_receiver) = std::sync::mpsc::channel();
+
         let mut segment_accountant: SegmentAccountant =
-            SegmentAccountant::start(config.clone(), snapshot)?;
+            SegmentAccountant::start(config.clone(), snapshot, clean_sender)?;
 
         let (next_lsn, next_lid) =
             if snapshot_last_lsn % segment_size as Lsn == 0 {
@@ -182,6 +187,7 @@ impl IoBufs {
                 snapshot_max_header_stable_lsn,
             )),
             segment_accountant: Mutex::new(segment_accountant),
+            clean_receiver: Mutex::new(clean_receiver),
             deferred_segment_ops: stack::Stack::default(),
             #[cfg(feature = "io_uring")]
             submission_mutex: Mutex::new(()),

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -5,9 +5,9 @@ use super::{
     arr_to_lsn, arr_to_u32, assert_usize, bump_atomic_lsn, iobuf, lsn_to_arr,
     maybe_decompress, pread_exact, pread_exact_or_eof, read_blob, u32_to_arr,
     BasedBuf, BlobPointer, DiskPtr, IoBuf, IoBufs, LogKind, LogOffset, Lsn,
-    MessageKind, Reservation, SegmentAccountant, Serialize, Snapshot,
-    BATCH_MANIFEST_PID, COUNTER_PID, MAX_MSG_HEADER_LEN, META_PID,
-    MINIMUM_ITEMS_PER_SEGMENT, SEG_HEADER_LEN,
+    MessageKind, Reservation, Serialize, Snapshot, BATCH_MANIFEST_PID,
+    COUNTER_PID, MAX_MSG_HEADER_LEN, META_PID, MINIMUM_ITEMS_PER_SEGMENT,
+    SEG_HEADER_LEN,
 };
 
 use crate::*;
@@ -96,14 +96,6 @@ impl Log {
     /// bytes written during this call.
     pub fn make_stable(&self, lsn: Lsn) -> Result<usize> {
         iobuf::make_stable(&self.iobufs, lsn)
-    }
-
-    // SegmentAccountant access for coordination with the `PageCache`
-    pub(in crate::pagecache) fn with_sa<B, F>(&self, f: F) -> B
-    where
-        F: FnOnce(&mut SegmentAccountant) -> B,
-    {
-        self.iobufs.with_sa(f)
     }
 
     /// Reserve a replacement buffer for a previously written

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1050,7 +1050,6 @@ impl PageCache {
         if let Ok((pid_to_clean, segment_to_clean)) =
             self.log.iobufs.clean_receiver.lock().try_recv()
         {
-            assert_ne!(pid, pid_to_clean);
             self.rewrite_page(pid_to_clean, segment_to_clean, guard)?;
         }
 

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -56,7 +56,7 @@
 
 #![allow(unused_results)]
 
-use std::{collections::BTreeSet, mem};
+use std::{collections::BTreeSet, mem, sync::mpsc::Sender};
 
 use super::PageState;
 
@@ -110,7 +110,7 @@ pub(crate) struct SegmentAccountant {
     free: BTreeSet<LogOffset>,
     tip: LogOffset,
     max_stabilized_lsn: Lsn,
-    to_clean: BTreeSet<LogOffset>,
+    clean_sender: Sender<(PageId, LogOffset)>,
     pause_rewriting: bool,
     ordering: BTreeMap<Lsn, LogOffset>,
     async_truncations: BTreeMap<LogOffset, OneShot<Result<()>>>,
@@ -160,7 +160,6 @@ struct Inactive {
 #[derive(Debug, Clone, Default)]
 struct Draining {
     lsn: Lsn,
-    pids: BTreeSet<PageId>,
     max_pids: usize,
     replaced_pids: usize,
     latest_replacement_lsn: Lsn,
@@ -287,21 +286,22 @@ impl Segment {
         Ok(ret)
     }
 
-    fn inactive_to_draining(&mut self, lsn: Lsn) {
+    fn inactive_to_draining(&mut self, lsn: Lsn) -> BTreeSet<PageId> {
         trace!("setting Segment with lsn {:?} to Draining", self.lsn());
 
         if let Segment::Inactive(inactive) = self {
             assert!(lsn >= inactive.lsn);
+            let ret = mem::replace(&mut inactive.pids, BTreeSet::default());
             *self = Segment::Draining(Draining {
                 lsn: inactive.lsn,
-                pids: mem::replace(&mut inactive.pids, BTreeSet::default()),
                 max_pids: inactive.max_pids,
                 replaced_pids: inactive.replaced_pids,
                 latest_replacement_lsn: inactive.latest_replacement_lsn,
             });
+            ret
         } else {
             panic!("called inactive_to_draining on {:?}", self);
-        };
+        }
     }
 
     fn defer_free_lsn(&mut self, lsn: Lsn) {
@@ -395,7 +395,6 @@ impl Segment {
                 }
             }
             Segment::Draining(Draining {
-                pids,
                 lsn,
                 latest_replacement_lsn,
                 replaced_pids,
@@ -403,7 +402,6 @@ impl Segment {
             }) => {
                 assert!(*lsn <= replacement_lsn);
                 if replacement_lsn != *lsn {
-                    pids.remove(&pid);
                     *replaced_pids += 1;
                 }
                 if replacement_lsn > *latest_replacement_lsn {
@@ -445,15 +443,7 @@ impl Segment {
 
     fn can_free(&self) -> bool {
         if let Segment::Draining(draining) = self {
-            let ret = draining.replaced_pids == draining.max_pids;
-            if ret {
-                assert!(
-                    draining.pids.is_empty(),
-                    "expected segment {:?} to be empty",
-                    self
-                );
-            }
-            ret
+            draining.replaced_pids == draining.max_pids
         } else {
             false
         }
@@ -462,8 +452,10 @@ impl Segment {
     fn is_empty(&self) -> bool {
         match self {
             Segment::Active(Active { pids, .. })
-            | Segment::Inactive(Inactive { pids, .. })
-            | Segment::Draining(Draining { pids, .. }) => pids.is_empty(),
+            | Segment::Inactive(Inactive { pids, .. }) => pids.is_empty(),
+            Segment::Draining(Draining { replaced_pids, max_pids, .. }) => {
+                replaced_pids == max_pids
+            }
             Segment::Free(_) => false,
         }
     }
@@ -474,6 +466,7 @@ impl SegmentAccountant {
     pub(super) fn start(
         config: RunningConfig,
         snapshot: &Snapshot,
+        clean_sender: Sender<(PageId, LogOffset)>,
     ) -> Result<Self> {
         let _measure = Measure::new(&M.start_segment_accountant);
         let mut ret = Self {
@@ -482,7 +475,7 @@ impl SegmentAccountant {
             free: BTreeSet::default(),
             tip: 0,
             max_stabilized_lsn: -1,
-            to_clean: BTreeSet::default(),
+            clean_sender,
             pause_rewriting: false,
             ordering: BTreeMap::default(),
             async_truncations: BTreeMap::default(),
@@ -743,12 +736,6 @@ impl SegmentAccountant {
 
         let new_idx = self.segment_id(new_cache_info.pointer.lid());
 
-        // make sure we're not actively trying to replace the destination
-        let new_segment_start =
-            new_idx as LogOffset * self.config.segment_size as LogOffset;
-
-        assert!(!self.to_clean.contains(&new_segment_start));
-
         // Do we need to schedule any blob cleanups?
         // Not if we just moved the pointer without changing
         // the underlying blob, as is the case with a single Blob
@@ -797,12 +784,6 @@ impl SegmentAccountant {
         trace!("mark_link pid {} at cache info {:?}", pid, cache_info);
         let idx = self.segment_id(cache_info.pointer.lid());
 
-        // make sure we're not actively trying to replace the destination
-        let new_segment_start =
-            idx as LogOffset * self.config.segment_size as LogOffset;
-
-        assert!(!self.to_clean.contains(&new_segment_start));
-
         let segment = &mut self.segments[idx];
 
         let segment_lsn = cache_info.lsn / self.config.segment_size as Lsn
@@ -842,8 +823,12 @@ impl SegmentAccountant {
                     "SA inserting {} into to_clean from possibly_clean_or_free_segment",
                     segment_start
                 );
-                self.segments[idx].inactive_to_draining(lsn);
-                self.to_clean.insert(segment_start);
+                let to_clean = self.segments[idx].inactive_to_draining(lsn);
+                for pid in to_clean.into_iter() {
+                    self.clean_sender
+                        .send((pid, segment_start))
+                        .expect("should always be able to send");
+                }
             }
         }
 
@@ -852,7 +837,6 @@ impl SegmentAccountant {
         if self.segments[idx].can_free() {
             // can be reused immediately
             let replacement_lsn = self.segments[idx].draining_to_free(lsn);
-            self.to_clean.remove(&segment_start);
             trace!(
                 "freed segment {} in possibly_clean_or_free_segment",
                 segment_start
@@ -870,45 +854,6 @@ impl SegmentAccountant {
                 assert!(replacement_lsn <= self.max_stabilized_lsn);
                 self.free_segment(segment_start, false);
             }
-        }
-    }
-
-    /// Called by the `PageCache` to find pages that are in
-    /// segments eligible for cleaning that it should
-    /// try to rewrite elsewhere.
-    pub(super) fn clean(
-        &mut self,
-        ignore_pid: Option<PageId>,
-    ) -> Option<(PageId, LogOffset)> {
-        let lid = self.to_clean.iter().next().copied()?;
-
-        let idx = self.segment_id(lid);
-        let segment = &mut self.segments[idx];
-
-        let pids = match segment {
-            Segment::Inactive(Inactive { pids, .. })
-            | Segment::Draining(Draining { pids, .. }) => pids,
-            Segment::Active(_) | Segment::Free(_) => {
-                panic!("called clean on {:?}", self)
-            }
-        };
-
-        if pids.is_empty() {
-            self.to_clean.remove(&lid);
-            None
-        } else {
-            let pid_opt =
-                pids.iter().find(|p| Some(**p) != ignore_pid).copied();
-
-            pid_opt.map(|pid| {
-                pids.remove(&pid);
-                trace!(
-                    "telling caller to clean {} from segment at {}",
-                    pid,
-                    lid
-                );
-                (pid, lid)
-            })
         }
     }
 
@@ -998,7 +943,12 @@ impl SegmentAccountant {
             let segment_start =
                 (last_index * self.config.segment_size) as LogOffset;
 
-            self.to_clean.insert(segment_start);
+            let to_clean = self.segments[last_index].inactive_to_draining(lsn);
+            for pid in to_clean.into_iter() {
+                self.clean_sender
+                    .send((pid, segment_start))
+                    .expect("should always be able to send");
+            }
         }
 
         Ok(())


### PR DESCRIPTION
a key aspect of reducing contention through the whole system is to reduce reliance on the SegmentAccountant mutex. writers need to check to see if they can help perform GC from time to time, and this lets them use a very low contention mutex connected to a mpsc::Receiver instead of the SegmentAccountant itself. 