### PR TITLE
Various code cleanup things

### DIFF
--- a/examples/structured.rs
+++ b/examples/structured.rs
@@ -190,7 +190,8 @@ fn hash_join(db: &sled::Db) -> sled::Result<()> {
     let mut join = std::collections::HashMap::new();
 
     for name_value_res in &cats {
-        // cats are stored as name -> favorite_number + battles_won + home name variable bytes
+        // cats are stored as name -> favorite_number + battles_won + home name
+        // variable bytes
         let (name, value_bytes) = name_value_res?;
         let (_, home_name): (LayoutVerified<&[u8], CatValue>, &[u8]) =
             LayoutVerified::new_from_prefix(&*value_bytes).unwrap();
@@ -200,7 +201,8 @@ fn hash_join(db: &sled::Db) -> sled::Result<()> {
     }
 
     for name_value_res in &dogs {
-        // dogs are stored as name -> home name variable bytes + woof count + postal code
+        // dogs are stored as name -> home name variable bytes + woof count +
+        // postal code
         let (name, value_bytes) = name_value_res?;
 
         // note that this is reversed from the cat example above, where

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -35,18 +35,12 @@ pub struct Batch {
 
 impl Batch {
     /// Set a key to a new value
-    pub fn insert<K, V>(&mut self, key: K, value: V)
-    where
-        IVec: From<K> + From<V>,
-    {
-        self.writes.insert(IVec::from(key), Some(IVec::from(value)));
+    pub fn insert<K: Into<IVec>, V: Into<IVec>>(&mut self, key: K, value: V) {
+        self.writes.insert(key.into(), Some(value.into()));
     }
 
     /// Remove a key
-    pub fn remove<K>(&mut self, key: K)
-    where
-        IVec: From<K>,
-    {
-        self.writes.insert(IVec::from(key), None);
+    pub fn remove<K: Into<IVec>>(&mut self, key: K) {
+        self.writes.insert(key.into(), None);
     }
 }

--- a/src/binary_search.rs
+++ b/src/binary_search.rs
@@ -35,11 +35,7 @@ pub fn binary_search<'a>(key: &[u8], s: &'a [IVec]) -> Result<usize, usize> {
     #[allow(unsafe_code)]
     let l = unsafe { s.get_unchecked(base).as_ref() };
     let cmp = fastcmp(l, key);
-    if cmp == Equal {
-        Ok(base)
-    } else {
-        Err(base + (cmp == Less) as usize)
-    }
+    if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as usize) }
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -500,14 +500,38 @@ impl Config {
     }
 
     builder!(
-        (cache_capacity, u64, "maximum size in bytes for the system page cache"),
-        (mode, Mode, "specify whether the system should run in \"small\" or \"fast\" mode"),
+        (
+            cache_capacity,
+            u64,
+            "maximum size in bytes for the system page cache"
+        ),
+        (
+            mode,
+            Mode,
+            "specify whether the system should run in \"small\" or \"fast\" mode"
+        ),
         (use_compression, bool, "whether to use zstd compression"),
-        (compression_factor, i32, "the compression factor to use with zstd compression. Ranges from 1 up to 22. 0 is 'default'. Levels >= 20 are 'ultra'."),
-        (temporary, bool, "deletes the database after drop. if no path is set, uses /dev/shm on linux"),
-        (create_new, bool, "attempts to exclusively open the database, failing if it already exists"),
+        (
+            compression_factor,
+            i32,
+            "the compression factor to use with zstd compression. Ranges from 1 up to 22. 0 is 'default'. Levels >= 20 are 'ultra'."
+        ),
+        (
+            temporary,
+            bool,
+            "deletes the database after drop. if no path is set, uses /dev/shm on linux"
+        ),
+        (
+            create_new,
+            bool,
+            "attempts to exclusively open the database, failing if it already exists"
+        ),
         (read_only, bool, "whether to run in read-only mode"),
-        (print_profile_on_drop, bool, "print a performance profile when the Config is dropped")
+        (
+            print_profile_on_drop,
+            bool,
+            "print a performance profile when the Config is dropped"
+        )
     );
 
     // panics if config options are outside of advised range

--- a/src/fastlock.rs
+++ b/src/fastlock.rs
@@ -54,10 +54,6 @@ impl<T> FastLock<T> {
         // otherwise the current value. If we succeed, it should return false.
         let success = !lock_result;
 
-        if success {
-            Some(FastLockGuard { mu: self })
-        } else {
-            None
-        }
+        if success { Some(FastLockGuard { mu: self }) } else { None }
     }
 }

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -6,7 +6,7 @@ use parking_lot::{Condvar, Mutex};
 
 use super::*;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShutdownState {
     Running,
     ShuttingDown,
@@ -15,19 +15,11 @@ pub(crate) enum ShutdownState {
 
 impl ShutdownState {
     fn is_running(self) -> bool {
-        if let ShutdownState::Running = self {
-            true
-        } else {
-            false
-        }
+        self == ShutdownState::Running
     }
 
     fn is_shutdown(self) -> bool {
-        if let ShutdownState::ShutDown = self {
-            true
-        } else {
-            false
-        }
+        self == ShutdownState::ShutDown
     }
 }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -40,14 +40,11 @@ impl Meta {
 
 /// Open or create a new disk-backed Tree with its own keyspace,
 /// accessible from the `Db` via the provided identifier.
-pub(crate) fn open_tree<V>(
+pub(crate) fn open_tree<V: Into<IVec>>(
     context: &Context,
     raw_name: V,
     guard: &Guard,
-) -> Result<Tree>
-where
-    V: Into<IVec>,
-{
+) -> Result<Tree> {
     let name = raw_name.into();
 
     // we loop because creating this Tree may race with

--- a/src/node.rs
+++ b/src/node.rs
@@ -704,11 +704,7 @@ impl Data {
     }
 
     pub(crate) fn is_index(&self) -> bool {
-        if let Data::Index(..) = self {
-            true
-        } else {
-            false
-        }
+        if let Data::Index(..) = self { true } else { false }
     }
 }
 

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -272,9 +272,10 @@ impl Log {
 
             // try to claim space
             let prospective_size = buf_offset + inline_buf_len;
-            // we don't reserve anything if we're within the last MAX_MSG_HEADER_LEN
-            // bytes of the buffer. during recovery, we assume that nothing
-            // can begin here, because headers are dynamically sized.
+            // we don't reserve anything if we're within the last
+            // MAX_MSG_HEADER_LEN bytes of the buffer. during
+            // recovery, we assume that nothing can begin here,
+            // because headers are dynamically sized.
             let red_zone = iobuf.capacity - buf_offset < MAX_MSG_HEADER_LEN;
             let would_overflow = prospective_size > iobuf.capacity || red_zone;
             if would_overflow {
@@ -800,8 +801,7 @@ pub(crate) fn read_message<R: ReadAt>(
                 {
                     debug!(
                         "underlying blob file not found for blob {} in segment number {:?}",
-                        id,
-                        header.segment_number,
+                        id, header.segment_number,
                     );
                     Ok(LogRead::DanglingBlob(header, id, inline_len))
                 }

--- a/src/pagecache/parallel_io_windows.rs
+++ b/src/pagecache/parallel_io_windows.rs
@@ -43,7 +43,7 @@ fn seek_write_all<F: FileExt>(
                 return Err(io::Error::new(
                     io::ErrorKind::WriteZero,
                     "failed to write whole buffer",
-                ))
+                ));
             }
             Ok(n) => {
                 buf = &buf[n..];

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -215,27 +215,15 @@ impl Default for Segment {
 
 impl Segment {
     fn is_free(&self) -> bool {
-        if let Segment::Free(_) = self {
-            true
-        } else {
-            false
-        }
+        if let Segment::Free(_) = self { true } else { false }
     }
 
     fn is_active(&self) -> bool {
-        if let Segment::Active { .. } = self {
-            true
-        } else {
-            false
-        }
+        if let Segment::Active { .. } = self { true } else { false }
     }
 
     fn is_inactive(&self) -> bool {
-        if let Segment::Inactive { .. } = self {
-            true
-        } else {
-            false
-        }
+        if let Segment::Inactive { .. } = self { true } else { false }
     }
 
     fn free_to_active(&mut self, new_lsn: Lsn) {
@@ -780,7 +768,7 @@ impl SegmentAccountant {
             old_cache_infos,
             new_cache_info,
             self.config.normalize(lsn)
-            );
+        );
 
         let new_idx = self.segment_id(new_cache_info.pointer.lid());
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -243,19 +243,17 @@ impl<T> From<Error> for TransactionError<T> {
 
 impl TransactionalTree {
     /// Set a key to a new value
-    pub fn insert<K, V>(
+    pub fn insert<K>(
         &self,
         key: K,
-        value: V,
+        value: impl Into<IVec>,
     ) -> UnabortableTransactionResult<Option<IVec>>
     where
-        IVec: From<K> + From<V>,
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + Into<IVec>,
     {
         let old = self.get(key.as_ref())?;
         let mut writes = self.writes.borrow_mut();
-        let _last_write =
-            writes.insert(IVec::from(key), Some(IVec::from(value)));
+        let _last_write = writes.insert(key.into(), Some(value.into()));
         Ok(old)
     }
 
@@ -265,12 +263,11 @@ impl TransactionalTree {
         key: K,
     ) -> UnabortableTransactionResult<Option<IVec>>
     where
-        IVec: From<K>,
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + Into<IVec>,
     {
         let old = self.get(key.as_ref());
         let mut writes = self.writes.borrow_mut();
-        let _last_write = writes.insert(IVec::from(key), None);
+        let _last_write = writes.insert(key.into(), None);
         old
     }
 

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -167,19 +167,14 @@ fn verify_batches(tree: &sled::Tree) -> u32 {
             Some(v) => v,
             None => panic!(
                 "expected key {} to have a value, instead it was missing in db: {:?}",
-                key,
-                tree
+                key, tree
             ),
         };
         let value = slice_to_u32(&*v);
         assert_eq!(
-            first_value,
-            value,
+            first_value, value,
             "expected key {} to have value {}, instead it had value {} in db: {:?}",
-            key,
-            first_value,
-            value,
-            tree
+            key, first_value, value, tree
         );
     }
 


### PR DESCRIPTION
- Converted all instances of `T: From<U>` to `U: From<T>` (Fixes #999)
- rustfmt
- converted some instances of `if let` to a more idiomatic match
- Added Eq/PartialEq to ShutdownState

My editor automatically runs rustfmt but I can revert those changes if you prefer