### PR TITLE
Drop mutex earlier to fix no-threads configuration

### DIFF
--- a/src/pagecache/reservation.rs
+++ b/src/pagecache/reservation.rs
@@ -103,6 +103,7 @@ impl<'a> Reservation<'a> {
 
             let mut intervals = self.log.iobufs.intervals.lock();
             intervals.mark_batch((self.lsn, peg_lsn));
+            drop(intervals);
 
             self.complete()
         }


### PR DESCRIPTION
When running tests with configuration that disables the threadpool, I was getting a deadlock on the intervals mutex from anything that used transactions. The transaction commit eventually calls `Reservation::mark_writebatch()`, which locks the intervals mutex, calls `StabilityIntervals::mark_batch()`, and calls `Reservation::complete()`. The issue is that `Reservation::complete()` eventually spawns a threadpool task that calls `IoBufs::write_to_log()`, which also needs to lock the intervals mutex. If the threadpool is disabled, this closure will be called right away, and `write_to_log` will deadlock on the mutex.

This PR resolves the issue by dropping the intervals mutex guard before calling `Reservation::complete()`. This is a fairly naive fix, and I'm not familiar with recent related changes, is it okay to unlock the mutex here?