### PR TITLE
Conversion of boxed slices to Arc and IVec

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -28,9 +28,9 @@ pub struct Arc<T: ?Sized> {
 unsafe impl<T: Send + Sync + ?Sized> Send for Arc<T> {}
 unsafe impl<T: Send + Sync + ?Sized> Sync for Arc<T> {}
 
-impl<T: Debug> Debug for Arc<T> {
+impl<T: Debug + ?Sized> Debug for Arc<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_map().entry(&"inner", unsafe { &(*self.ptr).inner }).finish()
+        Debug::fmt(&**self, f)
     }
 }
 
@@ -168,30 +168,32 @@ impl<T: Copy> From<&[T]> for Arc<[T]> {
 }
 
 #[allow(clippy::fallible_impl_from)]
-impl<T> From<Box<T>> for Arc<T> {
+impl<T> From<Box<[T]>> for Arc<[T]> {
     #[inline]
-    fn from(b: Box<T>) -> Arc<T> {
-        let align =
-            std::cmp::max(mem::align_of::<T>(), mem::align_of::<AtomicUsize>());
-
-        let rc_width = std::cmp::max(align, mem::size_of::<AtomicUsize>());
-
+    fn from(b: Box<[T]>) -> Arc<[T]> {
+        let len = b.len();
         unsafe {
-            let dst_layout = Layout::new::<ArcInner<T>>();
+            let src = Box::into_raw(b);
+            let value_layout = Layout::for_value(&*src);
+            let align = std::cmp::max(value_layout.align(), mem::align_of::<AtomicUsize>());
+            let rc_width = std::cmp::max(align, mem::size_of::<AtomicUsize>());
+            let unpadded_size = rc_width.checked_add(value_layout.size()).unwrap();
+            let size = (unpadded_size + align - 1) & !(align - 1);
+            let dst_layout = Layout::from_size_align(size, align).unwrap();
             let dst = alloc(dst_layout);
             assert!(!dst.is_null(), "failed to allocate Arc");
 
-            let data_ptr = dst.add(rc_width);
             #[allow(clippy::cast_ptr_alignment)]
             ptr::write(dst as _, AtomicUsize::new(1));
-            let src = Box::into_raw(b);
-            ptr::copy(src, data_ptr as *mut T, 1);
+            let data_ptr = dst.add(rc_width);
+            ptr::copy_nonoverlapping(src as *const u8, data_ptr, len);
 
             // free the old box memory without running Drop
-            let src_layout = Layout::new::<T>();
-            dealloc(src as *mut u8, src_layout);
+            dealloc(src as *mut u8, value_layout);
 
-            Arc { ptr: dst as *mut _ }
+            let fat_ptr: *const ArcInner<[T]> = Arc::fatten(dst, len);
+
+            Arc { ptr: fat_ptr as *mut _ }
         }
     }
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -178,6 +178,7 @@ impl<T> From<Box<[T]>> for Arc<[T]> {
             let align = std::cmp::max(value_layout.align(), mem::align_of::<AtomicUsize>());
             let rc_width = std::cmp::max(align, mem::size_of::<AtomicUsize>());
             let unpadded_size = rc_width.checked_add(value_layout.size()).unwrap();
+            // pad the total `Arc` allocation size to the alignment of `max(value, AtomicUsize)`
             let size = (unpadded_size + align - 1) & !(align - 1);
             let dst_layout = Layout::from_size_align(size, align).unwrap();
             let dst = alloc(dst_layout);

--- a/src/ivec.rs
+++ b/src/ivec.rs
@@ -81,6 +81,16 @@ impl FromIterator<u8> for IVec {
     }
 }
 
+impl From<Box<[u8]>> for IVec {
+    fn from(b: Box<[u8]>) -> Self {
+        if is_inline_candidate(b.len()) {
+            Self::inline(&b)
+        } else {
+            Self::remote(Arc::from(b))
+        }
+    }
+}
+
 impl From<&[u8]> for IVec {
     fn from(slice: &[u8]) -> Self {
         if is_inline_candidate(slice.len()) {
@@ -245,5 +255,15 @@ fn ivec_usage() {
     let iv1 = IVec::from(vec![1, 2, 3]);
     assert_eq!(iv1, vec![1, 2, 3]);
     let iv2 = IVec::from(&[4; 128][..]);
+    assert_eq!(iv2, vec![4; 128]);
+}
+
+#[test]
+fn boxed_slice_conversion() {
+    let boite1: Box<[u8]> = Box::new([1, 2, 3]);
+    let iv1: IVec = boite1.into();
+    assert_eq!(iv1, vec![1, 2, 3]);
+    let boite2: Box<[u8]> = Box::new([4; 128]);
+    let iv2: IVec = boite2.into();
     assert_eq!(iv2, vec![4; 128]);
 }


### PR DESCRIPTION
This PR rewrites the (unsafe code!) `From<Box<T>> for Arc<T>` implementation to allow dynamically sized types, like `std::sync::Arc` does. Constructing a fat pointer to a dynamically sized `ArcInner<T>` from a `*mut u8` thin pointer and the source fat pointer requires some extra gymnastics, see the comments for details. This implementation is then used to add back the `From<Box<[u8]>> for IVec` implementation. Also included: rewrite of Arc's Debug implementation to allow dynamically sized types, and a small test for the conversion. The unsafe code is modeled after the standard library's code, so it ought to be okay, plus I'm going to run tests with Miri overnight.

Fixes #1107