### PR TITLE
refactor shutdown logic. clear some deprecated items. properly spin-up the flusher thread on the BSDs

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -38,6 +38,21 @@ impl std::ops::Deref for Context {
 
 impl Drop for Context {
     fn drop(&mut self) {
+        #[cfg(any(
+            windows,
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+        ))]
+        {
+            if let Some(flusher) = self.flusher.lock().take() {
+                drop(flusher)
+            }
+        }
+
         loop {
             match self.pagecache.flush() {
                 Ok(0) => return,

--- a/src/db.rs
+++ b/src/db.rs
@@ -81,7 +81,15 @@ impl Db {
 
         let context = Context::start(config)?;
 
-        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+        #[cfg(any(
+            windows,
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+        ))]
         {
             let flusher_pagecache = context.pagecache.clone();
             let flusher = context.flush_every_ms.map(move |fem| {

--- a/src/db.rs
+++ b/src/db.rs
@@ -64,18 +64,6 @@ impl Db {
         Config::new().path(path).open()
     }
 
-    #[doc(hidden)]
-    #[deprecated(since = "0.24.2", note = "replaced by `sled::open`")]
-    pub fn start_default<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
-        open(path)
-    }
-
-    #[doc(hidden)]
-    #[deprecated(since = "0.29.0", note = "please use Config::open instead")]
-    pub fn start(config: RunningConfig) -> Result<Self> {
-        Db::start_inner(config)
-    }
-
     pub(crate) fn start_inner(config: RunningConfig) -> Result<Self> {
         let _measure = Measure::new(&M.tree_start);
 

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -150,6 +150,7 @@ fn run(
             sc.wait_for(&mut shutdown, sleep_duration);
         }
     }
+
     *shutdown = ShutdownState::ShutDown;
 
     // having held the mutex makes this linearized


### PR DESCRIPTION
@Erk- this may have an effect on some of the size issues you were seeing on FreeBSD, since I believe we may not have actually been spinning up the thread (still). Damn I hate conditional compilation.