### PR TITLE
Mockable I/O

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -206,7 +206,9 @@ impl<T: ?Sized> From<Box<T>> for Arc<T> {
             );
 
             // free the old box memory without running Drop
-            dealloc(src as *mut u8, value_layout);
+            if value_layout.size() != 0 {
+                dealloc(src as *mut u8, value_layout);
+            }
 
             Arc { ptr: dst }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -419,6 +419,20 @@ impl Config {
         self
     }
 
+    #[doc(hidden)]
+    pub fn mock_io(mut self, io: &'static dyn IO) -> Self {
+        if Arc::strong_count(&self.0) != 1 {
+            error!(
+                "config has already been used to start \
+                 the system and probably should not be \
+                 mutated",
+            );
+        }
+        let m = Arc::make_mut(&mut self.0);
+        m.io = io;
+        self
+    }
+
     /// Finalize the configuration.
     ///
     /// # Panics

--- a/src/config.rs
+++ b/src/config.rs
@@ -421,7 +421,7 @@ impl Config {
     }
 
     #[doc(hidden)]
-    pub fn mock_io(mut self, io: Arc<dyn IO>) -> Self {
+    pub fn mock_io(mut self, io: Box<dyn IO>) -> Self {
         if Arc::strong_count(&self.0) != 1 {
             error!(
                 "config has already been used to start \
@@ -430,7 +430,22 @@ impl Config {
             );
         }
         let m = Arc::make_mut(&mut self.0);
-        m.io = io;
+        m.io = io.into();
+        m.tmp_path = Config::gen_temp_path(&*m.io);
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn chain_mocked_io(mut self, other: &Config) -> Self {
+        if Arc::strong_count(&self.0) != 1 {
+            error!(
+                "config has already been used to start \
+                    the system and probably should not be \
+                    mutated",
+            );
+        }
+        let m = Arc::make_mut(&mut self.0);
+        m.io = other.io.clone();
         self
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -15,7 +15,8 @@ use crate::pagecache::parallel_io_windows::{pread_exact, pread_exact_or_eof, pwr
 type ReadDirPathsIter = Box<dyn Iterator<Item = std::io::Result<PathBuf>>>;
 type ReadDirSizesIter = Box<dyn Iterator<Item = std::io::Result<u64>>>;
 
-pub(crate) trait IO: std::fmt::Debug + Send + Sync {
+#[doc(hidden)]
+pub trait IO: std::fmt::Debug + Send + Sync {
     fn create_dir_all(&self, path: &Path) -> std::io::Result<()>;
     fn file_create_new_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
     fn file_create_new_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
@@ -33,7 +34,8 @@ pub(crate) trait IO: std::fmt::Debug + Send + Sync {
     fn temp_dir(&self) -> PathBuf;
 }
 
-pub(crate) trait IOFile: std::fmt::Debug + Send + Sync {
+#[doc(hidden)]
+pub trait IOFile: std::fmt::Debug + Send + Sync {
     fn len(&self) -> std::io::Result<u64>;
     fn pread_exact(&self, buf: &mut [u8], offset: LogOffset) -> std::io::Result<()>;
     fn pread_exact_or_eof(&self, buf: &mut [u8], offset: LogOffset) -> std::io::Result<usize>;

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,270 @@
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use super::LogOffset;
+
+#[cfg(all(not(unix), not(windows)))]
+use crate::pagecache::parallel_io_polyfill::{pread_exact, pread_exact_or_eof, pwrite_all};
+
+#[cfg(unix)]
+use crate::pagecache::parallel_io_unix::{pread_exact, pread_exact_or_eof, pwrite_all};
+
+#[cfg(windows)]
+use crate::pagecache::parallel_io_windows::{pread_exact, pread_exact_or_eof, pwrite_all};
+
+type ReadDirPathsIter = Box<dyn Iterator<Item = std::io::Result<PathBuf>>>;
+type ReadDirSizesIter = Box<dyn Iterator<Item = std::io::Result<u64>>>;
+
+pub(crate) trait IO: std::fmt::Debug + Send + Sync {
+    fn create_dir_all(&self, path: &Path) -> std::io::Result<()>;
+    fn file_create_new_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
+    fn file_create_new_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
+    fn file_open_or_create_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
+    fn file_open_or_create_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
+    fn file_open_r(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
+    fn file_open_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>>;
+    fn get_memory_limit(&self) -> u64;
+    fn path_exists(&self, path: &Path) -> bool;
+    fn read_dir_paths(&self, path: &Path) -> std::io::Result<ReadDirPathsIter>;
+    fn read_dir_sizes(&self, path: &Path) -> std::io::Result<ReadDirSizesIter>;
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()>;
+    fn remove_file(&self, path: &Path) -> std::io::Result<()>;
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()>;
+    fn temp_dir(&self) -> PathBuf;
+}
+
+pub(crate) trait IOFile: std::fmt::Debug + Send + Sync {
+    fn len(&self) -> std::io::Result<u64>;
+    fn pread_exact(&self, buf: &mut [u8], offset: LogOffset) -> std::io::Result<()>;
+    fn pread_exact_or_eof(&self, buf: &mut [u8], offset: LogOffset) -> std::io::Result<usize>;
+    fn pwrite_all(&self, buf: &[u8], offset: LogOffset) -> std::io::Result<()>;
+    fn read_exact(&mut self, buffer: &mut [u8]) -> std::io::Result<()>;
+    fn read_to_end(&mut self, buffer: &mut Vec<u8>) -> std::io::Result<usize>;
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64>;
+    fn set_len(&self, length: u64) -> std::io::Result<()>;
+    fn sync_all(&self) -> std::io::Result<()>;
+    fn sync_file_range_before_write_after(&self, offset: i64, nbytes: i64) -> std::io::Result<()>;
+    fn try_lock(&self) -> std::io::Result<()>;
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()>;
+}
+
+#[allow(missing_copy_implementations)]
+#[derive(Debug)]
+pub(crate) struct RealIO ();
+
+impl IO for RealIO {
+    fn create_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn file_create_new_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true);
+        options.read(true);
+        options.write(true);
+        let file = options.open(path)?;
+        Ok(Box::new(RealIOFile(file)))
+    }
+
+    fn file_create_new_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true);
+        options.write(true);
+        let file = options.open(path)?;
+        Ok(Box::new(RealIOFile(file)))
+    }
+
+    fn file_open_or_create_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true);
+        options.read(true);
+        options.write(true);
+        let file = options.open(path)?;
+        Ok(Box::new(RealIOFile(file)))
+    }
+
+    fn file_open_or_create_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true);
+        options.write(true);
+        let file = options.open(path)?;
+        Ok(Box::new(RealIOFile(file)))
+    }
+
+    fn file_open_r(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        let file = std::fs::OpenOptions::new().read(true).open(path)?;
+        Ok(Box::new(RealIOFile(file)))
+    }
+
+    fn file_open_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        let file = std::fs::OpenOptions::new().write(true).open(path)?;
+        Ok(Box::new(RealIOFile(file)))
+    }
+
+    fn get_memory_limit(&self) -> u64 {
+        crate::sys_limits::get_memory_limit()
+    }
+
+    fn path_exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn read_dir_paths(
+        &self,
+        path: &Path,
+    ) -> std::io::Result<ReadDirPathsIter> {
+        let read_dir = path.read_dir()?;
+        Ok(Box::new(RealReadDirPaths(read_dir)))
+    }
+
+    fn read_dir_sizes(
+        &self,
+        path: &Path,
+    ) -> std::io::Result<ReadDirSizesIter> {
+        let read_dir = path.read_dir()?;
+        Ok(Box::new(RealReadDirSizes(read_dir)))
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::remove_dir_all(path)
+    }
+
+    fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::remove_file(path)
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        std::fs::rename(from, to)
+    }
+
+    fn temp_dir(&self) -> PathBuf {
+        std::env::temp_dir()
+    }
+}
+
+pub struct RealReadDirPaths (std::fs::ReadDir);
+
+impl Iterator for RealReadDirPaths {
+    type Item = std::io::Result<PathBuf>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|direntry| Ok(direntry?.path()))
+    }
+}
+
+pub struct RealReadDirSizes (std::fs::ReadDir);
+
+impl Iterator for RealReadDirSizes {
+    type Item = std::io::Result<u64>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|direntry| Ok(direntry?.metadata()?.len()))
+    }
+}
+
+#[derive(Debug)]
+pub struct RealIOFile (std::fs::File);
+
+impl IOFile for RealIOFile {
+    fn len(&self) -> std::io::Result<u64> {
+        Ok(self.0.metadata()?.len())
+    }
+
+    fn pread_exact(
+        &self,
+        buf: &mut [u8],
+        offset: LogOffset,
+    ) -> std::io::Result<()>{
+        pread_exact(&self.0, buf, offset)
+    }
+
+    fn pread_exact_or_eof(
+        &self,
+        buf: &mut [u8],
+        offset: LogOffset,
+    ) -> std::io::Result<usize>{
+        pread_exact_or_eof(&self.0, buf, offset)
+    }
+
+    fn pwrite_all(
+        &self,
+        buf: &[u8],
+        offset: LogOffset,
+    ) -> std::io::Result<()> {
+        pwrite_all(&self.0, buf, offset)
+    }
+
+    fn read_exact(&mut self, buffer: &mut[u8]) -> std::io::Result<()> {
+        self.0.read_exact(buffer)
+    }
+
+    fn read_to_end(&mut self, buffer: &mut Vec<u8>) -> std::io::Result<usize> {
+        self.0.read_to_end(buffer)
+    }
+
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.0.seek(pos)
+    }
+
+    fn set_len(&self, length: u64) -> std::io::Result<()> {
+        self.0.set_len(length)
+    }
+
+    fn sync_all(&self) -> std::io::Result<()> {
+        self.0.sync_all()
+    }
+
+    #[allow(unsafe_code)]
+    fn sync_file_range_before_write_after(&self, offset: i64, nbytes: i64) -> std::io::Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::io::AsRawFd;
+            let ret = unsafe {
+                libc::sync_file_range(
+                    self.0.as_raw_fd(),
+                    offset,
+                    nbytes,
+                    libc::SYNC_FILE_RANGE_WAIT_BEFORE
+                        | libc::SYNC_FILE_RANGE_WRITE
+                        | libc::SYNC_FILE_RANGE_WAIT_AFTER,
+                )
+            };
+            if ret < 0 {
+                let err = std::io::Error::last_os_error();
+                if let Some(libc::ENOSYS) = err.raw_os_error() {
+                    self.sync_all()
+                } else {
+                    Err(err)
+                }
+            } else {
+                Ok(())
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        self.sync_all()
+    }
+
+    fn try_lock(&self) -> std::io::Result<()> {
+        if cfg!(any(windows, target_os = "linux", target_os = "macos")) {
+            use fs2::FileExt;
+
+            if cfg!(feature = "testing") {
+                // we block here because during testing
+                // there are many filesystem race condition
+                // that happen, causing locks to be held
+                // for long periods of time, so we should
+                // block to wait on reopening files.
+                self.0.lock_exclusive()
+            } else {
+                self.0.try_lock_exclusive()
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.0.write_all(buf)
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -248,7 +248,8 @@ impl IOFile for RealIOFile {
     }
 
     fn try_lock(&self) -> std::io::Result<()> {
-        if cfg!(any(windows, target_os = "linux", target_os = "macos")) {
+        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+        {
             use fs2::FileExt;
 
             if cfg!(feature = "testing") {
@@ -257,13 +258,13 @@ impl IOFile for RealIOFile {
                 // that happen, causing locks to be held
                 // for long periods of time, so we should
                 // block to wait on reopening files.
-                self.0.lock_exclusive()
+                self.0.lock_exclusive()?;
             } else {
-                self.0.try_lock_exclusive()
+                self.0.try_lock_exclusive()?;
             }
-        } else {
-            Ok(())
         }
+
+        Ok(())
     }
 
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ const DEFAULT_TREE_ID: &[u8] = b"__sled__default";
 pub use {
     self::{
         config::RunningConfig,
+        io::{IO, IOFile},
         lazy::Lazy,
         pagecache::{
             constants::{
@@ -312,7 +313,7 @@ use {
         context::Context,
         fastcmp::fastcmp,
         histogram::Histogram,
-        io::{IO, IOFile, RealIO},
+        io::RealIO,
         lru::Lru,
         meta::Meta,
         metrics::{clock, Measure, M},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ mod dll;
 mod fastcmp;
 mod fastlock;
 mod histogram;
+mod io;
 mod iter;
 mod ivec;
 mod lazy;
@@ -311,6 +312,7 @@ use {
         context::Context,
         fastcmp::fastcmp,
         histogram::Histogram,
+        io::{IO, IOFile, RealIO},
         lru::Lru,
         meta::Meta,
         metrics::{clock, Measure, M},
@@ -328,7 +330,7 @@ use {
         collections::BTreeMap,
         convert::TryFrom,
         fmt::{self, Debug},
-        io::{Read, Write},
+        io::Write,
         sync::atomic::{
             AtomicI64 as AtomicLsn, AtomicU64, AtomicUsize,
             Ordering::{Acquire, Relaxed, Release, SeqCst},

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -498,7 +498,7 @@ impl SegmentAccountant {
 
     fn initial_segments(&self, snapshot: &Snapshot) -> Result<Vec<Segment>> {
         let segment_size = self.config.segment_size;
-        let file_len = self.config.file.metadata()?.len();
+        let file_len = self.config.file.len()?;
         let number_of_segments =
             usize::try_from(file_len / segment_size as u64).unwrap()
                 + if file_len % segment_size as u64 == 0 { 0 } else { 1 };
@@ -619,8 +619,7 @@ impl SegmentAccountant {
         for segment_base in to_free {
             self.free_segment(segment_base)?;
             io_fail!(self.config, "zero garbage segment SA");
-            pwrite_all(
-                &self.config.file,
+            self.config.file.pwrite_all(
                 &*vec![MessageKind::Corrupted.into(); self.config.segment_size],
                 segment_base,
             )?;

--- a/tests/mocks/mod.rs
+++ b/tests/mocks/mod.rs
@@ -1,0 +1,497 @@
+// Currently, this all leans heavily on mutexes to get things working, though
+// this introduces unnecessary serialization that may mask concurrency
+// problems in sled itself. As future work, these mocks could be rewritten to
+// permit concurrent file operations.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::TryInto;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rand::{Rng, thread_rng};
+
+use sled::{IO, IOFile, LogOffset};
+
+enum CreationMode {
+    Create,
+    CreateOrExisting,
+    Existing,
+}
+
+#[derive(Debug)]
+struct FilePermissions {
+    read: bool,
+    write: bool,
+}
+
+impl FilePermissions {
+    const R: FilePermissions = FilePermissions { read: true, write: false };
+    const RW: FilePermissions = FilePermissions { read: true, write: true };
+    const W: FilePermissions = FilePermissions { read: false, write: true };
+}
+
+#[derive(Debug)]
+enum FileContents {
+    Present(Vec<u8>),
+    Tombstone,
+}
+
+impl FileContents {
+    fn unwrap(&self) -> &Vec<u8> {
+        match self {
+            FileContents::Present(vec) => vec,
+            FileContents::Tombstone => panic!("file was used after deletion"),
+        }
+    }
+
+    fn unwrap_mut(&mut self) -> &mut Vec<u8> {
+        match self {
+            FileContents::Present(vec) => vec,
+            FileContents::Tombstone => panic!("file was used after deletion"),
+        }
+    }
+}
+
+#[derive(Debug)]
+// always lock in the order dir_paths first, file_paths second to avoid deadlocks
+pub struct VirtualFileSystem {
+    working_dir: PathBuf,
+    dir_paths: Mutex<BTreeSet<PathBuf>>,
+    file_paths: Mutex<BTreeMap<PathBuf, Arc<Mutex<FileContents>>>>,
+}
+
+impl VirtualFileSystem {
+    pub fn new() -> VirtualFileSystem {
+        let workdir = PathBuf::from("/opt/sled");
+        let mut dir_paths = BTreeSet::new();
+        dir_paths.insert(workdir.parent().unwrap().to_owned());
+        dir_paths.insert(workdir.clone());
+        dir_paths.insert(PathBuf::from("/tmp"));
+        let dir_paths = Mutex::new(dir_paths);
+        VirtualFileSystem {
+            working_dir: workdir,
+            dir_paths,
+            file_paths: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn make_absolute(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_owned()
+        } else {
+            self.working_dir.join(path)
+        }
+    }
+
+    fn open_file(&self, path: &Path, creation: CreationMode, permissions: FilePermissions) -> std::io::Result<Box<dyn IOFile>> {
+        let path = self.make_absolute(path);
+        let dir_paths = self.dir_paths.lock();
+        if let Some(parent) = path.parent() {
+            if !dir_paths.contains(parent) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "parent directory does not exist",
+                ));
+            }
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "invalid file path",
+            ));
+        }
+        if dir_paths.contains(&path) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "cannot open or create file, there is a directory with the same name",
+            ));
+        }
+        let mut file_paths = self.file_paths.lock();
+        let contents = match (file_paths.entry(path.to_owned()), creation) {
+            (std::collections::btree_map::Entry::Vacant(entry), CreationMode::Create)
+                | (std::collections::btree_map::Entry::Vacant(entry), CreationMode::CreateOrExisting) => {
+                    entry.insert(Arc::new(Mutex::new(FileContents::Present(Vec::new())))).clone()
+                }
+            (std::collections::btree_map::Entry::Vacant(_), CreationMode::Existing) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "file does not exist",
+                ));
+            }
+            (std::collections::btree_map::Entry::Occupied(_), CreationMode::Create) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "file already exists",
+                ));
+            }
+            (std::collections::btree_map::Entry::Occupied(entry), CreationMode::CreateOrExisting)
+                | (std::collections::btree_map::Entry::Occupied(entry), CreationMode::Existing) => {
+                    entry.get().clone()
+                }
+        };
+        Ok(Box::new(VirtualFile {
+            offset: 0,
+            permissions,
+            contents,
+        }))
+    }
+}
+
+impl IO for VirtualFileSystem {
+    fn create_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        let target_dir = self.make_absolute(path);
+        let mut component_iter = target_dir.components();
+        assert_eq!(component_iter.next(), Some(std::path::Component::RootDir));
+        let mut create_path = PathBuf::with_capacity(target_dir.capacity());
+        create_path.push("/");
+        let mut dir_paths = self.dir_paths.lock();
+        let file_paths = self.file_paths.lock();
+        for component in component_iter {
+            match component {
+                std::path::Component::Prefix(_) => unimplemented!(),
+                std::path::Component::RootDir => unreachable!(),
+                std::path::Component::CurDir => unreachable!(),
+                std::path::Component::ParentDir => unimplemented!(),
+                std::path::Component::Normal(name) => {
+                    create_path.push(name);
+                    if file_paths.contains_key(&create_path) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::AlreadyExists,
+                            "directory cannot be created, a file already exists at that path",
+                        ));
+                    }
+                    dir_paths.insert(create_path.clone());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn file_create_new_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        self.open_file(path, CreationMode::Create, FilePermissions::RW)
+    }
+
+    fn file_create_new_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        self.open_file(path, CreationMode::Create, FilePermissions::W)
+    }
+
+    fn file_open_or_create_rw(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        self.open_file(path, CreationMode::CreateOrExisting, FilePermissions::RW)
+    }
+
+    fn file_open_or_create_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        self.open_file(path, CreationMode::CreateOrExisting, FilePermissions::W)
+    }
+
+    fn file_open_r(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        self.open_file(path, CreationMode::Existing, FilePermissions::R)
+    }
+
+    fn file_open_w(&self, path: &Path) -> std::io::Result<Box<dyn IOFile>> {
+        self.open_file(path, CreationMode::Existing, FilePermissions::W)
+    }
+
+    fn get_memory_limit(&self) -> u64 {
+        1024 * 1024 * 1024
+    }
+
+    fn path_exists(&self, path: &Path) -> bool {
+        let path = self.make_absolute(path);
+        self.dir_paths.lock().contains(&path) || self.file_paths.lock().contains_key(&path)
+    }
+
+    fn read_dir_paths(&self, path: &Path) -> std::io::Result<Box<dyn Iterator<Item = std::io::Result<PathBuf>>>> {
+        let path = self.make_absolute(path);
+        let dir_paths = self.dir_paths.lock();
+        if dir_paths.contains(&path) {
+            let file_paths = self.file_paths.lock();
+            let range = (std::ops::Bound::Included(&path), std::ops::Bound::Unbounded);
+            let mut paths: Vec<std::io::Result<PathBuf>> = dir_paths.range::<PathBuf, _>(range)
+                .take_while(|candidate| candidate.starts_with(&path))
+                .filter(|candidate| candidate.parent() == Some(&path))
+                .cloned()
+                .map(Result::Ok)
+                .collect();
+            paths.extend(
+                file_paths.range::<PathBuf, _>(range)
+                    .map(|(pathbuf, _)| pathbuf)
+                    .take_while(|candidate| candidate.starts_with(&path))
+                    .filter(|candidate| candidate.parent() == Some(&path))
+                    .cloned()
+                    .map(Result::Ok)
+            );
+            Ok(Box::new(paths.into_iter()))
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "directory does not exist"))
+        }
+    }
+
+    fn read_dir_sizes(&self, path: &Path) -> std::io::Result<Box<dyn Iterator<Item = std::io::Result<u64>>>> {
+        let path = self.make_absolute(path);
+        let dir_paths = self.dir_paths.lock();
+        if dir_paths.contains(&path) {
+            let file_paths = self.file_paths.lock();
+            let range = (std::ops::Bound::Included(&path), std::ops::Bound::Unbounded);
+            let sizes: Vec<std::io::Result<u64>> = file_paths.range::<PathBuf, _>(range)
+                .take_while(|(candidate, _)| candidate.starts_with(&path))
+                .filter(|(candidate, _)| candidate.parent() == Some(&path))
+                .map(|(_, arc)| Ok(arc.lock().unwrap().len().try_into().unwrap()))
+                .collect();
+            Ok(Box::new(sizes.into_iter()))
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "directory does not exist"))
+        }
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        let path = self.make_absolute(path);
+        let mut dir_paths = self.dir_paths.lock();
+        if dir_paths.remove(&path) {
+            let mut file_paths = self.file_paths.lock();
+            let range = (std::ops::Bound::Included(&path), std::ops::Bound::Unbounded);
+            while let Some(member) = dir_paths.range::<PathBuf, _>(range).next() {
+                if member.starts_with(&path) {
+                    let member = member.clone();
+                    dir_paths.remove(&member);
+                } else {
+                    break;
+                }
+            }
+            while let Some((member, arc)) = file_paths.range::<PathBuf, _>(range).next() {
+                if member.starts_with(&path) {
+                    let mut contents = arc.lock();
+                    *contents = FileContents::Tombstone;
+                    drop(contents);
+                    let member = member.clone();
+                    file_paths.remove(&member);
+                } else {
+                    break;
+                }
+            }
+            Ok(())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "directory does not exist"))
+        }
+    }
+
+    fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+        let path = self.make_absolute(path);
+        let mut file_paths = self.file_paths.lock();
+        if let Some(arc) = file_paths.remove(&path) {
+            let mut contents = arc.lock();
+            *contents = FileContents::Tombstone;
+            Ok(())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "file does not exist"))
+        }
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        let from = self.make_absolute(from);
+        let to = self.make_absolute(to);
+        let dir_paths = self.dir_paths.lock();
+        if dir_paths.contains(&from) {
+            // Renaming directories is not supported, as it would be hard, and it's not necessary for tests
+            unimplemented!();
+        }
+        if let Some(parent) = to.parent() {
+            if !dir_paths.contains(parent) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "destination directory does not exist",
+                ));
+            }
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "invalid destination",
+            ))
+        }
+        let mut file_paths = self.file_paths.lock();
+        if let Some(contents) = file_paths.remove(&from) {
+            file_paths.insert(to, contents);
+            Ok(())
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "file does not exist",
+            ))
+        }
+    }
+
+    fn temp_dir(&self) -> PathBuf {
+        const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234564789";
+
+        let parent = PathBuf::from("/tmp");
+        let mut dir_paths = self.dir_paths.lock();
+        let file_paths = self.file_paths.lock();
+        assert!(!file_paths.contains_key(&parent));
+        if !dir_paths.contains(&parent) {
+            dir_paths.insert(parent.clone());
+        }
+
+        let mut rng = thread_rng();
+        let path = loop {
+            let mut directory_bytes = [0u8; 11];
+            directory_bytes[0..3].copy_from_slice(b"tmp");
+            for byte in &mut directory_bytes[3..11] {
+                *byte = CHARS[rng.gen_range(0, CHARS.len())];
+            }
+            let directory_str = std::str::from_utf8(&directory_bytes[..]).unwrap();
+            let path = parent.join(PathBuf::from(directory_str));
+            if !dir_paths.contains(&path) {
+                break path;
+            }
+        };
+        dir_paths.insert(path.clone());
+        path
+    }
+}
+
+#[derive(Debug)]
+pub struct VirtualFile {
+    offset: usize,
+    permissions: FilePermissions,
+    contents: Arc<Mutex<FileContents>>,
+}
+
+impl VirtualFile {
+    fn check_read_access(&self) -> std::io::Result<()> {
+        if self.permissions.read {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "file not opened with read permissions"))
+        }
+    }
+
+    fn check_write_access(&self) -> std::io::Result<()> {
+        if self.permissions.write {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "file not opened with write permissions"))
+        }
+    }
+}
+
+impl IOFile for VirtualFile {
+    fn len(&self) -> std::io::Result<u64> {
+        Ok(self.contents.lock().unwrap().len().try_into().unwrap())
+    }
+
+    fn pread_exact(&self, buf: &mut [u8], offset: LogOffset) -> std::io::Result<()> {
+        self.check_read_access()?;
+        let offset = offset.try_into().unwrap();
+        let contents = self.contents.lock();
+        let v = contents.unwrap();
+        if offset > v.len() || buf.len() > v.len() - offset {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "could not read enough data",
+            ));
+        }
+        buf.copy_from_slice(&v[offset..offset + buf.len()]);
+        Ok(())
+    }
+
+    fn pread_exact_or_eof(&self, buf: &mut [u8], offset: LogOffset) -> std::io::Result<usize> {
+        self.check_read_access()?;
+        let offset = offset.try_into().unwrap();
+        let contents = self.contents.lock();
+        let v = contents.unwrap();
+        if offset > v.len() {
+            return Ok(0);
+        }
+        let read_len = std::cmp::min(buf.len(), v.len() - offset);
+        buf[0..read_len].copy_from_slice(&v[offset..offset + read_len]);
+        Ok(read_len)
+    }
+
+    fn pwrite_all(&self, buf: &[u8], offset: LogOffset) -> std::io::Result<()> {
+        self.check_write_access()?;
+        let offset_usize: usize = offset.try_into().unwrap();
+        let required_len = offset_usize + buf.len();
+        let mut contents = self.contents.lock();
+        let v = contents.unwrap_mut();
+        if v.len() < required_len {
+            v.resize(required_len, 0);
+        }
+        &v[offset_usize..required_len].copy_from_slice(buf);
+        Ok(())
+    }
+
+    fn read_exact(&mut self, buffer: &mut [u8]) -> std::io::Result<()> {
+        self.check_read_access()?;
+        let contents = self.contents.lock();
+        let v = contents.unwrap();
+        if self.offset > v.len() || buffer.len() > v.len() - self.offset {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "could not read enough data",
+            ));
+        }
+        buffer.copy_from_slice(&v[self.offset..self.offset + buffer.len()]);
+        self.offset += buffer.len();
+        Ok(())
+    }
+
+    fn read_to_end(&mut self, buffer: &mut Vec<u8>) -> std::io::Result<usize> {
+        self.check_read_access()?;
+        let contents = self.contents.lock();
+        let v = contents.unwrap();
+        if self.offset > v.len() {
+            return Ok(0);
+        }
+        let read_amount = v.len() - self.offset;
+        buffer.extend_from_slice(&v[self.offset..]);
+        self.offset = v.len();
+        Ok(read_amount)
+    }
+
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        let new_offset: u64 = match pos {
+            std::io::SeekFrom::Start(off) => off,
+            std::io::SeekFrom::End(off) => {
+                let len: i64 = self.contents.lock().unwrap().len().try_into().unwrap();
+                (len + off).try_into().unwrap()
+            }
+            std::io::SeekFrom::Current(off) => {
+                let old_offset: i64 = self.offset.try_into().unwrap();
+                (old_offset + off).try_into().unwrap()
+            }
+        };
+        self.offset = new_offset.try_into().unwrap();
+        Ok(new_offset)
+    }
+
+    fn set_len(&self, length: u64) -> std::io::Result<()> {
+        self.check_write_access()?;
+        self.contents.lock().unwrap_mut().resize(length.try_into().unwrap(), 0);
+        Ok(())
+    }
+
+    fn sync_all(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn sync_file_range_before_write_after(&self, _offset: i64, _nbytes: i64) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn try_lock(&self) -> std::io::Result<()> {
+        // always succeeds, there is only one "process" accessing the VFS
+        Ok(())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.check_write_access()?;
+        let required_len = self.offset + buf.len();
+        let mut contents = self.contents.lock();
+        let v = contents.unwrap_mut();
+        if v.len() < required_len {
+            v.resize(required_len, 0);
+        }
+        &v[self.offset..required_len].copy_from_slice(buf);
+        self.offset += buf.len();
+        Ok(())
+    }
+}

--- a/tests/test_mocked.rs
+++ b/tests/test_mocked.rs
@@ -1,0 +1,35 @@
+mod common;
+mod mocks;
+mod tree;
+
+use mocks::VirtualFileSystem;
+
+#[test]
+fn test_tree_mock_vfs() {
+    let db = sled::Config::default()
+        .mock_io(Box::new(VirtualFileSystem::new()))
+        .open()
+        .unwrap();
+    db.insert("key", "value").unwrap();
+    db.flush().unwrap();
+    assert_eq!(db.iter().count(), 1);
+    assert_eq!(db.get("key").unwrap(), Some("value".as_bytes().into()));
+
+    let new_config = sled::Config::default().chain_mocked_io(&db.context);
+    drop(db);
+
+    let db = new_config.open().unwrap();
+    assert_eq!(db.iter().count(), 1);
+    assert_eq!(db.get("key").unwrap(), Some("value".as_bytes().into()));
+    drop(db);
+
+    let db = sled::Config::default()
+        .mock_io(Box::new(VirtualFileSystem::new()))
+        .temporary(true)
+        .open()
+        .unwrap();
+    db.insert("key", "value").unwrap();
+    db.flush().unwrap();
+    assert_eq!(db.iter().count(), 1);
+    assert_eq!(db.get("key").unwrap(), Some("value".as_bytes().into()));
+}


### PR DESCRIPTION
Here's an initial effort at adding an indirection layer to all I/O, so that it can be mocked or traced. The approach I'm using here is to put a trait object in the Config to handle all top-level filesystem interactions, and to make open file handles trait objects as well. There are currently two sets of implementations for these traits, one for the real operating system, and a simple mock file system for testing. The mocks lean heavily on mutexes for now, concurrent file operations are future work. `strace` reports that the test using mocked I/O does not touch the operating system! Tracing is not yet supported, but it would fit naturally as wrapper implementations of the I/O traits. Something in these changes seems to cause a significant performance penalty on the benchmarks, so non-test performance is an open issue too.

See also #1077. Some of the changes here also appear in #1108.