### PR TITLE
Change transaction `apply_batch` to take argument by-reference.

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -299,9 +299,9 @@ impl TransactionalTree {
     /// Atomically apply multiple inserts and removals.
     pub fn apply_batch(
         &self,
-        batch: Batch,
+        batch: &Batch,
     ) -> UnabortableTransactionResult<()> {
-        for (k, v_opt) in batch.writes {
+        for (k, v_opt) in &batch.writes {
             if let Some(v) = v_opt {
                 let _old = self.insert(k, v)?;
             } else {


### PR DESCRIPTION
This change facilitates that you can setup a batch and then execute it
inside of a transaction. For example:

```rust
let db = config.open().unwrap();
let t1 = db.open_tree(b"1")?;

let mut b1 = Batch::default();
b1.insert(b"k1", b"v1");
b1.insert(b"k2", b"v2");

t1.transaction(|tree| {
    tree.apply_batch(&b1)?;
    Ok(())
})?;
```

----

This PR is the implementation of #1013 if it is accepted.

----

I did have a spurious fail in the test `log_writebatch`, but I am unsure if 
it is connected to this change in any way.