### PR TITLE
use memcmp for key comparisons

### DIFF
--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -3,10 +3,10 @@ set -e
 
 # checks sled's compatibility using several targets
 
-targets="aarch64-fuchsia aarch64-linux-android aarch64-apple-ios \
+targets="wasm32-unknown-unknown aarch64-fuchsia aarch64-linux-android \
          i686-linux-android i686-unknown-linux-gnu \
          x86_64-linux-android x86_64-fuchsia \
-         wasm32-unknown-unknown"
+         aarch64-apple-ios"
 
 for target in $targets; do
   echo "setting up $target..."

--- a/src/binary_search.rs
+++ b/src/binary_search.rs
@@ -1,6 +1,6 @@
-use std::cmp::Ordering::*;
+use std::cmp::Ordering::{Equal, Greater, Less};
 
-use crate::IVec;
+use crate::{fastcmp, IVec};
 
 pub(crate) fn binary_search_lub<'a, T>(
     key: &[u8],
@@ -29,13 +29,15 @@ pub fn binary_search<'a, T>(
         // mid >= 0: by definition
         // mid < size: mid = size / 2 + size / 4 + size / 8 ...
         #[allow(unsafe_code)]
-        let cmp = unsafe { s.get_unchecked(mid).0.as_ref().cmp(key) };
+        let l = unsafe { s.get_unchecked(mid).0.as_ref() };
+        let cmp = fastcmp(l, key);
         base = if cmp == Greater { base } else { mid };
         size -= half;
     }
     // base is always in [0, size) because base <= mid.
     #[allow(unsafe_code)]
-    let cmp = unsafe { s.get_unchecked(base).0.as_ref().cmp(key) };
+    let l = unsafe { s.get_unchecked(base).0.as_ref() };
+    let cmp = fastcmp(l, key);
     if cmp == Equal {
         Ok(base)
     } else {

--- a/src/fastcmp.rs
+++ b/src/fastcmp.rs
@@ -1,0 +1,48 @@
+use std::cmp::Ordering::{self, Greater, Less};
+
+#[allow(unsafe_code)]
+pub(crate) fn fastcmp(l: &[u8], r: &[u8]) -> Ordering {
+    let len = std::cmp::min(l.len(), r.len());
+    let cmp = unsafe { libc::memcmp(l.as_ptr() as _, r.as_ptr() as _, len) };
+    match cmp {
+        a if a > 0 => Greater,
+        a if a < 0 => Less,
+        _ => l.len().cmp(&r.len()),
+    }
+}
+
+#[cfg(test)]
+mod qc {
+    use super::fastcmp;
+
+    fn prop_cmp_matches(l: &[u8], r: &[u8]) -> bool {
+        assert_eq!(fastcmp(l, r), l.cmp(r));
+        assert_eq!(fastcmp(r, l), r.cmp(l));
+        assert_eq!(fastcmp(l, l), l.cmp(l));
+        assert_eq!(fastcmp(r, r), r.cmp(r));
+        true
+    }
+
+    #[test]
+    fn test_fastcmp() {
+        let cases: [&[u8]; 8] = [
+            &[],
+            &[0],
+            &[1],
+            &[1],
+            &[255],
+            &[1, 2, 3],
+            &[1, 2, 3, 0],
+            &[1, 2, 3, 55],
+        ];
+        for pair in cases.windows(2) {
+            prop_cmp_matches(pair[0], pair[1]);
+        }
+    }
+    quickcheck::quickcheck! {
+        fn qc_fastcmp(l: Vec<u8>, r: Vec<u8>) -> bool {
+            println!("{:?}", l);
+            prop_cmp_matches(&l, &r)
+        }
+    }
+}

--- a/src/fastcmp.rs
+++ b/src/fastcmp.rs
@@ -1,14 +1,21 @@
-use std::cmp::Ordering::{self, Greater, Less};
+use std::cmp::Ordering;
 
+#[cfg(any(unix, windows))]
 #[allow(unsafe_code)]
 pub(crate) fn fastcmp(l: &[u8], r: &[u8]) -> Ordering {
     let len = std::cmp::min(l.len(), r.len());
     let cmp = unsafe { libc::memcmp(l.as_ptr() as _, r.as_ptr() as _, len) };
     match cmp {
-        a if a > 0 => Greater,
-        a if a < 0 => Less,
+        a if a > 0 => Ordering::Greater,
+        a if a < 0 => Ordering::Less,
         _ => l.len().cmp(&r.len()),
     }
+}
+
+#[cfg(not(any(unix, windows)))]
+#[allow(unsafe_code)]
+pub(crate) fn fastcmp(l: &[u8], r: &[u8]) -> Ordering {
+    l.cmp(r)
 }
 
 #[cfg(test)]

--- a/src/fastcmp.rs
+++ b/src/fastcmp.rs
@@ -41,7 +41,6 @@ mod qc {
     }
     quickcheck::quickcheck! {
         fn qc_fastcmp(l: Vec<u8>, r: Vec<u8>) -> bool {
-            println!("{:?}", l);
             prop_cmp_matches(&l, &r)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ mod config;
 mod context;
 mod db;
 mod dll;
+mod fastcmp;
 mod fastlock;
 mod histogram;
 mod iter;
@@ -262,6 +263,7 @@ use {
     self::{
         binary_search::binary_search_lub,
         context::Context,
+        fastcmp::fastcmp,
         histogram::Histogram,
         lru::Lru,
         meta::Meta,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -97,6 +97,7 @@ pub struct Metrics {
     pub decompress: Histogram,
     pub deserialize: Histogram,
     pub get_page: Histogram,
+    pub get_pagetable: Histogram,
     pub link_page: Histogram,
     pub log_reservation_attempts: CachePadded<AtomicUsize>,
     pub log_reservations: CachePadded<AtomicUsize>,
@@ -285,6 +286,7 @@ impl Metrics {
         p(vec![
             lat("snapshot", &self.advance_snapshot),
             lat("get", &self.get_page),
+            lat("get pt", &self.get_pagetable),
             lat("rewrite", &self.rewrite_page),
             lat("replace", &self.replace_page),
             lat("link", &self.link_page),
@@ -292,7 +294,7 @@ impl Metrics {
             lat("page_out", &self.page_out),
         ]);
         let hit_ratio = (self.get_page.count() - self.pull.count()) * 100
-            / self.get_page.count();
+            / std::cmp::max(1, self.get_page.count());
         println!("hit ratio: {}%", hit_ratio);
 
         println!("{}", std::iter::repeat("-").take(134).collect::<String>());
@@ -317,7 +319,8 @@ impl Metrics {
             lat("reserve lat", &self.reserve_lat),
             sz("reserve sz", &self.reserve_sz),
         ]);
-        let log_reservations = self.log_reservations.load(Acquire);
+        let log_reservations =
+            std::cmp::max(1, self.log_reservations.load(Acquire));
         let log_reservation_attempts =
             self.log_reservation_attempts.load(Acquire);
         let log_reservation_retry_rate =

--- a/src/node.rs
+++ b/src/node.rs
@@ -73,7 +73,7 @@ impl Node {
 
     pub(crate) fn set_leaf(&mut self, key: IVec, val: IVec) {
         if !self.hi.is_empty() {
-            assert!(&*key < &self.hi[self.prefix_len as usize..]);
+            assert!(*key < self.hi[self.prefix_len as usize..]);
         }
         if let Data::Leaf(ref mut records) = self.data {
             let search = records.binary_search_by(|(k, _)| fastcmp(k, &key));
@@ -89,7 +89,7 @@ impl Node {
 
     pub(crate) fn del_leaf(&mut self, key: &IVec) {
         if let Data::Leaf(ref mut records) = self.data {
-            let search = records.binary_search_by(|(k, _)| fastcmp(k, &key));
+            let search = records.binary_search_by(|(k, _)| fastcmp(k, key));
             if let Ok(idx) = search {
                 records.remove(idx);
             }
@@ -102,7 +102,7 @@ impl Node {
     pub(crate) fn parent_split(&mut self, at: &[u8], to: PageId) -> bool {
         if let Data::Index(ref mut pointers) = self.data {
             let encoded_sep = &at[self.prefix_len as usize..];
-            match pointers.binary_search_by(|(k, _)| fastcmp(k, &encoded_sep)) {
+            match pointers.binary_search_by(|(k, _)| fastcmp(k, encoded_sep)) {
                 Ok(_) => {
                     debug!(
                         "parent_split skipped because \

--- a/src/node.rs
+++ b/src/node.rs
@@ -76,7 +76,7 @@ impl Node {
             assert!(&*key < &self.hi[self.prefix_len as usize..]);
         }
         if let Data::Leaf(ref mut records) = self.data {
-            let search = records.binary_search_by_key(&&key, |(k, _)| k);
+            let search = records.binary_search_by(|(k, _)| fastcmp(k, &key));
             match search {
                 Ok(idx) => records[idx] = (key, val),
                 Err(idx) => records.insert(idx, (key, val)),
@@ -89,7 +89,7 @@ impl Node {
 
     pub(crate) fn del_leaf(&mut self, key: &IVec) {
         if let Data::Leaf(ref mut records) = self.data {
-            let search = records.binary_search_by_key(&key, |(k, _)| k);
+            let search = records.binary_search_by(|(k, _)| fastcmp(k, &key));
             if let Ok(idx) = search {
                 records.remove(idx);
             }
@@ -102,7 +102,7 @@ impl Node {
     pub(crate) fn parent_split(&mut self, at: &[u8], to: PageId) -> bool {
         if let Data::Index(ref mut pointers) = self.data {
             let encoded_sep = &at[self.prefix_len as usize..];
-            match pointers.binary_search_by_key(&encoded_sep, |(k, _)| k) {
+            match pointers.binary_search_by(|(k, _)| fastcmp(k, &encoded_sep)) {
                 Ok(_) => {
                     debug!(
                         "parent_split skipped because \
@@ -467,7 +467,8 @@ impl Node {
         };
 
         let records = self.data.leaf_ref().unwrap();
-        let search = records.binary_search_by_key(&&successor_key, |(k, _)| k);
+        let search =
+            records.binary_search_by(|(k, _)| fastcmp(k, &successor_key));
 
         let idx = match search {
             Ok(idx) => idx,
@@ -505,7 +506,7 @@ impl Node {
 
         let suffix = &key[self.prefix_len as usize..];
 
-        let search = records.binary_search_by_key(&suffix, |(k, _)| k).ok();
+        let search = records.binary_search_by(|(k, _)| fastcmp(k, suffix)).ok();
 
         search.map(|idx| (&records[idx].0, &records[idx].1))
     }

--- a/src/pagecache/pagetable.rs
+++ b/src/pagecache/pagetable.rs
@@ -13,6 +13,7 @@ use crossbeam_epoch::{pin, Atomic, Guard, Owned, Shared};
 use crate::{
     debug_delay,
     pagecache::{Page, PageView},
+    Measure, M,
 };
 
 #[allow(unused)]
@@ -133,6 +134,7 @@ impl PageTable {
         pid: PageId,
         guard: &'g Guard,
     ) -> Option<PageView<'g>> {
+        let _measure = Measure::new(&M.get_pagetable);
         debug_delay();
         let tip = self.traverse(pid, guard);
 


### PR DESCRIPTION
I would have hoped that this didn't do anything, but it seems to shave off a few % of CPU usage on read-heavy workloads. Maybe we'll stick SIMD-related key comparisons here later on.