### PR TITLE
Fix rare deadlock from failpoint test in make_stable()

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -743,7 +743,7 @@ impl Config {
     #[doc(hidden)]
     pub fn global_error(&self) -> Result<()> {
         let guard = pin();
-        let ge = self.global_error.load(Relaxed, &guard);
+        let ge = self.global_error.load(SeqCst, &guard);
         if ge.is_null() {
             Ok(())
         } else {

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -1144,6 +1144,10 @@ pub(in crate::pagecache) fn maybe_seal_and_write_iobuf(
                     "hit error while writing iobuf with lsn {}: {:?}",
                     lsn, e
                 );
+
+                // store error before notifying so that waiting threads will see it
+                iobufs.config.set_global_error(e);
+
                 let intervals = iobufs.intervals.lock();
 
                 // having held the mutex makes this linearized
@@ -1151,7 +1155,6 @@ pub(in crate::pagecache) fn maybe_seal_and_write_iobuf(
                 drop(intervals);
 
                 let _notified = iobufs.interval_updated.notify_all();
-                iobufs.config.set_global_error(e);
             }
         });
 


### PR DESCRIPTION
I chased down the source of the rare deadlock I was seeing and made a few changes to fix it. There was insufficient synchronization between `make_stable()` and `maybe_seal_and_write_iobuf()`, so it was possible for make_stable to read the global error, see none, and wait forever, while the writing thread had notified waiters too early and then stored the error. Alternately, make_stable could read the global error, be preempted before it locked the intervals mutex, and miss the error and notify_all from the writing thread regardless of what order they were done in.

I was able to reproduce the issue more easily by running a quickcheck test with the "buffer write" failpoint in a loop, and then running that binary two to four times in parallel to increase contention. Depending on timing, I would either see the main test thread panic when the flush inside Context's drop fails, or I would see the flusher thread panic, and the main test thread wait forever. After these three changes, I have run the same test again for long enough that I'm reassured the problem is resolved.

Changes:
1. Rewrite `maybe_seal_and_write_iobuf()` error handling to set the global error before locking the intervals mutex and notifying other threads, rather than after. This was an odd one out, all other uses of `set_global_error` came before taking the mutex.
2. Use sequentially consistent ordering for reading the global error. I'm not 100% certain if this is necessary, perhaps the other two changes are sufficient. The documentation says that Relaxed has "no ordering constraints", and the C++ documentation says that memory_order_relaxed is "not synchronization operations; they do not impose an order among concurrent memory accesses." My worry here is that make_stable could see a stale Ok(()) when reading with relaxed ordering from the global error even if the threads are otherwise synchronized with the intervals mutex and there's an in-flight sequentially consistent store to the global error coming from the writer thread. If that's the case, make_stable could deadlock again as seen here.
3. Check the global error a second time in make_stable after taking the intervals mutex. We need to hang on to the mutex from this read of the global error through to the condvar wait, or else the wait could miss a notification from the writer thread, which will take the same mutex before notifying. The first global error check might be redundant now, perhaps it could be removed?