### PR TITLE
Tidy up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ let tree = sled::open("/tmp/welcome-to-sled").expect("open");
 
 // insert and get, similar to std's BTreeMap
 tree.insert("KEY1", "VAL1");
-assert_eq!(tree.get(&"KEY1"), Ok(Some("VAL1")));
+assert_eq!(tree.get(&"KEY1"), Ok(Some(sled::IVec::from("VAL1"))));
 
 // range queries
 for kv in tree.range("KEY1".."KEY9") {}

--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@
 A (beta) modern embedded database. Doesn't your data deserve a (beta) beautiful new home?
 
 ```rust
-let tree = sled::open(path)?;
+let tree = sled::open("/tmp/welcome-to-sled").expect("open");
 
 // insert and get, similar to std's BTreeMap
-tree.insert(k, v1);
-assert_eq!(tree.get(&k), Ok(Some(v1)));
+tree.insert("KEY1", "VAL1");
+assert_eq!(tree.get(&"KEY1"), Ok(Some("VAL1")));
 
 // range queries
-for kv in tree.range(k..) {}
+for kv in tree.range("KEY1".."KEY9") {}
 
 // deletion
-tree.remove(&k);
+tree.remove(&"KEY1");
 
 // atomic compare and swap
-tree.compare_and_swap(k, Some(v1), Some(v2));
+tree.compare_and_swap("KEY1", Some("VAL1"), Some("VAL2"));
 
 // block until all operations are stable on disk
 // (flush_async also available to get a Future)


### PR DESCRIPTION
Replaces notional variables in the first README snippet with concrete examples.

Resolves #1074. 