### PR TITLE
add fallback when `libc::sync_file_range` is not supported

### DIFF
--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -541,7 +541,12 @@ impl IoBufs {
                         )
                     };
                     if ret < 0 {
-                        return Err(std::io::Error::last_os_error().into());
+                        let err = std::io::Error::last_os_error();
+                        if let Some(libc::ENOSYS) = err.raw_os_error() {
+                            f.sync_all()?;
+                        } else {
+                            return Err(err.into());
+                        }                        
                     }
                 }
 


### PR DESCRIPTION
This PR fixes #957 by falling back to `File::sync_all` when `libc::sync_file_range` is not supported.