### PR TITLE
Fix histogram test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: cargo test
       run: |
         rustup update
-        cargo test --release --features=testing -- --nocapture
+        cargo test --release --no-default-features --features=testing -- --nocapture
   examples:
     name: Example Tests
     runs-on: ubuntu-latest

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -171,11 +171,11 @@ fn decompress(compressed: u16) -> f64 {
 #[test]
 fn it_works() {
     let c = Histogram::default();
-    assert_eq!(c.measure(2), 1);
-    assert_eq!(c.measure(2), 2);
-    assert_eq!(c.measure(3), 1);
-    assert_eq!(c.measure(3), 2);
-    assert_eq!(c.measure(4), 1);
+    c.measure(2);
+    c.measure(2);
+    c.measure(3);
+    c.measure(3);
+    c.measure(4);
     assert_eq!(c.percentile(0.).round() as usize, 2);
     assert_eq!(c.percentile(40.).round() as usize, 2);
     assert_eq!(c.percentile(40.1).round() as usize, 3);


### PR DESCRIPTION
I noticed the histogram tests have bitrotted. This fixes one test to reflect the change in return type, and adds `--no-default-features` to a command line so that the histogram tests can run in the CI.