### PR TITLE
Support Rust versions 1.37 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 
+* The minimum supported Rust version (MSRV) is now 1.37.0.
 * `Subscription` now implements `Future` (non-fused)
   so prefix watching may now be iterated over via
   `while let Some(event) = (&mut subscription).await {}`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ extreme::run(async move {
 });
 ```
 
+# minimum supported Rust version (MSRV)
+
+We support Rust 1.37.0 and up.
+
 # architecture
 
 lock-free tree on a lock-free pagecache on a lock-free log. the pagecache scatters
@@ -142,7 +146,6 @@ for a more detailed overview of where we're at and where we see things going!
 * if storage price performance is your primary constraint, use RocksDB. sled uses too much space sometimes.
 * quite young, should be considered unstable for the time being.
 * the on-disk format is going to change in ways that require [manual migrations](https://docs.rs/sled/latest/sled/struct.Db.html#method.export) before the `1.0.0` release!
-* until `1.0.0`, sled targets the *current* stable version of rust. after `1.0.0`, we will aim to trail current by at least one version. If this is an issue for your business, please consider helping us reach `1.0.0` sooner by financially supporting our efforts to get there.
 
 # plans
 

--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -16,3 +16,8 @@ for target in $targets; do
   echo "checking $target..."
   cargo check --target $target
 done
+
+rustup toolchain install 1.37.0
+cargo clean
+rm Cargo.lock
+cargo +1.37.0 check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@
     // clippy::wildcard_enum_match_arm,
     clippy::wrong_pub_self_convention,
 )]
+#![allow(clippy::mem_replace_with_default)]
 #![recursion_limit = "128"]
 
 macro_rules! io_fail {
@@ -372,5 +373,11 @@ pub(crate) type FastSet8<V> = std::collections::HashSet<
 
 /// Allows arbitrary logic to be injected into mere operations of the
 /// `PageCache`.
-pub trait MergeOperator: Fn(&[u8], Option<&[u8]>, &[u8]) -> Option<Vec<u8>> {}
-impl<F> MergeOperator for F where F: Fn(&[u8], Option<&[u8]>, &[u8]) -> Option<Vec<u8>> {}
+pub trait MergeOperator:
+    Fn(&[u8], Option<&[u8]>, &[u8]) -> Option<Vec<u8>>
+{
+}
+impl<F> MergeOperator for F where
+    F: Fn(&[u8], Option<&[u8]>, &[u8]) -> Option<Vec<u8>>
+{
+}

--- a/src/pagecache/reservation.rs
+++ b/src/pagecache/reservation.rs
@@ -70,7 +70,7 @@ impl<'a> Reservation<'a> {
     }
 
     /// Returns the length of the on-log reservation.
-    pub const fn reservation_len(&self) -> usize {
+    pub fn reservation_len(&self) -> usize {
         self.buf.len()
     }
 

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -290,7 +290,10 @@ impl Segment {
                 latest_replacement_lsn: active.latest_replacement_lsn,
             });
 
-            let can_free = mem::take(&mut active.can_free_upon_deactivation);
+            let can_free = mem::replace(
+                &mut active.can_free_upon_deactivation,
+                Default::default(),
+            );
 
             (inactive, can_free)
         } else {
@@ -306,7 +309,7 @@ impl Segment {
 
         if let Segment::Inactive(inactive) = self {
             assert!(lsn >= inactive.lsn);
-            let ret = mem::take(&mut inactive.pids);
+            let ret = mem::replace(&mut inactive.pids, Default::default());
             *self = Segment::Draining(Draining {
                 lsn: inactive.lsn,
                 max_pids: inactive.max_pids,

--- a/src/stackvec.rs
+++ b/src/stackvec.rs
@@ -1,11 +1,28 @@
-use std::{convert::TryFrom, mem::MaybeUninit};
+use std::{convert::TryFrom, fmt, mem::MaybeUninit};
 
 use crate::pagecache::{constants::PAGE_CONSOLIDATION_THRESHOLD, CacheInfo};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub(crate) struct StackVec {
     items: [MaybeUninit<CacheInfo>; PAGE_CONSOLIDATION_THRESHOLD],
     len: u8,
+}
+
+impl fmt::Debug for StackVec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_map()
+            .entry(
+                &"items",
+                #[allow(unsafe_code)]
+                unsafe {
+                    &std::mem::transmute::<
+                        _,
+                        [CacheInfo; PAGE_CONSOLIDATION_THRESHOLD],
+                    >(self.items)
+                },
+            )
+            .finish()
+    }
 }
 
 impl Default for StackVec {

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -151,7 +151,7 @@ impl Drop for Subscriptions {
     fn drop(&mut self) {
         let watched = self.watched.read();
 
-        for (_, senders) in &*watched {
+        for senders in watched.values() {
             let mut senders = senders.write();
             for (_, (waker, sender)) in senders.drain() {
                 drop(sender);


### PR DESCRIPTION
This makes our MSRV policy clear, tested, and hopefully will increase general feelings around project stability.