### PR TITLE
copy_from_slice: unsafe, private; pad allocation

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -51,9 +51,10 @@ impl<T> Arc<T> {
         let data_width = mem::size_of::<T>().checked_mul(s.len()).unwrap();
 
         let size = rc_width.checked_add(data_width).unwrap();
+        // Pad size out to alignment
+        let size = (size + align - 1) & !(align - 1);
 
         let layout = Layout::from_size_align(size, align).unwrap();
-        let layout = layout.pad_to_align();
 
         let ptr = alloc(layout);
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -41,7 +41,9 @@ impl<T> Arc<T> {
         Arc { ptr }
     }
 
-    pub fn copy_from_slice(s: &[T]) -> Arc<[T]> {
+    // See std::sync::arc::Arc::copy_from_slice,
+    // "Unsafe because the caller must either take ownership or bind `T: Copy`"
+    unsafe fn copy_from_slice(s: &[T]) -> Arc<[T]> {
         let align =
             std::cmp::max(mem::align_of::<T>(), mem::align_of::<AtomicUsize>());
 
@@ -51,21 +53,20 @@ impl<T> Arc<T> {
         let size = rc_width.checked_add(data_width).unwrap();
 
         let layout = Layout::from_size_align(size, align).unwrap();
+        let layout = layout.pad_to_align();
 
-        unsafe {
-            let ptr = alloc(layout);
+        let ptr = alloc(layout);
 
-            assert!(!ptr.is_null(), "failed to allocate Arc");
-            #[allow(clippy::cast_ptr_alignment)]
-            ptr::write(ptr as _, AtomicUsize::new(1));
+        assert!(!ptr.is_null(), "failed to allocate Arc");
+        #[allow(clippy::cast_ptr_alignment)]
+        ptr::write(ptr as _, AtomicUsize::new(1));
 
-            let data_ptr = ptr.add(rc_width);
-            ptr::copy_nonoverlapping(s.as_ptr(), data_ptr as _, s.len());
+        let data_ptr = ptr.add(rc_width);
+        ptr::copy_nonoverlapping(s.as_ptr(), data_ptr as _, s.len());
 
-            let fat_ptr: *const ArcInner<[T]> = Arc::fatten(ptr, s.len());
+        let fat_ptr: *const ArcInner<[T]> = Arc::fatten(ptr, s.len());
 
-            Arc { ptr: fat_ptr as *mut _ }
-        }
+        Arc { ptr: fat_ptr as *mut _ }
     }
 
     /// <https://users.rust-lang.org/t/construct-fat-pointer-to-struct/29198/9>
@@ -161,7 +162,7 @@ impl<T: ?Sized> Drop for Arc<T> {
 impl<T: Copy> From<&[T]> for Arc<[T]> {
     #[inline]
     fn from(s: &[T]) -> Arc<[T]> {
-        Arc::copy_from_slice(s)
+        unsafe { Arc::copy_from_slice(s) }
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -50,11 +50,11 @@ impl<T> Arc<T> {
         let rc_width = std::cmp::max(align, mem::size_of::<AtomicUsize>());
         let data_width = mem::size_of::<T>().checked_mul(s.len()).unwrap();
 
-        let size = rc_width.checked_add(data_width).unwrap();
+        let size_unpadded = rc_width.checked_add(data_width).unwrap();
         // Pad size out to alignment
-        let size = (size + align - 1) & !(align - 1);
+        let size_padded = (size_unpadded + align - 1) & !(align - 1);
 
-        let layout = Layout::from_size_align(size, align).unwrap();
+        let layout = Layout::from_size_align(size_padded, align).unwrap();
 
         let ptr = alloc(layout);
 


### PR DESCRIPTION
Follow-up to #1096 to fix UB caught with Miri.

The allocation in copy_from_slice needs to be padded out to its
alignment, or else the slice methods called on it may cause undefined
behavior, since the slice's memory layout expects that memory to be
valid.

I also made Arc::copy_from_slice unsafe to call and private, to mirror
the corresponding function in the standard library.