### PR TITLE
Rewrite Debug implementation for StackVec

### DIFF
--- a/src/stackvec.rs
+++ b/src/stackvec.rs
@@ -10,17 +10,8 @@ pub(crate) struct StackVec {
 
 impl fmt::Debug for StackVec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_map()
-            .entry(
-                &"items",
-                #[allow(unsafe_code)]
-                unsafe {
-                    &std::mem::transmute::<
-                        _,
-                        [CacheInfo; PAGE_CONSOLIDATION_THRESHOLD],
-                    >(self.items)
-                },
-            )
+        f.debug_list()
+            .entries(std::ops::Deref::deref(self))
             .finish()
     }
 }


### PR DESCRIPTION
Fixes uninitialized memory use by only printing the first `len` entries of the backing array (by using `deref()`). Fix for #1045. [Playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=809f6670dae846ce33a659873d2fb399), for kicking the tires on the formatted output.