### PR TITLE
Flush out more crash bugs with configurable process exit chance from debug_delay

### DIFF
--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -3,7 +3,7 @@ set -e
 
 # checks sled's compatibility using several targets
 
-targets="wasm32-unknown-unknown aarch64-fuchsia aarch64-linux-android \
+targets="wasm32-wasi wasm32-unknown-unknown aarch64-fuchsia aarch64-linux-android \
          i686-linux-android i686-unknown-linux-gnu \
          x86_64-linux-android x86_64-fuchsia \
          aarch64-apple-ios"

--- a/src/debug_delay.rs
+++ b/src/debug_delay.rs
@@ -19,7 +19,17 @@ pub fn debug_delay() {
             .parse()
             .expect(
                 "SLED_LOCK_FREE_DELAY_INTENSITY must be set to a \
-                 float (ideally between 1-1,000,000)",
+                 non-negative integer (ideally below 1,000,000)",
+            )
+    });
+
+    static CRASH_CHANCE: Lazy<u32, fn() -> u32> = Lazy::new(|| {
+        std::env::var("SLED_CRASH_CHANCE")
+            .unwrap_or_else(|_| "0".into())
+            .parse()
+            .expect(
+                "SLED_CRASH_CHANCE must be set to a \
+                 non-negative integer (ideally below 50,000)",
             )
     });
 
@@ -34,6 +44,10 @@ pub fn debug_delay() {
         *ld = std::cmp::max(global_delays + 1, *ld + 1);
         old
     });
+
+    if *CRASH_CHANCE > 0 && random(*CRASH_CHANCE) == 0 {
+        std::process::exit(9)
+    }
 
     if global_delays == local_delays {
         // no other threads seem to be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ macro_rules! io_fail {
     ($config:expr, $e:expr) => {
         #[cfg(feature = "failpoints")]
         {
+            debug_delay();
             if fail::is_active($e) {
                 $config.set_global_error(Error::FailPoint);
                 return Err(Error::FailPoint).into();

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -17,6 +17,7 @@ macro_rules! io_fail {
     ($self:expr, $e:expr) => {
         #[cfg(feature = "failpoints")]
         {
+            debug_delay();
             if crate::fail::is_active($e) {
                 $self.config.set_global_error(Error::FailPoint);
                 // wake up any waiting threads so they don't stall forever

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -40,11 +40,7 @@ impl Iterator for LogIter {
 
             if self.segment_base.is_none() {
                 if let Err(e) = self.read_segment() {
-                    debug!(
-                        "hit snap while reading segments in \
-                         iterator: {:?}",
-                        e
-                    );
+                    debug!("unable to load new segment: {:?}", e);
                     return None;
                 }
             }

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -618,6 +618,12 @@ impl SegmentAccountant {
 
         for segment_base in to_free {
             self.free_segment(segment_base)?;
+            io_fail!(self.config, "zero garbage segment SA");
+            pwrite_all(
+                &self.config.file,
+                &*vec![MessageKind::Corrupted.into(); self.config.segment_size],
+                segment_base,
+            )?;
         }
 
         // we want to complete all truncations because
@@ -1068,6 +1074,7 @@ impl SegmentAccountant {
 
         let config = self.config.clone();
 
+        io_fail!(&config, "file truncation");
         threadpool::spawn(move || {
             debug!("truncating file to length {}", at);
             let res = config


### PR DESCRIPTION
@divergentdave this might be cool for you - I was having some trouble reproducing the crash bug that sometimes happens on ci, #1085, so I added this simple probabilistic process crash that gets called sometimes from debug_delay, which is already threaded through all of our correctness-critical operations. Immediately the system exploded with panics :)

Now that this reproduction test is in, further work on this branch will aim to fix the bugs that are found with this fun new test.