### PR TITLE
reuse io buffers for rolled segments

### DIFF
--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -1047,6 +1047,7 @@ pub(in crate::pagecache) fn maybe_seal_and_write_iobuf(
         let new_salt = bump_salt(last_salt);
 
         IoBuf {
+            // reuse the previous io buffer
             buf: iobuf.buf.clone(),
             header: CachePadded::new(AtomicU64::new(new_salt)),
             base: iobuf.base + res_len,

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -614,9 +614,10 @@ impl IoBufs {
         #[cfg(feature = "io_uring")]
         {
             let mut wrote = 0;
-            let mut to_write = &data[wrote..];
-            let mut offset = log_offset;
             while wrote < total_len {
+                let to_write = &data[wrote..];
+                let offset = log_offset + wrote as u64;
+
                 // we take out this mutex to guarantee
                 // that our `Link` write operation below
                 // is serialized with the following sync.
@@ -641,7 +642,7 @@ impl IoBufs {
                 let sync_completion = self.io_uring.sync_file_range(
                     &*self.config.file,
                     offset,
-                    remaining_len,
+                    to_write.len(),
                 );
 
                 sync_completion.wait()?;


### PR DESCRIPTION
This causes io buffers to be reused until they fill up to the end, reducing allocations and initialization work. This is a lead-up to a significant reduction in reservation contention by leaning more into `Arc`s and lock-free atomic add for reservations.