### PR TITLE
dynamically enable concurrency control when it actually is needed

### DIFF
--- a/src/concurrency_control.rs
+++ b/src/concurrency_control.rs
@@ -1,0 +1,48 @@
+use std::sync::atomic::AtomicBool;
+
+use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
+
+use super::*;
+
+#[derive(Default)]
+pub(crate) struct ConcurrencyControl {
+    necessary: AtomicBool,
+    rw: RwLock<()>,
+}
+
+pub(crate) enum Protector<'a> {
+    Write(RwLockWriteGuard<'a, ()>),
+    Read(RwLockReadGuard<'a, ()>),
+    None,
+}
+
+impl ConcurrencyControl {
+    fn enable(&self) {
+        if !self.necessary.swap(true, SeqCst) {
+            // upgrade the system to using transactional
+            // concurrency control, which is a little
+            // more expensive for every operation.
+            let (tx, rx) = std::sync::mpsc::channel();
+
+            let guard = pin();
+            guard.defer(move || tx.send(()).unwrap());
+            guard.flush();
+            drop(guard);
+
+            rx.recv().unwrap();
+        }
+    }
+
+    pub(crate) fn read<'a>(&'a self, _: &'a Guard) -> Protector<'a> {
+        if self.necessary.load(SeqCst) {
+            Protector::Read(self.rw.read())
+        } else {
+            Protector::None
+        }
+    }
+
+    pub(crate) fn write<'a>(&'a self) -> Protector<'a> {
+        self.enable();
+        Protector::Write(self.rw.write())
+    }
+}

--- a/src/concurrency_control.rs
+++ b/src/concurrency_control.rs
@@ -41,7 +41,7 @@ impl ConcurrencyControl {
         }
     }
 
-    pub(crate) fn write<'a>(&'a self) -> Protector<'a> {
+    pub(crate) fn write(&self) -> Protector<'_> {
         self.enable();
         Protector::Write(self.rw.write())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -112,7 +112,7 @@ impl Db {
                 subscriptions: Subscriptions::default(),
                 context: context.clone(),
                 root: AtomicU64::new(root),
-                concurrency_control: RwLock::new(()),
+                concurrency_control: ConcurrencyControl::default(),
                 merge_operator: RwLock::new(None),
             }));
             assert!(tenants.insert(id, tree).is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ macro_rules! maybe_fail {
 
 mod batch;
 mod binary_search;
+mod concurrency_control;
 mod config;
 mod context;
 mod db;
@@ -262,6 +263,7 @@ pub use self::{
 use {
     self::{
         binary_search::binary_search_lub,
+        concurrency_control::{ConcurrencyControl, Protector},
         context::Context,
         fastcmp::fastcmp,
         histogram::Histogram,

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -60,7 +60,7 @@ where
                     context: context.clone(),
                     subscriptions: Subscriptions::default(),
                     root: AtomicU64::new(root_id),
-                    concurrency_control: RwLock::new(()),
+                    concurrency_control: ConcurrencyControl::default(),
                     merge_operator: RwLock::new(None),
                 })));
             }
@@ -114,7 +114,7 @@ where
             subscriptions: Subscriptions::default(),
             context: context.clone(),
             root: AtomicU64::new(root_id),
-            concurrency_control: RwLock::new(()),
+            concurrency_control: ConcurrencyControl::default(),
             merge_operator: RwLock::new(None),
         })));
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -70,10 +70,9 @@
 //! assert_eq!(unprocessed.get(b"k3").unwrap(), None);
 //! assert_eq!(&processed.get(b"k3").unwrap().unwrap(), b"yappin' ligers");
 //! ```
-use parking_lot::RwLockWriteGuard;
 use std::{cell::RefCell, collections::HashMap, fmt, rc::Rc};
 
-use crate::{Batch, Error, IVec, Result, Tree};
+use crate::{pin, Batch, Error, IVec, Protector, Result, Tree};
 
 /// A transaction that will
 /// be applied atomically to the
@@ -289,7 +288,8 @@ impl TransactionalTree {
         }
 
         // not found in a cache, need to hit the backing db
-        let get = self.tree.get_inner(key.as_ref())?;
+        let guard = pin();
+        let get = self.tree.get_inner(key.as_ref(), &guard)?;
         let last = reads.insert(key.as_ref().into(), get.clone());
         assert!(last.is_none());
 
@@ -311,11 +311,9 @@ impl TransactionalTree {
         Ok(())
     }
 
-    fn stage(
-        &self,
-    ) -> UnabortableTransactionResult<Vec<RwLockWriteGuard<'_, ()>>> {
-        let guard = self.tree.concurrency_control.write();
-        Ok(vec![guard])
+    fn stage(&self) -> UnabortableTransactionResult<Vec<Protector<'_>>> {
+        let protector = self.tree.concurrency_control.write();
+        Ok(vec![protector])
     }
 
     fn unstage(&self) {
@@ -328,11 +326,12 @@ impl TransactionalTree {
 
     fn commit(&self) -> Result<()> {
         let writes = self.writes.borrow();
+        let guard = pin();
         for (k, v_opt) in &*writes {
             if let Some(v) = v_opt {
-                let _old = self.tree.insert_inner(k, v)?;
+                let _old = self.tree.insert_inner(k, v, &guard)?;
             } else {
-                let _old = self.tree.remove_inner(k)?;
+                let _old = self.tree.remove_inner(k, &guard)?;
             }
         }
         Ok(())
@@ -344,9 +343,7 @@ pub struct TransactionalTrees {
 }
 
 impl TransactionalTrees {
-    fn stage(
-        &self,
-    ) -> UnabortableTransactionResult<Vec<RwLockWriteGuard<'_, ()>>> {
+    fn stage(&self) -> UnabortableTransactionResult<Vec<Protector<'_>>> {
         // we want to stage our trees in
         // lexicographic order to guarantee
         // no deadlocks should they block

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -153,7 +153,7 @@ impl Tree {
 
         loop {
             let View { node_view, pid, .. } =
-                self.view_for_key(key.as_ref(), &guard)?;
+                self.view_for_key(key.as_ref(), guard)?;
 
             let mut subscriber_reservation = self.subscriptions.reserve(&key);
 
@@ -164,7 +164,7 @@ impl Tree {
                 pid,
                 node_view.0,
                 frag.clone(),
-                &guard,
+                guard,
             )?;
             if let Ok(_new_cas_key) = link {
                 // success
@@ -422,7 +422,7 @@ impl Tree {
 
         loop {
             let View { pid, node_view, .. } =
-                self.view_for_key(key.as_ref(), &guard)?;
+                self.view_for_key(key.as_ref(), guard)?;
 
             let mut subscriber_reservation = self.subscriptions.reserve(&key);
 
@@ -430,7 +430,7 @@ impl Tree {
                 node_view.node_kv_pair(key.as_ref());
             let frag = Link::Del(encoded_key);
             let link =
-                self.context.pagecache.link(pid, node_view.0, frag, &guard)?;
+                self.context.pagecache.link(pid, node_view.0, frag, guard)?;
 
             if link.is_ok() {
                 // success

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -78,7 +78,7 @@ pub struct TreeInner {
     pub(crate) context: Context,
     pub(crate) subscriptions: Subscriptions,
     pub(crate) root: AtomicU64,
-    pub(crate) concurrency_control: RwLock<()>,
+    pub(crate) concurrency_control: ConcurrencyControl,
     pub(crate) merge_operator: RwLock<Option<MergeOperator>>,
 }
 
@@ -125,14 +125,16 @@ impl Tree {
         K: AsRef<[u8]>,
         IVec: From<V>,
     {
-        let _ = self.concurrency_control.read();
-        self.insert_inner(key, value)
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
+        self.insert_inner(key, value, &guard)
     }
 
     pub(crate) fn insert_inner<K, V>(
         &self,
         key: K,
         value: V,
+        guard: &Guard,
     ) -> Result<Option<IVec>>
     where
         K: AsRef<[u8]>,
@@ -150,7 +152,6 @@ impl Tree {
         let value = IVec::from(value);
 
         loop {
-            let guard = pin();
             let View { node_view, pid, .. } =
                 self.view_for_key(key.as_ref(), &guard)?;
 
@@ -323,16 +324,21 @@ impl Tree {
     /// ```
     pub fn apply_batch(&self, batch: Batch) -> Result<()> {
         let _ = self.concurrency_control.write();
-        self.apply_batch_inner(batch)
+        let guard = pin();
+        self.apply_batch_inner(batch, &guard)
     }
 
-    pub(crate) fn apply_batch_inner(&self, batch: Batch) -> Result<()> {
+    pub(crate) fn apply_batch_inner(
+        &self,
+        batch: Batch,
+        guard: &Guard,
+    ) -> Result<()> {
         let peg = self.context.pin_log()?;
         for (k, v_opt) in batch.writes {
             if let Some(v) = v_opt {
-                let _old = self.insert_inner(k, v)?;
+                let _old = self.insert_inner(k, v, guard)?;
             } else {
-                let _old = self.remove_inner(k)?;
+                let _old = self.remove_inner(k, guard)?;
             }
         }
 
@@ -356,21 +362,21 @@ impl Tree {
     /// assert_eq!(t.get(&[1]), Ok(None));
     /// ```
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<IVec>> {
-        let _ = self.concurrency_control.read();
-        self.get_inner(key)
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
+        self.get_inner(key, &guard)
     }
 
     pub(crate) fn get_inner<K: AsRef<[u8]>>(
         &self,
         key: K,
+        guard: &Guard,
     ) -> Result<Option<IVec>> {
         let _measure = Measure::new(&M.tree_get);
 
         trace!("getting key {:?}", key.as_ref());
 
-        let guard = pin();
-
-        let View { node_view, .. } = self.view_for_key(key.as_ref(), &guard)?;
+        let View { node_view, .. } = self.view_for_key(key.as_ref(), guard)?;
 
         let pair = node_view.leaf_pair_for_key(key.as_ref());
         let val = pair.map(|kv| kv.1.clone());
@@ -396,13 +402,15 @@ impl Tree {
     /// assert_eq!(t.remove(&[1]), Ok(None));
     /// ```
     pub fn remove<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<IVec>> {
-        let _ = self.concurrency_control.read();
-        self.remove_inner(key)
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
+        self.remove_inner(key, &guard)
     }
 
     pub(crate) fn remove_inner<K: AsRef<[u8]>>(
         &self,
         key: K,
+        guard: &Guard,
     ) -> Result<Option<IVec>> {
         let _measure = Measure::new(&M.tree_del);
 
@@ -413,8 +421,6 @@ impl Tree {
         }
 
         loop {
-            let guard = pin();
-
             let View { pid, node_view, .. } =
                 self.view_for_key(key.as_ref(), &guard)?;
 
@@ -504,7 +510,8 @@ impl Tree {
         trace!("casing key {:?}", key.as_ref());
         let _measure = Measure::new(&M.tree_cas);
 
-        let _ = self.concurrency_control.read();
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
 
         if self.context.read_only {
             return Err(Error::Unsupported(
@@ -517,7 +524,6 @@ impl Tree {
         // we need to retry caps until old != cur, since just because
         // cap fails it doesn't mean our value was changed.
         loop {
-            let guard = pin();
             let View { pid, node_view, .. } =
                 self.view_for_key(key.as_ref(), &guard)?;
 
@@ -848,7 +854,8 @@ impl Tree {
         K: AsRef<[u8]>,
     {
         let _measure = Measure::new(&M.tree_get);
-        let _ = self.concurrency_control.read();
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
         self.range(..key).next_back().transpose()
     }
 
@@ -903,7 +910,8 @@ impl Tree {
         K: AsRef<[u8]>,
     {
         let _measure = Measure::new(&M.tree_get);
-        let _ = self.concurrency_control.read();
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
         self.range((ops::Bound::Excluded(key), ops::Bound::Unbounded))
             .next()
             .transpose()
@@ -968,7 +976,8 @@ impl Tree {
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
-        let _ = self.concurrency_control.read();
+        let guard = pin();
+        let _ = self.concurrency_control.read(&guard);
         self.merge_inner(key, value)
     }
 


### PR DESCRIPTION
This uses some self-tuning concurrency control logic to avoid taking out reader locks on common tree operations unless the system has ever used something that requires them. This trades a small amount of effort on the transactional workload side for the first operation performed, where it sets the enabled boolean to true and then waits for all in-flight operations to finish via sending a deferred mpsc send over crossbeam-epoch to be executed after all currently active threads are done.

The result of this is that non-transactional/locking operations (checksum is locking, in addition to transactions) and workloads never need to pay the reader lock acquisition costs on every update, which actually speeds things up quite a lot.

For reads on a database with 10k items with 4 byte keys, this causes read throughput on my laptop with 12 cores to go from 6.3 million reads/second to 15-19 million reads per second.  

Self-tuning is pretty fun :)