### PR TITLE
safety-critical recovery approach

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ log = "0.4.8"
 parking_lot = "0.10.0"
 color-backtrace = { version = "0.3.0", optional = true }
 rio = { version = "0.9.2", optional = true }
+backtrace = "0.3.46"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os="windows"))'.dependencies]
 fs2 = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ log = "0.4.8"
 parking_lot = "0.10.0"
 color-backtrace = { version = "0.4.0", optional = true }
 rio = { version = "0.9.2", optional = true }
-backtrace = "0.3.46"
+backtrace = "0.3.48"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os="windows"))'.dependencies]
 fs2 = "0.4.3"

--- a/SAFETY.md
+++ b/SAFETY.md
@@ -1,0 +1,109 @@
+# sled safety model
+
+This document applies
+[STPA](http://psas.scripts.mit.edu/home/get_file.php?name=STPA_handbook.pdf)-style
+hazard analysis to the sled embedded database for the purpose of guiding
+design and testing efforts to prevent unacceptable losses.
+
+Outline
+
+* [purpose of analysis](#purpose-of-analysis)
+  * [losses](#losses)
+  * [system boundary](#system-boundary)
+  * [hazards](#hazards)
+  * [leading indicators](#leading-indicators)
+  * [constraints](#constraints)
+* [model of control structure](#model-of-control-structure)
+* [identify unsafe control actions](#identify-unsafe-control-actions)
+* [identify loss scenarios][#identify-loss-scenarios)
+* [resources for learning more about STAMP, STPA, and CAST](#resources)
+
+# Purpose of Analysis
+
+## Losses
+
+We wish to prevent the following undesirable situations:
+
+* data loss
+* inconsistent (non-linearizable) data access
+* process crash
+* resource exhaustion
+
+## System Boundary
+
+We draw the line between system and environment where we can reasonably
+invest our efforts to prevent losses.
+
+Inside the boundary:
+
+* codebase
+  * put safe control actions into place that prevent losses
+* documentation
+  * show users how to use sled safely
+  * recommend hardware, kernels, user code
+
+Outside the boundary:
+
+* Direct changes to hardware, kernels, user code
+
+## Hazards
+
+These hazards can result in the above losses:
+
+* data may be lost if
+  * bugs in the logging system
+    * `Db::flush` fails to make previous writes durable
+  * bugs in the GC system
+    * the old location is overwritten before the defragmented location becomes durable
+  * bugs in the recovery system
+  * hardare failures
+* consistency violations may be caused by
+  * transaction concurrency control failure to enforce linearizability (strict serializability)
+  * non-linearizable lock-free single-key operations
+* panic
+  * of user threads
+  * IO threads
+  * flusher & GC thread
+  * indexing
+  * unwraps/expects
+  * failed TryInto/TryFrom + unwrap
+* persistent storage exceeding (2 + N concurrent writers) * logical data size
+* in-memory cache exceeding the configured cache size
+  * caused by incorrect calculation of cache
+* use-after-free
+* data race
+* memory leak
+* integer overflow
+* buffer overrun
+* uninitialized memory access
+
+## Constraints
+
+# Models of Control Structures
+
+for each control action we have, consider:
+
+1. what hazards happen when we fail to apply it / it does not exist?
+2. what hazards happen when we do apply it
+3. what hazards happen when we apply it too early or too late?
+4. what hazards happen if we apply it for too long or not long enough?
+
+durability model
+
+  * recovery
+    * LogIter::max_lsn
+      * return None if last_lsn_in_batch >= self.max_lsn
+    * batch requirement set to last reservation base + inline len - 1
+      * reserve bumps
+        * bump_atomic_lsn(&self.iobufs.max_reserved_lsn, reservation_lsn + inline_buf_len as Lsn - 1);
+
+lock-free linearizability model
+
+transactional linearizability (strict serializability) model
+
+panic model
+
+memory usage model
+
+storage usage model
+

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,6 +1,12 @@
 #![allow(unused_results)]
 
-use std::collections::HashMap;
+#[cfg(not(feature = "testing"))]
+use std::collections::HashMap as Map;
+
+// we avoid HashMap while testing because
+// it makes tests non-deterministic
+#[cfg(feature = "testing")]
+use std::collections::BTreeMap as Map;
 
 use super::*;
 
@@ -32,7 +38,7 @@ use super::*;
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct Batch {
-    pub(crate) writes: HashMap<IVec, Option<IVec>>,
+    pub(crate) writes: Map<IVec, Option<IVec>>,
 }
 
 impl Batch {

--- a/src/concurrency_control.rs
+++ b/src/concurrency_control.rs
@@ -50,12 +50,10 @@ impl<'a> Drop for Protector<'a> {
     }
 }
 
-#[must_use]
 pub(crate) fn read<'a>() -> Protector<'a> {
     CONCURRENCY_CONTROL.read()
 }
 
-#[must_use]
 pub(crate) fn write<'a>() -> Protector<'a> {
     CONCURRENCY_CONTROL.write()
 }
@@ -70,7 +68,7 @@ impl ConcurrencyControl {
         }
     }
 
-    fn read<'a>(&'a self) -> Protector<'a> {
+    fn read(&self) -> Protector<'_> {
         #[cfg(feature = "testing")]
         COUNT.with(|c| {
             let mut c = c.borrow_mut();

--- a/src/concurrency_control.rs
+++ b/src/concurrency_control.rs
@@ -21,6 +21,7 @@ fn init_cc() -> ConcurrencyControl {
     ConcurrencyControl::default()
 }
 
+#[derive(Debug)]
 pub(crate) enum Protector<'a> {
     Write(RwLockWriteGuard<'a, ()>),
     Read(RwLockReadGuard<'a, ()>),

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,13 +78,13 @@ impl StorageParameters {
                 k
             } else {
                 error!("failed to parse persisted config line: {}", line);
-                return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                return Err(Error::corruption(None));
             };
             let v = if let Some(v) = split.next() {
                 v
             } else {
                 error!("failed to parse persisted config line: {}", line);
-                return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                return Err(Error::corruption(None));
             };
             lines.insert(k, v);
         }
@@ -94,13 +94,13 @@ impl StorageParameters {
                 parsed
             } else {
                 error!("failed to parse segment_size value: {}", raw);
-                return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                return Err(Error::corruption(None));
             }
         } else {
             error!(
                 "failed to retrieve required configuration parameter: segment_size"
             );
-            return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+            return Err(Error::corruption(None));
         };
 
         let use_compression: bool = if let Some(raw) =
@@ -110,13 +110,13 @@ impl StorageParameters {
                 parsed
             } else {
                 error!("failed to parse use_compression value: {}", raw);
-                return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                return Err(Error::corruption(None));
             }
         } else {
             error!(
                 "failed to retrieve required configuration parameter: use_compression"
             );
-            return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+            return Err(Error::corruption(None));
         };
 
         let version: (usize, usize) = if let Some(raw) = lines.get("version") {
@@ -129,11 +129,11 @@ impl StorageParameters {
                         "failed to parse major version value from line: {}",
                         raw
                     );
-                    return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                    return Err(Error::corruption(None));
                 }
             } else {
                 error!("failed to parse major version value: {}", raw);
-                return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                return Err(Error::corruption(None));
             };
 
             let minor = if let Some(raw_minor) = split.next() {
@@ -144,11 +144,11 @@ impl StorageParameters {
                         "failed to parse minor version value from line: {}",
                         raw
                     );
-                    return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                    return Err(Error::corruption(None));
                 }
             } else {
                 error!("failed to parse minor version value: {}", raw);
-                return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+                return Err(Error::corruption(None));
             };
 
             (major, minor)
@@ -156,7 +156,7 @@ impl StorageParameters {
             error!(
                 "failed to retrieve required configuration parameter: version"
             );
-            return Err(Error::Corruption { at: DiskPtr::Inline(0) });
+            return Err(Error::corruption(None));
         };
 
         Ok(StorageParameters { segment_size, use_compression, version })

--- a/src/config.rs
+++ b/src/config.rs
@@ -500,14 +500,38 @@ impl Config {
     }
 
     builder!(
-        (cache_capacity, u64, "maximum size in bytes for the system page cache"),
-        (mode, Mode, "specify whether the system should run in \"small\" or \"fast\" mode"),
+        (
+            cache_capacity,
+            u64,
+            "maximum size in bytes for the system page cache"
+        ),
+        (
+            mode,
+            Mode,
+            "specify whether the system should run in \"small\" or \"fast\" mode"
+        ),
         (use_compression, bool, "whether to use zstd compression"),
-        (compression_factor, i32, "the compression factor to use with zstd compression. Ranges from 1 up to 22. 0 is 'default'. Levels >= 20 are 'ultra'."),
-        (temporary, bool, "deletes the database after drop. if no path is set, uses /dev/shm on linux"),
-        (create_new, bool, "attempts to exclusively open the database, failing if it already exists"),
+        (
+            compression_factor,
+            i32,
+            "the compression factor to use with zstd compression. Ranges from 1 up to 22. 0 is 'default'. Levels >= 20 are 'ultra'."
+        ),
+        (
+            temporary,
+            bool,
+            "deletes the database after drop. if no path is set, uses /dev/shm on linux"
+        ),
+        (
+            create_new,
+            bool,
+            "attempts to exclusively open the database, failing if it already exists"
+        ),
         (read_only, bool, "whether to run in read-only mode"),
-        (print_profile_on_drop, bool, "print a performance profile when the Config is dropped")
+        (
+            print_profile_on_drop,
+            bool,
+            "print a performance profile when the Config is dropped"
+        )
     );
 
     // panics if config options are outside of advised range

--- a/src/db.rs
+++ b/src/db.rs
@@ -113,7 +113,6 @@ impl Db {
                 subscribers: Subscribers::default(),
                 context: context.clone(),
                 root: AtomicU64::new(root),
-                concurrency_control: ConcurrencyControl::default(),
                 merge_operator: RwLock::new(None),
             }));
             assert!(tenants.insert(id, tree).is_none());
@@ -395,15 +394,13 @@ impl Db {
         let mut hasher = crc32fast::Hasher::new();
         let mut locks = vec![];
 
-        for tree in tenants.values() {
-            locks.push(tree.concurrency_control.write());
-        }
+        locks.push(concurrency_control::write());
 
         for (name, tree) in &tenants {
             hasher.update(name);
 
             let mut iter = tree.iter();
-            let _ = self.concurrency_control.write();
+            let _ = concurrency_control::write();
             while let Some(kv_res) = iter.next_inner() {
                 let (k, v) = kv_res?;
                 hasher.update(&k);

--- a/src/db.rs
+++ b/src/db.rs
@@ -400,7 +400,6 @@ impl Db {
             hasher.update(name);
 
             let mut iter = tree.iter();
-            let _ = concurrency_control::write();
             while let Some(kv_res) = iter.next_inner() {
                 let (k, v) = kv_res?;
                 hasher.update(&k);

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -75,7 +75,9 @@ impl EventLog {
                     if let Some(later_lsn) = minimum_lsn {
                         assert!(
                             later_lsn >= lsn,
-                            "lsn must never go down between recoveries or stabilizations"
+                            "lsn must never go down between recoveries \
+                            or stabilizations. It was {} but later became {}"
+                            lsn, later_lsn,
                         );
                     }
                     minimum_lsn = Some(lsn);

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -129,7 +129,7 @@ impl EventLog {
             }
         }
 
-        debug!("event log verified ✓");
+        debug!("event log verified \u{2713}");
     }
 
     pub(crate) fn stabilized_lsn(&self, lsn: Lsn) {

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -76,9 +76,13 @@ impl EventLog {
                         assert!(
                             later_lsn >= lsn,
                             "lsn must never go down between recoveries \
-                            or stabilizations. It was {} but later became {}",
+                            or stabilizations. It was {} but later became {}. history: {:?}",
                             lsn,
                             later_lsn,
+                            self.iter(&guard)
+                                .filter(|e| matches!(e, Event::Stabilized(_))
+                                    || matches!(e, Event::RecoveredLsn(_)))
+                                .collect::<Vec<_>>(),
                         );
                     }
                     minimum_lsn = Some(lsn);

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -128,6 +128,8 @@ impl EventLog {
                 }
             }
         }
+
+        debug!("event log verified ✓");
     }
 
     pub(crate) fn stabilized_lsn(&self, lsn: Lsn) {

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -76,8 +76,9 @@ impl EventLog {
                         assert!(
                             later_lsn >= lsn,
                             "lsn must never go down between recoveries \
-                            or stabilizations. It was {} but later became {}"
-                            lsn, later_lsn,
+                            or stabilizations. It was {} but later became {}",
+                            lsn,
+                            later_lsn,
                         );
                     }
                     minimum_lsn = Some(lsn);
@@ -159,11 +160,5 @@ impl EventLog {
     pub fn meta_after_restart(&self, meta: Meta) {
         let guard = pin();
         self.inner.push(Event::MetaOnRecovery { meta }, &guard);
-    }
-}
-
-impl Drop for EventLog {
-    fn drop(&mut self) {
-        self.verify();
     }
 }

--- a/src/fail.rs
+++ b/src/fail.rs
@@ -4,8 +4,11 @@ use parking_lot::Mutex;
 
 use crate::Lazy;
 
-type HM =
-    HashMap<&'static str, u64, std::hash::BuildHasherDefault<fxhash::FxHasher64>>;
+type HM = HashMap<
+    &'static str,
+    u64,
+    std::hash::BuildHasherDefault<fxhash::FxHasher64>,
+>;
 
 static ACTIVE: Lazy<Mutex<HM>, fn() -> Mutex<HM>> = Lazy::new(init);
 
@@ -18,7 +21,7 @@ pub fn is_active(name: &'static str) -> bool {
     let mut active = ACTIVE.lock();
     if let Some(bitset) = active.get_mut(&name) {
         let bit = *bitset & 1;
-        *bitset = *bitset >> 1;
+        *bitset >>= 1;
         if *bitset == 0 {
             active.remove(&name);
         }

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -65,8 +65,7 @@ fn run(
     let mut wrote_data = false;
     while shutdown.is_running() || wrote_data {
         let before = std::time::Instant::now();
-        let guard = pin();
-        let cc = concurrency_control::read(&guard);
+        let cc = concurrency_control::read();
         match pagecache.log.iobufs.roll_iobuf() {
             Ok(0) => {
                 wrote_data = false;

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -15,19 +15,11 @@ pub(crate) enum ShutdownState {
 
 impl ShutdownState {
     fn is_running(self) -> bool {
-        if let ShutdownState::Running = self {
-            true
-        } else {
-            false
-        }
+        if let ShutdownState::Running = self { true } else { false }
     }
 
     fn is_shutdown(self) -> bool {
-        if let ShutdownState::ShutDown = self {
-            true
-        } else {
-            false
-        }
+        if let ShutdownState::ShutDown = self { true } else { false }
     }
 }
 
@@ -73,7 +65,9 @@ fn run(
     let mut wrote_data = false;
     while shutdown.is_running() || wrote_data {
         let before = std::time::Instant::now();
-        match pagecache.flush() {
+        let guard = pin();
+        let cc = concurrency_control::read(&guard);
+        match pagecache.log.iobufs.roll_iobuf() {
             Ok(0) => {
                 wrote_data = false;
                 if !shutdown.is_running() {
@@ -105,6 +99,7 @@ fn run(
                 return;
             }
         }
+        drop(cc);
 
         // so we can spend a little effort
         // cleaning up the segments. try not to

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -66,7 +66,7 @@ fn run(
     while shutdown.is_running() || wrote_data {
         let before = std::time::Instant::now();
         let cc = concurrency_control::read();
-        match pagecache.log.iobufs.roll_iobuf() {
+        match pagecache.log.roll_iobuf() {
             Ok(0) => {
                 wrote_data = false;
                 if !shutdown.is_running() {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -158,8 +158,7 @@ impl Iterator for Iter {
 
     fn next(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_scan);
-        let guard = pin();
-        let _ = concurrency_control::read(&guard);
+        let _cc = concurrency_control::read();
         self.next_inner()
     }
 
@@ -172,7 +171,7 @@ impl DoubleEndedIterator for Iter {
     fn next_back(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_reverse_scan);
         let guard = pin();
-        let _ = concurrency_control::read(&guard);
+        let _cc = concurrency_control::read();
 
         let (mut pid, mut node, guard) =
             if let (false, Some((pid, node, guard))) =

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -159,7 +159,7 @@ impl Iterator for Iter {
     fn next(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_scan);
         let guard = pin();
-        let _ = self.tree.concurrency_control.read(&guard);
+        let _ = concurrency_control::read(&guard);
         self.next_inner()
     }
 
@@ -172,7 +172,7 @@ impl DoubleEndedIterator for Iter {
     fn next_back(&mut self) -> Option<Self::Item> {
         let _measure = Measure::new(&M.tree_reverse_scan);
         let guard = pin();
-        let _ = self.tree.concurrency_control.read(&guard);
+        let _ = concurrency_control::read(&guard);
 
         let (mut pid, mut node, guard) =
             if let (false, Some((pid, node, guard))) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ pub use self::{
 use {
     self::{
         binary_search::binary_search_lub,
-        concurrency_control::{ConcurrencyControl, Protector},
+        concurrency_control::Protector,
         context::Context,
         fastcmp::fastcmp,
         histogram::Histogram,

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -90,7 +90,8 @@ impl AccessQueue {
                     continue;
                 }
 
-                // push the now-full item to the full list for future consumption
+                // push the now-full item to the full list for future
+                // consumption
                 let mut ret;
                 let mut full_list_ptr = self.full_list.load(Ordering::Acquire);
                 while {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -64,7 +64,6 @@ where
                     context: context.clone(),
                     subscribers: Subscribers::default(),
                     root: AtomicU64::new(root_id),
-                    concurrency_control: ConcurrencyControl::default(),
                     merge_operator: RwLock::new(None),
                 })));
             }
@@ -116,7 +115,6 @@ where
             subscribers: Subscribers::default(),
             context: context.clone(),
             root: AtomicU64::new(root_id),
-            concurrency_control: ConcurrencyControl::default(),
             merge_operator: RwLock::new(None),
         })));
     }

--- a/src/pagecache/blob_io.rs
+++ b/src/pagecache/blob_io.rs
@@ -58,7 +58,7 @@ pub(crate) fn read_blob(
     } else {
         warn!("blob {} failed crc check!", blob_ptr);
 
-        Err(Error::Corruption { at: DiskPtr::Blob(0, blob_ptr) })
+        Err(Error::corruption(Some(DiskPtr::Blob(0, blob_ptr))))
     }
 }
 

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -507,23 +507,6 @@ impl IoBufs {
         ret
     }
 
-    pub(crate) fn roll_iobuf(self: &Arc<Self>) -> Result<usize> {
-        let iobuf = self.current_iobuf();
-        let header = iobuf.get_header();
-        if is_sealed(header) {
-            trace!("skipping roll_iobuf due to already-sealed header");
-            return Ok(0);
-        }
-        if offset(header) == 0 {
-            trace!("skipping roll_iobuf due to empty segment");
-        } else {
-            trace!("sealing ioubuf from  roll_iobuf");
-            maybe_seal_and_write_iobuf(self, &iobuf, header, false)?;
-        }
-
-        Ok(offset(header))
-    }
-
     /// Return an iterator over the log, starting with
     /// a specified offset.
     pub(crate) fn iter_from(&self, lsn: Lsn) -> LogIter {
@@ -876,6 +859,23 @@ impl IoBufs {
         std::mem::forget(arc.clone());
         arc
     }
+}
+
+pub(crate) fn roll_iobuf(iobufs: &Arc<IoBufs>) -> Result<usize> {
+    let iobuf = iobufs.current_iobuf();
+    let header = iobuf.get_header();
+    if is_sealed(header) {
+        trace!("skipping roll_iobuf due to already-sealed header");
+        return Ok(0);
+    }
+    if offset(header) == 0 {
+        trace!("skipping roll_iobuf due to empty segment");
+    } else {
+        trace!("sealing ioubuf from  roll_iobuf");
+        maybe_seal_and_write_iobuf(iobufs, &iobuf, header, false)?;
+    }
+
+    Ok(offset(header))
 }
 
 /// Blocks until the specified log sequence number has

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -515,7 +515,6 @@ impl IoBufs {
             config: self.config.clone(),
             max_lsn: self.stable(),
             cur_lsn: corrected_lsn,
-            segment_lid: None,
             segment_base: None,
             segments,
         }

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -365,7 +365,7 @@ impl IoBufs {
             (Some(_), None) => unreachable!(),
         };
 
-        assert!(next_lsn >= next_lid as Lsn);
+        assert!(next_lsn >= Lsn::try_from(next_lid).unwrap());
 
         debug!(
             "starting IoBufs with next_lsn: {} \

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -514,14 +514,14 @@ impl IoBufs {
             trace!("skipping roll_iobuf due to already-sealed header");
             return Ok(0);
         }
-        if offset(header) != 0 {
+        if offset(header) == 0 {
+            trace!("skipping roll_iobuf due to empty segment");
+        } else {
             trace!("sealing ioubuf from  roll_iobuf");
             maybe_seal_and_write_iobuf(self, &iobuf, header, false)?;
-        } else {
-            trace!("skipping roll_iobuf due to empty segment");
         }
 
-        return Ok(offset(header));
+        Ok(offset(header))
     }
 
     /// Return an iterator over the log, starting with

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -191,11 +191,7 @@ impl IoBuf {
     ) -> std::result::Result<Header, Header> {
         debug_delay();
         let res = self.header.compare_and_swap(old, new, SeqCst);
-        if res == old {
-            Ok(new)
-        } else {
-            Err(res)
-        }
+        if res == old { Ok(new) } else { Err(res) }
     }
 }
 
@@ -263,7 +259,7 @@ impl StabilityIntervals {
                 low,
                 high
             );
-            if high < self.stable_lsn {
+            if high <= self.stable_lsn {
                 if let Some(bsl) = batch_stable_lsn {
                     assert!(bsl < high);
                 }

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -1014,8 +1014,7 @@ pub(in crate::pagecache) fn make_stable_inner(
 /// to flush some pending writes. Returns the number
 /// of bytes written during this call.
 pub(in crate::pagecache) fn flush(iobufs: &Arc<IoBufs>) -> Result<usize> {
-    let guard = pin();
-    let _cc = concurrency_control::read(&guard);
+    let _cc = concurrency_control::read();
     let max_reserved_lsn = iobufs.max_reserved_lsn.load(SeqCst);
     make_stable(iobufs, max_reserved_lsn)
 }

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -504,6 +504,7 @@ impl IoBufs {
             cur_lsn: None,
             segment_base: None,
             segments,
+            last_stage: false,
         }
     }
 
@@ -813,6 +814,7 @@ impl IoBufs {
         let updated = intervals.mark_fsync(interval);
 
         if let Some(new_stable_lsn) = updated {
+            trace!("mark_interval new highest lsn {}", new_stable_lsn);
             self.stable_lsn.store(new_stable_lsn, SeqCst);
 
             #[cfg(feature = "event_log")]

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -250,8 +250,7 @@ impl StabilityIntervals {
             }
         }
 
-        let mut stable_lsn =
-            if self.batches.is_empty() { Some(self.stable_lsn) } else { None };
+        let mut batch_stable_lsn = None;
 
         while let Some(&(low, high)) = self.batches.last() {
             assert!(
@@ -261,14 +260,21 @@ impl StabilityIntervals {
                 high
             );
             if high < self.stable_lsn {
-                stable_lsn = Some(high);
+                if let Some(bsl) = batch_stable_lsn {
+                    assert!(bsl < high);
+                }
+                batch_stable_lsn = Some(high);
                 self.batches.pop().unwrap();
             } else {
                 break;
             }
         }
 
-        stable_lsn
+        if self.batches.is_empty() {
+            Some(self.stable_lsn)
+        } else {
+            batch_stable_lsn
+        }
     }
 }
 

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -1140,7 +1140,8 @@ pub(in crate::pagecache) fn maybe_seal_and_write_iobuf(
                     lsn, e
                 );
 
-                // store error before notifying so that waiting threads will see it
+                // store error before notifying so that waiting threads will see
+                // it
                 iobufs.config.set_global_error(e);
 
                 let intervals = iobufs.intervals.lock();

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -845,9 +845,8 @@ impl IoBufs {
             // having held the mutex makes this linearized
             // with the notify below.
             drop(intervals);
-
-            let _notified = self.interval_updated.notify_all();
         }
+        let _notified = self.interval_updated.notify_all();
     }
 
     pub(in crate::pagecache) fn current_iobuf(&self) -> Arc<IoBuf> {

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -193,7 +193,7 @@ impl LogIter {
         let segment_header = read_segment_header(f, offset)?;
         if offset % self.config.segment_size as LogOffset != 0 {
             debug!("segment offset not divisible by segment length");
-            return Err(Error::Corruption { at: DiskPtr::Inline(offset) });
+            return Err(Error::corruption(None));
         }
         if segment_header.lsn % self.config.segment_size as Lsn != 0 {
             debug!(
@@ -201,7 +201,7 @@ impl LogIter {
                  by the segment_size ({}) instead it was {}",
                 self.config.segment_size, segment_header.lsn
             );
-            return Err(Error::Corruption { at: DiskPtr::Inline(offset) });
+            return Err(Error::corruption(None));
         }
 
         if segment_header.lsn != lsn {

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -52,6 +52,7 @@ impl Iterator for LogIter {
                     }
                 } else {
                     trace!("no segments remaining to iterate over");
+
                     return None;
                 }
             }

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -221,13 +221,14 @@ impl LogIter {
 
         trace!("read segment header {:?}", segment_header);
 
-        self.cur_lsn = segment_header.lsn + SEG_HEADER_LEN as Lsn;
-
         let mut buf = vec![0; self.config.segment_size];
         let size = pread_exact_or_eof(f, &mut buf, offset)?;
 
         trace!("setting stored segment buffer length to {} after read", size);
         buf.truncate(size);
+
+        self.cur_lsn = segment_header.lsn + SEG_HEADER_LEN as Lsn;
+
         self.segment_base = Some(BasedBuf { buf, offset });
 
         // NB this should only happen after we've successfully read

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -729,14 +729,6 @@ pub(crate) fn read_message<R: ReadAt>(
 
     assert!(lid + message_offset as LogOffset <= ceiling);
 
-    if header.segment_number != expected_segment_number {
-        debug!(
-            "header {:?} does not contain expected segment_number {:?}",
-            header, expected_segment_number
-        );
-        return Ok(LogRead::Corrupted);
-    }
-
     let max_possible_len =
         assert_usize(ceiling - lid - message_offset as LogOffset);
 
@@ -781,6 +773,14 @@ pub(crate) fn read_message<R: ReadAt>(
 
     let inline_len = u32::try_from(message_offset).unwrap()
         + u32::try_from(header.len).unwrap();
+
+    if header.segment_number != expected_segment_number {
+        debug!(
+            "header {:?} does not contain expected segment_number {:?}",
+            header, expected_segment_number
+        );
+        return Ok(LogRead::Corrupted);
+    }
 
     match header.kind {
         MessageKind::Canceled => {

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use super::{
     arr_to_lsn, arr_to_u32, assert_usize, bump_atomic_lsn, iobuf, lsn_to_arr,
-    maybe_decompress, pread_exact, pread_exact_or_eof, read_blob, u32_to_arr,
-    BasedBuf, BlobPointer, DiskPtr, IoBuf, IoBufs, LogKind, LogOffset, Lsn,
-    MessageKind, Reservation, Serialize, Snapshot, BATCH_MANIFEST_PID,
-    COUNTER_PID, MAX_MSG_HEADER_LEN, META_PID, MINIMUM_ITEMS_PER_SEGMENT,
-    SEG_HEADER_LEN,
+    maybe_decompress, pread_exact, pread_exact_or_eof, read_blob, roll_iobuf,
+    u32_to_arr, BasedBuf, BlobPointer, DiskPtr, IoBuf, IoBufs, LogKind,
+    LogOffset, Lsn, MessageKind, Reservation, Serialize, Snapshot,
+    BATCH_MANIFEST_PID, COUNTER_PID, MAX_MSG_HEADER_LEN, META_PID,
+    MINIMUM_ITEMS_PER_SEGMENT, SEG_HEADER_LEN,
 };
 
 use crate::*;
@@ -42,6 +42,10 @@ impl Log {
     /// a specified offset.
     pub fn iter_from(&self, lsn: Lsn) -> super::LogIter {
         self.iobufs.iter_from(lsn)
+    }
+
+    pub(crate) fn roll_iobuf(&self) -> Result<usize> {
+        roll_iobuf(&self.iobufs)
     }
 
     /// read a buffer from the disk

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -19,7 +19,7 @@ use crate::*;
 #[derive(Debug)]
 pub struct Log {
     /// iobufs is the underlying lock-free IO write buffer.
-    pub(super) iobufs: Arc<IoBufs>,
+    pub(crate) iobufs: Arc<IoBufs>,
     pub(crate) config: RunningConfig,
 }
 

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -347,7 +347,10 @@ impl Log {
                 reservation_lid,
             );
 
-            bump_atomic_lsn(&self.iobufs.max_reserved_lsn, reservation_lsn);
+            bump_atomic_lsn(
+                &self.iobufs.max_reserved_lsn,
+                reservation_lsn + inline_buf_len as Lsn - 1,
+            );
 
             let blob_id =
                 if over_blob_threshold { Some(reservation_lsn) } else { None };

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1592,6 +1592,12 @@ impl PageCache {
                 return Ok(Some(NodeView(page_view)));
             }
 
+            trace!(
+                "pulling pid {} view {:?} deref {:?}",
+                pid,
+                page_view,
+                page_view.deref()
+            );
             if page_view.cache_infos.first()
                 == last_attempted_cache_info.as_ref()
             {

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -801,6 +801,7 @@ impl PageCache {
     /// while performing this GC.
     pub(crate) fn attempt_gc(&self) -> Result<bool> {
         let guard = pin();
+        let _cc = concurrency_control::read(&guard);
         let to_clean = self.log.iobufs.segment_cleaner.pop();
         let ret = if let Some((pid_to_clean, segment_to_clean)) = to_clean {
             self.rewrite_page(pid_to_clean, segment_to_clean, &guard)

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1692,14 +1692,6 @@ impl PageCache {
         }
     }
 
-    /// Blocks until the provided Lsn is stable on disk,
-    /// triggering necessary flushes in the process.
-    /// Returns the number of bytes written during
-    /// this call.
-    pub(crate) fn make_stable(&self, lsn: Lsn) -> Result<usize> {
-        self.log.make_stable(lsn)
-    }
-
     /// Returns `true` if the database was
     /// recovered from a previous process.
     /// Note that database state is only

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -801,7 +801,7 @@ impl PageCache {
     /// while performing this GC.
     pub(crate) fn attempt_gc(&self) -> Result<bool> {
         let guard = pin();
-        let cc = concurrency_control::read(&guard);
+        let cc = concurrency_control::read();
         let to_clean = self.log.iobufs.segment_cleaner.pop();
         let ret = if let Some((pid_to_clean, segment_to_clean)) = to_clean {
             self.rewrite_page(pid_to_clean, segment_to_clean, &guard)

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1837,6 +1837,7 @@ impl PageCache {
                         update: None,
                         cache_infos: page_view.cache_infos,
                     });
+
                     debug_delay();
                     if page_view
                         .entry

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -20,8 +20,9 @@ mod reservation;
 mod segment;
 mod snapshot;
 
-use crate::*;
 use std::{collections::BinaryHeap, ops::Deref};
+
+use crate::*;
 
 #[cfg(all(not(unix), not(windows)))]
 use parallel_io_polyfill::{pread_exact, pread_exact_or_eof, pwrite_all};
@@ -1824,7 +1825,7 @@ impl PageCache {
             }
             Ok(other) => {
                 debug!("read unexpected page: {:?}", other);
-                Err(Error::Corruption { at: pointer })
+                Err(Error::corruption(Some(pointer)))
             }
             Err(e) => {
                 debug!("failed to read page: {:?}", e);

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -39,7 +39,7 @@ use self::{
         BATCH_MANIFEST_PID, COUNTER_PID, META_PID,
         PAGE_CONSOLIDATION_THRESHOLD, SEGMENT_CLEANUP_THRESHOLD,
     },
-    iobuf::{IoBuf, IoBufs},
+    iobuf::{roll_iobuf, IoBuf, IoBufs},
     iterator::{raw_segment_iter_from, LogIter},
     pagetable::PageTable,
     segment::{SegmentAccountant, SegmentCleaner, SegmentOp},
@@ -835,7 +835,7 @@ impl PageCache {
         // transactions with a begin and end message, rather
         // than a single beginning message that needs to
         // be held until we know the final batch LSN.
-        self.log.iobufs.roll_iobuf()?;
+        self.log.roll_iobuf()?;
 
         let batch_res = self.log.reserve(
             LogKind::Skip,

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -211,27 +211,15 @@ impl Default for Segment {
 
 impl Segment {
     fn is_free(&self) -> bool {
-        if let Segment::Free(_) = self {
-            true
-        } else {
-            false
-        }
+        if let Segment::Free(_) = self { true } else { false }
     }
 
     fn is_active(&self) -> bool {
-        if let Segment::Active { .. } = self {
-            true
-        } else {
-            false
-        }
+        if let Segment::Active { .. } = self { true } else { false }
     }
 
     fn is_inactive(&self) -> bool {
-        if let Segment::Inactive { .. } = self {
-            true
-        } else {
-            false
-        }
+        if let Segment::Inactive { .. } = self { true } else { false }
     }
 
     fn free_to_active(&mut self, new_lsn: Lsn) {
@@ -512,7 +500,8 @@ impl SegmentAccountant {
         let segment_size = self.config.segment_size;
         let file_len = self.config.file.metadata()?.len();
         let number_of_segments =
-            usize::try_from(file_len / segment_size as u64).unwrap();
+            usize::try_from(file_len / segment_size as u64).unwrap()
+                + if file_len % segment_size as u64 == 0 { 0 } else { 1 };
 
         // generate segments from snapshot lids
         let mut segments = vec![Segment::default(); number_of_segments];
@@ -1061,11 +1050,7 @@ impl SegmentAccountant {
         self.ordering
             .iter()
             .filter_map(move |(l, r)| {
-                if *l >= normalized_lsn {
-                    Some((*l, *r))
-                } else {
-                    None
-                }
+                if *l >= normalized_lsn { Some((*l, *r)) } else { None }
             })
             .collect()
     }

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -509,11 +509,12 @@ impl SegmentAccountant {
         // sometimes the current segment is still empty, after only
         // recovering the segment header but no valid messages yet
         if let Some(tip_lid) = snapshot.active_segment {
-            let tip_idx = (tip_lid / segment_size as LogOffset) as usize;
+            let tip_idx =
+                usize::try_from(tip_lid / segment_size as LogOffset).unwrap();
             if tip_idx == number_of_segments {
                 segments.push(Segment::default());
             }
-            println!(
+            trace!(
                 "setting segment for tip_lid {} to stable_lsn {}",
                 tip_lid,
                 self.config.normalize(snapshot.stable_lsn.unwrap_or(0))
@@ -585,7 +586,7 @@ impl SegmentAccountant {
 
         let currently_active_segment = snapshot
             .active_segment
-            .map(|tl| (tl / segment_size as LogOffset) as usize);
+            .map(|tl| usize::try_from(tl / segment_size as LogOffset).unwrap());
 
         for (idx, segment) in self.segments.iter_mut().enumerate() {
             let segment_base = idx as LogOffset * segment_size as LogOffset;
@@ -1005,12 +1006,6 @@ impl SegmentAccountant {
         self.segments[idx].free_to_active(lsn);
 
         self.ordering.insert(lsn, lid);
-
-        println!(
-            "segment accountant returning offset: {} for lsn {} \
-             on deck: {:?}",
-            lid, lsn, self.free,
-        );
 
         debug!(
             "segment accountant returning offset: {} for lsn {} \

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -450,17 +450,6 @@ impl Segment {
             false
         }
     }
-
-    fn is_empty(&self) -> bool {
-        match self {
-            Segment::Active(Active { pids, .. })
-            | Segment::Inactive(Inactive { pids, .. }) => pids.is_empty(),
-            Segment::Draining(Draining { replaced_pids, max_pids, .. }) => {
-                replaced_pids == max_pids
-            }
-            Segment::Free(_) => false,
-        }
-    }
 }
 
 impl SegmentAccountant {

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -211,15 +211,27 @@ impl Default for Segment {
 
 impl Segment {
     fn is_free(&self) -> bool {
-        if let Segment::Free(_) = self { true } else { false }
+        if let Segment::Free(_) = self {
+            true
+        } else {
+            false
+        }
     }
 
     fn is_active(&self) -> bool {
-        if let Segment::Active { .. } = self { true } else { false }
+        if let Segment::Active { .. } = self {
+            true
+        } else {
+            false
+        }
     }
 
     fn is_inactive(&self) -> bool {
-        if let Segment::Inactive { .. } = self { true } else { false }
+        if let Segment::Inactive { .. } = self {
+            true
+        } else {
+            false
+        }
     }
 
     fn free_to_active(&mut self, new_lsn: Lsn) {
@@ -1038,8 +1050,7 @@ impl SegmentAccountant {
             "expected ordering to have been initialized already"
         );
 
-        let segment_len = self.config.segment_size as Lsn;
-        let normalized_lsn = lsn / segment_len * segment_len;
+        let normalized_lsn = self.config.normalize(lsn);
 
         trace!(
             "generated iterator over {:?} where lsn >= {}",
@@ -1050,7 +1061,11 @@ impl SegmentAccountant {
         self.ordering
             .iter()
             .filter_map(move |(l, r)| {
-                if *l >= normalized_lsn { Some((*l, *r)) } else { None }
+                if *l >= normalized_lsn {
+                    Some((*l, *r))
+                } else {
+                    None
+                }
             })
             .collect()
     }

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -12,7 +12,7 @@ use super::{
 /// A snapshot of the state required to quickly restart
 /// the `PageCache` and `SegmentAccountant`.
 #[derive(PartialEq, Debug, Default)]
-#[cfg_attr(test, derive(Clone, PartialEq))]
+#[cfg_attr(test, derive(Clone))]
 pub struct Snapshot {
     /// The last read message lsn
     pub stable_lsn: Option<Lsn>,
@@ -306,7 +306,7 @@ fn advance_snapshot(
     }
 
     #[cfg(feature = "event_log")]
-    config.event_log.recovered_lsn(snapshot.stable_lsn);
+    config.event_log.recovered_lsn(snapshot.stable_lsn.unwrap_or(0));
 
     Ok(snapshot)
 }

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -246,7 +246,7 @@ fn advance_snapshot(
         io_fail!(config, "segment initial free zero");
         pwrite_all(
             &config.file,
-            &*vec![MessageKind::Corrupted.into(); SEG_HEADER_LEN],
+            &*vec![MessageKind::Corrupted.into(); config.segment_size],
             to_zero,
         )?;
         if !config.temporary {

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -39,8 +39,9 @@ impl Snapshot {
 
             (Some(offset), Some(stable_lsn))
         } else {
-            let lsn_idx = stable_lsn / segment_size as Lsn;
-            let next_lsn = (lsn_idx + 1) * segment_size as Lsn;
+            let lsn_idx = stable_lsn / segment_size as Lsn
+                + if stable_lsn % segment_size as Lsn == 0 { 0 } else { 1 };
+            let next_lsn = lsn_idx * segment_size as Lsn;
             (None, Some(next_lsn))
         }
     }
@@ -172,8 +173,7 @@ impl Snapshot {
             }
             LogKind::Corrupted | LogKind::Skip => panic!(
                 "unexppected messagekind in snapshot application for pid {}: {:?}",
-                pid,
-                log_kind
+                pid, log_kind
             ),
         }
     }

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -133,7 +133,9 @@ impl Snapshot {
                     lsn,
                 );
 
-                self.pt[usize::try_from(pid).unwrap()] = PageState::Present {
+                let pid_usize = usize::try_from(pid).unwrap();
+
+                self.pt[pid_usize] = PageState::Present {
                     base: (lsn, disk_ptr, sz),
                     frags: vec![],
                 };
@@ -209,6 +211,8 @@ fn advance_snapshot(
             );
             continue;
         }
+
+        assert!(lsn < iter.max_lsn.unwrap());
 
         snapshot.apply(log_kind, pid, lsn, ptr, sz);
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,8 @@ use std::{
     io,
 };
 
+use backtrace::Backtrace;
+
 use crate::{
     pagecache::{DiskPtr, PageView},
     IVec,
@@ -37,12 +39,20 @@ pub enum Error {
     /// Corruption has been detected in the storage file.
     Corruption {
         /// The file location that corrupted data was found at.
-        at: DiskPtr,
+        at: Option<DiskPtr>,
+        /// A backtrace for where the corruption was encountered.
+        bt: Backtrace,
     },
     // a failpoint has been triggered for testing purposes
     #[doc(hidden)]
     #[cfg(feature = "failpoints")]
     FailPoint,
+}
+
+impl Error {
+    pub(crate) fn corruption(at: Option<DiskPtr>) -> Error {
+        Error::Corruption { at, bt: Backtrace::new() }
+    }
 }
 
 impl Clone for Error {
@@ -54,7 +64,7 @@ impl Clone for Error {
             CollectionNotFound(name) => CollectionNotFound(name.clone()),
             Unsupported(why) => Unsupported(why.clone()),
             ReportableBug(what) => ReportableBug(what.clone()),
-            Corruption { at } => Corruption { at: *at },
+            Corruption { at, bt } => Corruption { at: *at, bt: bt.clone() },
             #[cfg(feature = "failpoints")]
             FailPoint => FailPoint,
         }
@@ -97,8 +107,8 @@ impl PartialEq for Error {
                     false
                 }
             }
-            Corruption { at: l } => {
-                if let Corruption { at: r } = *other {
+            Corruption { at: l, .. } => {
+                if let Corruption { at: r, .. } = *other {
                     l == r
                 } else {
                     false
@@ -139,9 +149,11 @@ impl Display for Error {
             #[cfg(feature = "failpoints")]
             FailPoint => write!(f, "Fail point has been triggered."),
             Io(ref e) => write!(f, "IO error: {}", e),
-            Corruption { at } => {
-                write!(f, "Read corrupted data at file offset {}", at)
-            }
+            Corruption { at, ref bt } => write!(
+                f,
+                "Read corrupted data at file offset {:?} backtrace {:?}",
+                at, bt
+            ),
         }
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -460,7 +460,7 @@ impl Serialize for Snapshot {
             stable_lsn: { i64::deserialize(buf)? },
             tip_lid: {
                 let lid = u64::deserialize(buf)?;
-                if lid != 0 { Some(lid) } else { None }
+                if lid == 0 { None } else { Some(lid) }
             },
             pt: deserialize_sequence(buf)?,
         })

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -939,7 +939,7 @@ mod qc {
         fn arbitrary<G: Gen>(g: &mut G) -> Snapshot {
             Snapshot {
                 stable_lsn: g.gen(),
-                tip_lid: g.gen(),
+                active_segment: g.gen(),
                 pt: Arbitrary::arbitrary(g),
             }
         }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -68,7 +68,7 @@ impl Serialize for BatchManifest {
 
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.len() < 8 {
-            return Err(Error::Corruption { at: DiskPtr::Inline(104) });
+            return Err(Error::corruption(None));
         }
 
         let array = buf[..8].try_into().unwrap();
@@ -211,7 +211,7 @@ impl Serialize for u64 {
 
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
-            return Err(Error::Corruption { at: DiskPtr::Inline(150) });
+            return Err(Error::corruption(None));
         }
         let (res, scoot) = match buf[0] {
             0..=240 => (u64::from(buf[0]), 1),
@@ -243,7 +243,7 @@ impl Serialize for i64 {
 
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.len() < 8 {
-            return Err(Error::Corruption { at: DiskPtr::Inline(103) });
+            return Err(Error::corruption(None));
         }
 
         let array = buf[..8].try_into().unwrap();
@@ -264,7 +264,7 @@ impl Serialize for u32 {
 
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.len() < 4 {
-            return Err(Error::Corruption { at: DiskPtr::Inline(250) });
+            return Err(Error::corruption(None));
         }
 
         let array = buf[..4].try_into().unwrap();
@@ -286,7 +286,7 @@ impl Serialize for bool {
 
     fn deserialize(buf: &mut &[u8]) -> Result<bool> {
         if buf.is_empty() {
-            return Err(Error::Corruption { at: DiskPtr::Inline(77) });
+            return Err(Error::corruption(None));
         }
         let value = buf[0] != 0;
         *buf = &buf[1..];
@@ -306,7 +306,7 @@ impl Serialize for u8 {
 
     fn deserialize(buf: &mut &[u8]) -> Result<u8> {
         if buf.is_empty() {
-            return Err(Error::Corruption { at: DiskPtr::Inline(93) });
+            return Err(Error::corruption(None));
         }
         let value = buf[0];
         *buf = &buf[1..];
@@ -379,7 +379,7 @@ impl Serialize for Link {
 
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
-            return Err(Error::Corruption { at: DiskPtr::Inline(210) });
+            return Err(Error::corruption(None));
         }
         let discriminant = buf[0];
         *buf = &buf[1..];
@@ -389,7 +389,7 @@ impl Serialize for Link {
             2 => Link::ParentMergeIntention(u64::deserialize(buf)?),
             3 => Link::ParentMergeConfirm,
             4 => Link::ChildMergeCap,
-            _ => return Err(Error::Corruption { at: DiskPtr::Inline(220) }),
+            _ => return Err(Error::corruption(None)),
         })
     }
 }
@@ -528,7 +528,7 @@ impl Serialize for Data {
 
     fn deserialize(buf: &mut &[u8]) -> Result<Data> {
         if buf.is_empty() {
-            return Err(Error::Corruption { at: DiskPtr::Inline(108) });
+            return Err(Error::corruption(None));
         }
         let discriminant = buf[0];
         *buf = &buf[1..];
@@ -542,7 +542,7 @@ impl Serialize for Data {
                 keys: deserialize_bounded_sequence(buf, len)?,
                 pointers: deserialize_bounded_sequence(buf, len)?,
             }),
-            _ => return Err(Error::Corruption { at: DiskPtr::Inline(115) }),
+            _ => return Err(Error::corruption(None)),
         })
     }
 }
@@ -573,14 +573,14 @@ impl Serialize for DiskPtr {
 
     fn deserialize(buf: &mut &[u8]) -> Result<DiskPtr> {
         if buf.len() < 2 {
-            return Err(Error::Corruption { at: DiskPtr::Inline(136) });
+            return Err(Error::corruption(None));
         }
         let discriminant = buf[0];
         *buf = &buf[1..];
         Ok(match discriminant {
             0 => DiskPtr::Inline(u64::deserialize(buf)?),
             1 => DiskPtr::Blob(u64::deserialize(buf)?, i64::deserialize(buf)?),
-            _ => return Err(Error::Corruption { at: DiskPtr::Inline(666) }),
+            _ => return Err(Error::corruption(None)),
         })
     }
 }
@@ -622,7 +622,7 @@ impl Serialize for PageState {
 
     fn deserialize(buf: &mut &[u8]) -> Result<PageState> {
         if buf.is_empty() {
-            return Err(Error::Corruption { at: DiskPtr::Inline(402) });
+            return Err(Error::corruption(None));
         }
         let discriminant = buf[0];
         *buf = &buf[1..];

--- a/src/stackvec.rs
+++ b/src/stackvec.rs
@@ -10,9 +10,7 @@ pub(crate) struct StackVec {
 
 impl fmt::Debug for StackVec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_list()
-            .entries(std::ops::Deref::deref(self))
-            .finish()
+        f.debug_list().entries(std::ops::Deref::deref(self)).finish()
     }
 }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     future::Future,
     pin::Pin,
     sync::{
@@ -8,6 +7,14 @@ use std::{
     },
     task::{Context, Poll, Waker},
 };
+
+#[cfg(not(feature = "testing"))]
+use std::collections::HashMap as Map;
+
+// we avoid HashMap while testing because
+// it makes tests non-deterministic
+#[cfg(feature = "testing")]
+use std::collections::BTreeMap as Map;
 
 use crate::*;
 
@@ -39,8 +46,7 @@ impl Event {
     }
 }
 
-type Senders =
-    HashMap<usize, (Option<Waker>, SyncSender<OneShot<Option<Event>>>)>;
+type Senders = Map<usize, (Option<Waker>, SyncSender<OneShot<Option<Event>>>)>;
 
 /// A subscriber listening on a specified prefix
 ///
@@ -179,7 +185,7 @@ impl Subscribers {
                 if !w_mu.contains_key(prefix) {
                     let old = w_mu.insert(
                         prefix.to_vec(),
-                        Arc::new(RwLock::new(HashMap::default())),
+                        Arc::new(RwLock::new(Map::default())),
                     );
                     assert!(old.is_none());
                 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -161,8 +161,9 @@ impl Drop for Subscribers {
         let watched = self.watched.read();
 
         for senders in watched.values() {
-            let mut senders = senders.write();
-            for (_, (waker, sender)) in senders.drain() {
+            let senders =
+                std::mem::replace(&mut *senders.write(), Map::default());
+            for (_, (waker, sender)) in senders {
                 drop(sender);
                 if let Some(waker) = waker {
                     waker.wake();

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -22,6 +22,7 @@ const DESIRED_WAITING_THREADS: usize = 2;
 
 static WAITING_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 static TOTAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
+static SPAWNS: AtomicUsize = AtomicUsize::new(1);
 
 macro_rules! once {
     ($args:block) => {
@@ -116,8 +117,10 @@ fn maybe_spawn_new_thread() {
         return;
     }
 
-    let spawn_res =
-        thread::Builder::new().name("sled-io".to_string()).spawn(|| {
+    let spawn_id = SPAWNS.fetch_add(1, Relaxed);
+    let spawn_res = thread::Builder::new()
+        .name(format!("sled-io-{}", spawn_id))
+        .spawn(|| {
             debug_delay();
             TOTAL_THREAD_COUNT.fetch_add(1, SeqCst);
             perform_work();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -327,11 +327,6 @@ impl TransactionalTree {
         Ok(())
     }
 
-    fn stage(&self) -> UnabortableTransactionResult<Vec<Protector<'_>>> {
-        let protector = concurrency_control::write();
-        Ok(vec![protector])
-    }
-
     fn unstage(&self) {
         unimplemented!()
     }
@@ -372,17 +367,7 @@ impl TransactionalTrees {
             .collect();
         tree_idxs.sort_unstable();
 
-        let mut last_idx = usize::max_value();
-        let mut all_guards = vec![];
-        for (_, idx) in tree_idxs {
-            if idx == last_idx {
-                // prevents us from double-locking
-                continue;
-            }
-            last_idx = idx;
-            let mut guards = self.inner[idx].stage()?;
-            all_guards.append(&mut guards);
-        }
+        let all_guards = vec![concurrency_control::write()];
         Ok(all_guards)
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -81,7 +81,10 @@ use std::collections::HashMap as Map;
 #[cfg(feature = "testing")]
 use std::collections::BTreeMap as Map;
 
-use crate::{pin, Batch, Error, Guard, IVec, Protector, Result, Tree};
+use crate::{
+    concurrency_control, pin, Batch, Error, Guard, IVec, Protector, Result,
+    Tree,
+};
 
 /// A transaction that will
 /// be applied atomically to the
@@ -325,7 +328,7 @@ impl TransactionalTree {
     }
 
     fn stage(&self) -> UnabortableTransactionResult<Vec<Protector<'_>>> {
-        let protector = self.tree.concurrency_control.write();
+        let protector = concurrency_control::write();
         Ok(vec![protector])
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -71,7 +71,15 @@
 //! assert_eq!(&processed.get(b"k3").unwrap().unwrap(), b"yappin' ligers");
 //! ```
 #![allow(clippy::module_name_repetitions)]
-use std::{cell::RefCell, collections::HashMap, fmt, rc::Rc};
+use std::{cell::RefCell, fmt, rc::Rc};
+
+#[cfg(not(feature = "testing"))]
+use std::collections::HashMap as Map;
+
+// we avoid HashMap while testing because
+// it makes tests non-deterministic
+#[cfg(feature = "testing")]
+use std::collections::BTreeMap as Map;
 
 use crate::{pin, Batch, Error, Guard, IVec, Protector, Result, Tree};
 
@@ -81,8 +89,8 @@ use crate::{pin, Batch, Error, Guard, IVec, Protector, Result, Tree};
 #[derive(Clone)]
 pub struct TransactionalTree {
     pub(super) tree: Tree,
-    pub(super) writes: Rc<RefCell<HashMap<IVec, Option<IVec>>>>,
-    pub(super) read_cache: Rc<RefCell<HashMap<IVec, Option<IVec>>>>,
+    pub(super) writes: Rc<RefCell<Map<IVec, Option<IVec>>>>,
+    pub(super) read_cache: Rc<RefCell<Map<IVec, Option<IVec>>>>,
 }
 
 /// An error type that is returned from the closure

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -363,8 +363,13 @@ impl Tree {
         guard: &mut Guard,
     ) -> Result<()> {
         let peg = self.context.pin_log(guard)?;
+        trace!("applying batch {:?}", batch);
         for (k, v_opt) in batch.writes {
-            let _old = self.insert_inner(&k, v_opt, guard)?;
+            loop {
+                if self.insert_inner(&k, v_opt.clone(), guard)?.is_ok() {
+                    break;
+                }
+            }
         }
 
         // when the peg drops, it ensures all updates

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -172,7 +172,7 @@ impl Tree {
         let link = self.context.pagecache.link(
             pid,
             node_view.0,
-            frag.clone(),
+            frag,
             guard,
         )?;
 
@@ -410,7 +410,7 @@ impl Tree {
     ) -> Result<Abortable<Option<IVec>>> {
         let _measure = Measure::new(&M.tree_get);
 
-        trace!("getting key {:?}", key.as_ref());
+        trace!("getting key {:?}", key);
 
         let View { node_view, pid, .. } = self.view_for_key(key.as_ref(), guard)?;
 
@@ -1008,7 +1008,7 @@ impl Tree {
         key: &[u8],
         value: &[u8],
     ) -> Result<Abortable<Option<IVec>>> {
-        trace!("merging key {:?}", key.as_ref());
+        trace!("merging key {:?}", key);
         let _measure = Measure::new(&M.tree_merge);
 
         let merge_operator_opt = self.merge_operator.read();
@@ -1032,8 +1032,7 @@ impl Tree {
             let (encoded_key, current_value) =
                 node_view.node_kv_pair(key.as_ref());
             let tmp = current_value.as_ref().map(AsRef::as_ref);
-            let new = merge_operator(key.as_ref(), tmp, value.as_ref())
-                .map(IVec::from);
+            let new = merge_operator(key, tmp, value).map(IVec::from);
 
             let mut subscriber_reservation = self.subscribers.reserve(&key);
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -158,9 +158,6 @@ impl Tree {
 
         let (encoded_key, last_value) = node_view.node_kv_pair(key.as_ref());
 
-        let (encoded_key, last_value) =
-            node_view.node_kv_pair(key.as_ref());
-      
         if value == last_value {
             // short-circuit a no-op set or delete
             return Ok(Ok(value))
@@ -171,7 +168,7 @@ impl Tree {
         } else {
             Link::Del(encoded_key)
         };
-      
+
         let link = self.context.pagecache.link(
             pid,
             node_view.0,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -351,7 +351,7 @@ impl Tree {
     /// # Ok(()) }
     /// ```
     pub fn apply_batch(&self, batch: Batch) -> Result<()> {
-        let _ = concurrency_control::write();
+        let _cc = concurrency_control::write();
         let mut guard = pin();
         self.apply_batch_inner(batch, &mut guard)
     }

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -28,9 +28,6 @@ fn main() {
     match env::var(TEST_ENV_VAR) {
         Err(VarError::NotPresent) => {
             test_crash_recovery();
-
-            // TODO this is currently being ignored until it is fixed
-            // with a refactor of recovery logic.
             test_crash_batches();
         }
 
@@ -112,7 +109,6 @@ fn spawn_killah() {
     thread::spawn(|| {
         let runtime = rand::thread_rng().gen_range(0, 60);
         thread::sleep(Duration::from_millis(runtime));
-        println!("~");
         exit(9);
     });
 }

--- a/tests/test_log.rs
+++ b/tests/test_log.rs
@@ -14,6 +14,7 @@ const PID: PageId = 4;
 const REPLACE: LogKind = LogKind::Replace;
 
 #[test]
+#[ignore = "adding 50 causes the flush to never return"]
 fn log_writebatch() -> crate::Result<()> {
     common::setup_logger();
     let config = Config::new().temporary(true);

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -2303,3 +2303,29 @@ fn tree_bug_43() {
         52,
     );
 }
+
+#[test]
+fn tree_bug_44() {
+    // postmortem: off-by-one bug related to LSN recovery
+    // where 1 was added to the index when the recovered
+    // LSN was actually divisible by the segment size
+    assert!(prop_tree_matches_btreemap(
+        vec![
+            Merge(Key(vec![]), 97),
+            Merge(Key(vec![]), 41),
+            Merge(Key(vec![]), 241),
+            Set(Key(vec![21; 1]), 24),
+            Del(Key(vec![])),
+            Set(Key(vec![]), 145),
+            Set(Key(vec![151; 1]), 187),
+            Get(Key(vec![])),
+            Restart,
+            Set(Key(vec![]), 151),
+            Restart,
+        ],
+        false,
+        false,
+        0,
+        0,
+    ))
+}

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -2329,3 +2329,26 @@ fn tree_bug_44() {
         0,
     ))
 }
+#[test]
+fn tree_bug_45() {
+    // postmortem: recovery was not properly accounting for
+    // the possibility of a segment to be maxed out, similar
+    // to bug 44.
+    for _ in 0..10 {
+        assert!(prop_tree_matches_btreemap(
+            vec![
+                Merge(Key(vec![206; 77]), 225),
+                Set(Key(vec![88; 190]), 40),
+                Set(Key(vec![162; 1]), 213),
+                Merge(Key(vec![186; 1]), 175),
+                Set(Key(vec![105; 16]), 111),
+                Cas(Key(vec![]), 75, 252),
+                Restart
+            ],
+            false,
+            true,
+            0,
+            210
+        ))
+    }
+}

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -1660,3 +1660,40 @@ fn failpoints_bug_33() {
         ));
     }
 }
+
+#[test]
+fn failpoints_bug_34() {
+    // postmortem 1: the implementation of make_durable was not properly
+    // exiting the function when local durability was detected
+    use BatchOp::*;
+    assert!(prop_tree_crashes_nicely(
+        vec![Batched(vec![
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set, Set,
+            Set, Set, Set, Set, Set, Set,
+        ])],
+        false
+    ));
+}

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -1593,72 +1593,70 @@ fn failpoints_bug_32() {
 #[test]
 fn failpoints_bug_33() {
     // postmortem 1:
-    for _ in 0..10 {
-        assert!(prop_tree_crashes_nicely(
-            vec![
-                Batched(vec![
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(85),
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(148),
-                    BatchOp::Set,
-                    BatchOp::Set
-                ]),
-                Restart,
-                Batched(vec![
-                    BatchOp::Del(255),
-                    BatchOp::Del(42),
-                    BatchOp::Del(150),
-                    BatchOp::Del(16),
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(111),
-                    BatchOp::Del(65),
-                    BatchOp::Del(102),
-                    BatchOp::Del(99),
-                    BatchOp::Del(25),
-                    BatchOp::Del(156),
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(73),
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(238),
-                    BatchOp::Del(211),
-                    BatchOp::Del(14),
-                    BatchOp::Del(7),
-                    BatchOp::Del(137),
-                    BatchOp::Del(115),
-                    BatchOp::Del(91),
-                    BatchOp::Set,
-                    BatchOp::Del(172),
-                    BatchOp::Del(49),
-                    BatchOp::Del(152),
-                    BatchOp::Set,
-                    BatchOp::Del(189),
-                    BatchOp::Set,
-                    BatchOp::Del(37),
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(96),
-                    BatchOp::Set,
-                    BatchOp::Set,
-                    BatchOp::Del(159),
-                    BatchOp::Del(126)
-                ])
-            ],
-            true
-        ));
-    }
+    assert!(prop_tree_crashes_nicely(
+        vec![
+            Batched(vec![
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(85),
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(148),
+                BatchOp::Set,
+                BatchOp::Set
+            ]),
+            Restart,
+            Batched(vec![
+                BatchOp::Del(255),
+                BatchOp::Del(42),
+                BatchOp::Del(150),
+                BatchOp::Del(16),
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(111),
+                BatchOp::Del(65),
+                BatchOp::Del(102),
+                BatchOp::Del(99),
+                BatchOp::Del(25),
+                BatchOp::Del(156),
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(73),
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(238),
+                BatchOp::Del(211),
+                BatchOp::Del(14),
+                BatchOp::Del(7),
+                BatchOp::Del(137),
+                BatchOp::Del(115),
+                BatchOp::Del(91),
+                BatchOp::Set,
+                BatchOp::Del(172),
+                BatchOp::Del(49),
+                BatchOp::Del(152),
+                BatchOp::Set,
+                BatchOp::Del(189),
+                BatchOp::Set,
+                BatchOp::Del(37),
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(96),
+                BatchOp::Set,
+                BatchOp::Set,
+                BatchOp::Del(159),
+                BatchOp::Del(126)
+            ])
+        ],
+        false
+    ));
 }
 
 #[test]
@@ -1696,4 +1694,29 @@ fn failpoints_bug_34() {
         ])],
         false
     ));
+}
+
+#[test]
+fn failpoints_bug_35() {
+    // postmortem 1:
+    use BatchOp::*;
+    for _ in 0..50 {
+        assert!(prop_tree_crashes_nicely(
+            vec![
+                Batched(vec![Del(106), Set, Del(32), Del(149), Set]),
+                Flush,
+                Batched(vec![Del(136), Set, Set, Del(61), Set, Del(202)]),
+                Flush,
+                Batched(vec![Del(106), Set, Del(32), Del(149), Set]),
+                Flush,
+                Batched(vec![Del(136), Set, Set, Del(61), Set, Del(202)]),
+                Flush,
+                Batched(vec![Del(106), Set, Del(32), Del(149), Set]),
+                Flush,
+                Batched(vec![Del(136), Set, Set, Del(61), Set, Del(202)]),
+                Flush,
+            ],
+            true
+        ));
+    }
 }

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -1576,3 +1576,85 @@ fn failpoints_bug_31() {
         ));
     }
 }
+
+#[test]
+fn failpoints_bug_32() {
+    // postmortem 1:
+    for _ in 0..10 {
+        assert!(prop_tree_crashes_nicely(
+            vec![Batched(vec![BatchOp::Set, BatchOp::Set]), Restart],
+            false
+        ));
+    }
+}
+
+#[test]
+fn failpoints_bug_33() {
+    // postmortem 1:
+    for _ in 0..10 {
+        assert!(prop_tree_crashes_nicely(
+            vec![
+                Batched(vec![
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(85),
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(148),
+                    BatchOp::Set,
+                    BatchOp::Set
+                ]),
+                Restart,
+                Batched(vec![
+                    BatchOp::Del(255),
+                    BatchOp::Del(42),
+                    BatchOp::Del(150),
+                    BatchOp::Del(16),
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(111),
+                    BatchOp::Del(65),
+                    BatchOp::Del(102),
+                    BatchOp::Del(99),
+                    BatchOp::Del(25),
+                    BatchOp::Del(156),
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(73),
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(238),
+                    BatchOp::Del(211),
+                    BatchOp::Del(14),
+                    BatchOp::Del(7),
+                    BatchOp::Del(137),
+                    BatchOp::Del(115),
+                    BatchOp::Del(91),
+                    BatchOp::Set,
+                    BatchOp::Del(172),
+                    BatchOp::Del(49),
+                    BatchOp::Del(152),
+                    BatchOp::Set,
+                    BatchOp::Del(189),
+                    BatchOp::Set,
+                    BatchOp::Del(37),
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(96),
+                    BatchOp::Set,
+                    BatchOp::Set,
+                    BatchOp::Del(159),
+                    BatchOp::Del(126)
+                ])
+            ],
+            true
+        ));
+    }
+}


### PR DESCRIPTION
- [x] merging @divergentdave's batch failpoint work
- [x] accounting for batches in the log stabilization code
- [ ] more formally document emergent properties of the system which must be controlled for in a documented way, and tested in a documented way
  - fully atomic serializable batch recovery
- [ ] more formally document requirements around file reuse, stability and crash recovery
  - a segment may only be reused after it is no longer in the unstable tail
  - a segment may only be reused after the segments that replaced its data are no longer in the unstable tail
  - strictly monotonic segments. never duplicate segments
- [x] ~~make failpoints work with a "bit queue" so that they may not be triggered upon first hit of the failpoint~~ #1052 
- [ ] separate synchronous requirements from asynchronous requirements, allow async requirements to be disabled to ensure they don't cause bugs to happen by being async
  - runtime segment reuse
  - recovery segment freeing
  - snapshot reading (only can be disabled in combination with segment freeing/reuse)
- [x] uncomment page_out body and clear stability assumptions
