### PR TITLE
remove runtime snapshotting

### DIFF
--- a/benchmarks/stress2/src/main.rs
+++ b/benchmarks/stress2/src/main.rs
@@ -226,7 +226,6 @@ fn main() {
     let config = sled::Config::new()
         .cache_capacity(256 * 1024 * 1024)
         .flush_every_ms(Some(200))
-        .snapshot_after_ops(100_000_000_000)
         .print_profile_on_drop(true);
 
     let tree = Arc::new(config.open().unwrap());

--- a/src/config.rs
+++ b/src/config.rs
@@ -380,6 +380,15 @@ impl Config {
         Log::start_raw_log(config)
     }
 
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.31.0",
+        note = "this does nothing for now. maybe it will come back in the future."
+    )]
+    pub fn snapshot_after_ops(self, _: &u64) -> Self {
+        self
+    }
+
     /// Finalize the configuration.
     ///
     /// # Panics
@@ -452,7 +461,6 @@ impl Config {
         (print_profile_on_drop, bool, "print a performance profile when the Config is dropped"),
         (use_compression, bool, "whether to use zstd compression"),
         (compression_factor, i32, "the compression factor to use with zstd compression. Ranges from 1 up to 22. 0 is 'default'. Levels >= 20 are 'ultra'."),
-        (snapshot_after_ops, u64, "number of operations between page table snapshots"),
         (segment_cleanup_threshold, u8, "the proportion of remaining valid pages in the segment before GC defragments it"),
         (segment_cleanup_skew, usize, "the cleanup threshold skew in percentage points between the first and last segments"),
         (segment_mode, SegmentMode, "the file segment selection mode"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -385,7 +385,7 @@ impl Config {
         since = "0.31.0",
         note = "this does nothing for now. maybe it will come back in the future."
     )]
-    pub fn snapshot_after_ops(self, _: &u64) -> Self {
+    pub fn snapshot_after_ops(self, _: u64) -> Self {
         self
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -284,7 +284,6 @@ impl Metrics {
         println!("{}", std::iter::repeat("-").take(134).collect::<String>());
         println!("pagecache:");
         p(vec![
-            lat("snapshot", &self.advance_snapshot),
             lat("get", &self.get_page),
             lat("get pt", &self.get_pagetable),
             lat("rewrite", &self.rewrite_page),

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -723,14 +723,6 @@ impl SegmentAccountant {
         self.pause_rewriting = true;
     }
 
-    /// Re-enables segment rewriting after iteration is complete.
-    pub(super) fn resume_rewriting(&mut self) {
-        // we never want to resume segment rewriting in Linear mode
-        if self.config.segment_mode != SegmentMode::Linear {
-            self.pause_rewriting = false;
-        }
-    }
-
     /// Asynchronously apply a GC-related operation. Used in a flat-combining
     /// style that allows callers to avoid blocking while sending these
     /// messages to this module.

--- a/tests/test_space_leaks.rs
+++ b/tests/test_space_leaks.rs
@@ -8,7 +8,6 @@ fn size_leak() -> sled::Result<()> {
         .temporary(true)
         .segment_size(2048)
         .flush_every_ms(None)
-        .snapshot_after_ops(100_000_000)
         .open()?;
 
     for _ in 0..10_000 {

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -74,7 +74,6 @@ fn concurrent_tree_ops() {
         let config = Config::new()
             .temporary(true)
             .flush_every_ms(None)
-            .snapshot_after_ops(100_000_000)
             .segment_size(256);
 
         macro_rules! par {
@@ -719,11 +718,8 @@ fn tree_range() {
 fn recover_tree() {
     common::setup_logger();
 
-    let config = Config::new()
-        .temporary(true)
-        .flush_every_ms(None)
-        .snapshot_after_ops(N_PER_THREAD as u64)
-        .segment_size(4096);
+    let config =
+        Config::new().temporary(true).flush_every_ms(None).segment_size(4096);
 
     let t = config.open().unwrap();
     for i in 0..N_PER_THREAD {
@@ -842,14 +838,14 @@ fn quickcheck_tree_matches_btreemap() {
         .tests(n_tests)
         .max_tests(n_tests * 10)
         .quickcheck(
-            prop_tree_matches_btreemap as fn(Vec<Op>, u8, bool, bool) -> bool,
+            prop_tree_matches_btreemap as fn(Vec<Op>, bool, bool) -> bool,
         );
 }
 
 #[test]
 fn tree_bug_00() {
     // postmortem:
-    prop_tree_matches_btreemap(vec![Restart], 0, false, false);
+    prop_tree_matches_btreemap(vec![Restart], false, false);
 }
 
 #[test]
@@ -870,7 +866,6 @@ fn tree_bug_01() {
             Restart,
             Set(Key(vec![164]), 147),
         ],
-        0,
         true,
         false,
     );
@@ -897,7 +892,6 @@ fn tree_bug_02() {
             Set(Key(vec![216]), 203),
             Scan(Key(vec![210]), 4),
         ],
-        0,
         true,
         false,
     );
@@ -920,7 +914,6 @@ fn tree_bug_03() {
             Restart,
             Scan(Key(vec![198]), 11),
         ],
-        0,
         true,
         false,
     );
@@ -945,7 +938,6 @@ fn tree_bug_4() {
             Restart,
             Set(Key(vec![59]), 119),
         ],
-        0,
         true,
         false,
     );
@@ -966,7 +958,6 @@ fn tree_bug_5() {
             Set(Key(vec![98]), 78),
             Set(Key(vec![0]), 45),
         ],
-        0,
         true,
         false,
     );
@@ -989,7 +980,6 @@ fn tree_bug_6() {
             Set(Key(vec![150]), 146),
             Set(Key(vec![18]), 34),
         ],
-        0,
         true,
         false,
     );
@@ -1012,7 +1002,6 @@ fn tree_bug_7() {
             Set(Key(vec![64]), 9),
             Scan(Key(vec![196]), 25),
         ],
-        0,
         true,
         false,
     );
@@ -1034,7 +1023,6 @@ fn tree_bug_8() {
             Set(Key(vec![102]), 205),
             Restart,
         ],
-        0,
         true,
         false,
     );
@@ -1059,7 +1047,6 @@ fn tree_bug_9() {
             Set(Key(vec![190]), 16),
             Restart,
         ],
-        0,
         true,
         false,
     );
@@ -1097,7 +1084,6 @@ fn tree_bug_10() {
             Cas(Key(vec![201]), 93, 196),
             Set(Key(vec![172]), 84),
         ],
-        0,
         true,
         false,
     );
@@ -1122,7 +1108,6 @@ fn tree_bug_11() {
             Restart,
             Set(Key(vec![243]), 6),
         ],
-        0,
         true,
         false,
     );
@@ -1172,7 +1157,6 @@ fn tree_bug_12() {
             Get(Key(vec![156])),
             Set(Key(vec![214]), 72),
         ],
-        0,
         true,
         false,
     );
@@ -1202,7 +1186,6 @@ fn tree_bug_13() {
             Restart,
             Del(Key(vec![165])),
         ],
-        0,
         true,
         false,
     );
@@ -1222,7 +1205,6 @@ fn tree_bug_14() {
             Set(Key(vec![171]), 176),
             Scan(Key(vec![93]), 33),
         ],
-        0,
         true,
         false,
     );
@@ -1240,7 +1222,6 @@ fn tree_bug_15() {
             Del(Key(vec![141])),
             Scan(Key(vec![101]), 26),
         ],
-        0,
         true,
         false,
     );
@@ -1251,7 +1232,6 @@ fn tree_bug_16() {
     // postmortem: the test merge function was not properly adding numbers.
     prop_tree_matches_btreemap(
         vec![Merge(Key(vec![247]), 162), Scan(Key(vec![209]), 31)],
-        0,
         false,
         false,
     );
@@ -1267,7 +1247,6 @@ fn tree_bug_17() {
             Set(Key(vec![194, 215, 103, 0, 138, 11, 248, 131]), 70),
             Scan(Key(vec![]), 30),
         ],
-        0,
         false,
         false,
     );
@@ -1286,7 +1265,6 @@ fn tree_bug_18() {
             Get(Key(vec![255])),
             GetGt(Key(vec![89])),
         ],
-        0,
         false,
         false,
     );
@@ -1305,7 +1283,6 @@ fn tree_bug_19() {
             Set(Key(vec![]), 247),
             GetLt(Key(vec![100])),
         ],
-        0,
         false,
         false,
     );
@@ -1325,7 +1302,6 @@ fn tree_bug_20() {
             Set(Key(vec![]), 251),
             GetGt(Key(vec![94])),
         ],
-        0,
         false,
         false,
     );
@@ -1346,7 +1322,6 @@ fn tree_bug_21() {
             Set(Key(vec![]), 58),
             GetLt(Key(vec![176])),
         ],
-        0,
         false,
         false,
     );
@@ -1363,7 +1338,6 @@ fn tree_bug_22() {
             Merge(Key(vec![56]), 251),
             Scan(Key(vec![]), 2),
         ],
-        0,
         false,
         false,
     );
@@ -1374,7 +1348,6 @@ fn tree_bug_23() {
     // postmortem: when rewriting CRC handling code, mis-sized the blob crc
     prop_tree_matches_btreemap(
         vec![Set(Key(vec![6; 5120]), 92), Restart, Scan(Key(vec![]), 35)],
-        0,
         false,
         false,
     );
@@ -1398,7 +1371,6 @@ fn tree_bug_24() {
             Merge(Key(vec![62]), 34),
             GetGt(Key(vec![])),
         ],
-        0,
         false,
         false,
     );
@@ -1410,7 +1382,6 @@ fn tree_bug_25() {
     // the frag chain and a Del was encountered
     prop_tree_matches_btreemap(
         vec![Del(Key(vec![])), Merge(Key(vec![]), 84), Get(Key(vec![]))],
-        0,
         false,
         false,
     );
@@ -1434,7 +1405,6 @@ fn tree_bug_26() {
             GetGt(Key(vec![])),
             GetLt(Key(vec![80])),
         ],
-        0,
         false,
         false,
     );
@@ -1504,7 +1474,6 @@ fn tree_bug_27() {
             ])),
             Merge(Key(vec![]), 50),
         ],
-        0,
         false,
         false,
     );
@@ -1527,7 +1496,6 @@ fn tree_bug_28() {
             Merge(Key(vec![149]), 60),
             Scan(Key(vec![178]), 18),
         ],
-        0,
         false,
         false,
     );
@@ -1668,7 +1636,6 @@ fn tree_bug_29() {
             Set(Key(vec![145]), 43),
             GetLt(Key(vec![229])),
         ],
-        0,
         false,
         false,
     );
@@ -1707,7 +1674,6 @@ fn tree_bug_30() {
             Merge(Key(vec![119]), 152),
             Scan(Key(vec![]), 31),
         ],
-        0,
         false,
         false,
     );
@@ -1730,7 +1696,6 @@ fn tree_bug_31() {
             ),
             Scan(Key(vec![]), -18),
         ],
-        0,
         false,
         false,
     );
@@ -1743,7 +1708,6 @@ fn tree_bug_32() {
     // no longer perform per-key prefix encoding.
     prop_tree_matches_btreemap(
         vec![Set(Key(vec![57]), 141), Scan(Key(vec![]), -40)],
-        0,
         false,
         false,
     );
@@ -1761,7 +1725,6 @@ fn tree_bug_33() {
             Set(Key(vec![85]), 43),
             GetLt(Key(vec![])),
         ],
-        0,
         false,
         false,
     );
@@ -1781,7 +1744,6 @@ fn tree_bug_34() {
             Set(Key(vec![9, 70]), 188),
             Scan(Key(vec![]), -40),
         ],
-        0,
         false,
         false,
     );
@@ -1816,7 +1778,6 @@ fn tree_bug_35() {
             Set(Key(vec![0, 229]), 117),
             Set(Key(vec![]), 112),
         ],
-        0,
         false,
         false,
     );
@@ -1837,7 +1798,6 @@ fn tree_bug_36() {
             Set(Key(vec![254, 5]), 207),
             Scan(Key(vec![]), -30),
         ],
-        0,
         false,
         false,
     );
@@ -1856,7 +1816,6 @@ fn tree_bug_37() {
             Set(Key(vec![1]), 187),
             Scan(Key(vec![]), 33),
         ],
-        0,
         false,
         false,
     );
@@ -1875,7 +1834,6 @@ fn tree_bug_38() {
                 GetLt(Key(vec![123])),
                 Restart,
             ],
-            0,
             false,
             false,
         );
@@ -2139,7 +2097,6 @@ fn tree_bug_39() {
                 Get(Key(vec![61])),
                 Restart,
             ],
-            38,
             false,
             false,
         );

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -132,7 +132,6 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
 
     let config = Config::new()
         .temporary(true)
-        .snapshot_after_ops(1)
         .flush_every_ms(if flusher { Some(1) } else { None })
         .cache_capacity(256)
         .idgen_persist_interval(1)

--- a/tests/tree/mod.rs
+++ b/tests/tree/mod.rs
@@ -64,7 +64,7 @@ pub fn fuzz_then_shrink(buf: &[u8]) {
         .collect();
 
     match panic::catch_unwind(move || {
-        prop_tree_matches_btreemap(ops, 100, false, use_compression)
+        prop_tree_matches_btreemap(ops, false, use_compression)
     }) {
         Ok(_) => {}
         Err(_e) => panic!("TODO"),
@@ -191,16 +191,12 @@ fn test_merge_operator(
 
 pub fn prop_tree_matches_btreemap(
     ops: Vec<Op>,
-    snapshot_after: u8,
     flusher: bool,
     use_compression: bool,
 ) -> bool {
-    if let Err(e) = prop_tree_matches_btreemap_inner(
-        ops,
-        snapshot_after,
-        flusher,
-        use_compression,
-    ) {
+    if let Err(e) =
+        prop_tree_matches_btreemap_inner(ops, flusher, use_compression)
+    {
         eprintln!("hit error while running quickcheck on tree: {:?}", e);
         false
     } else {
@@ -210,7 +206,6 @@ pub fn prop_tree_matches_btreemap(
 
 fn prop_tree_matches_btreemap_inner(
     ops: Vec<Op>,
-    snapshot_after: u8,
     flusher: bool,
     use_compression: bool,
 ) -> Result<()> {
@@ -223,7 +218,6 @@ fn prop_tree_matches_btreemap_inner(
     let config = Config::new()
         .temporary(true)
         .use_compression(use_compression)
-        .snapshot_after_ops(u64::from(snapshot_after) + 1)
         .flush_every_ms(if flusher { Some(1) } else { None })
         .cache_capacity(256)
         .idgen_persist_interval(1)


### PR DESCRIPTION
this is an area of the codebase that can lead to runaway file growth, and generally has felt like something that is undertested. for now, it makes sense to remove this bit of risky complexity, possibly coming back to it in the future.