### PR TITLE
Make the backtrace crate optional for faster compile times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+## Breaking Changes
+
+* the backtrace crate has been made optional, which cuts
+  several seconds off compilation time, but may cause
+  breakage if you interacted with the backtrace field
+  of corruption-related errors.
+
 # 0.32.1
 
 ## New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 edition = "2018"
 exclude = ["benchmarks", "examples", "bindings", "scripts", "experiments"]
 
+[package.metadata.docs.rs]
+features = ["docs"]
+
 [badges]
 maintenance = { status = "actively-developed" }
 
@@ -22,7 +25,7 @@ opt-level = 3
 
 [features]
 default = ["no_metrics"]
-testing = ["event_log", "lock_free_delays", "compression", "failpoints"]
+testing = ["event_log", "lock_free_delays", "compression", "failpoints", "backtrace"]
 compression = ["zstd"]
 lock_free_delays = []
 failpoints = []
@@ -48,7 +51,7 @@ log = "0.4.8"
 parking_lot = "0.11.0"
 color-backtrace = { version = "0.4.2", optional = true }
 rio = { version = "0.9.3", optional = true }
-backtrace = "0.3.49"
+backtrace = { version = "0.3.49", optional = true }
 array-init = "0.1.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os="windows"))'.dependencies]
@@ -63,9 +66,6 @@ log = "0.4.8"
 env_logger = "0.7.1"
 zerocopy = "0.3.0"
 byteorder = "1.3.4"
-
-[package.metadata.docs.rs]
-features = ["docs"]
 
 [[test]]
 name = "test_crash_recovery"

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,7 @@ use std::{
     io,
 };
 
+#[cfg(feature = "testing")]
 use backtrace::Backtrace;
 
 use crate::{
@@ -47,7 +48,11 @@ pub enum Error {
         /// The file location that corrupted data was found at.
         at: Option<DiskPtr>,
         /// A backtrace for where the corruption was encountered.
+        #[cfg(feature = "testing")]
         bt: Backtrace,
+        /// A backtrace for where the corruption was encountered.
+        #[cfg(not(feature = "testing"))]
+        bt: (),
     },
     // a failpoint has been triggered for testing purposes
     #[doc(hidden)]
@@ -57,7 +62,13 @@ pub enum Error {
 
 impl Error {
     pub(crate) fn corruption(at: Option<DiskPtr>) -> Error {
-        Error::Corruption { at, bt: Backtrace::new() }
+        Error::Corruption {
+            at,
+            #[cfg(feature = "testing")]
+            bt: Backtrace::new(),
+            #[cfg(not(feature = "testing"))]
+            bt: (),
+        }
     }
 }
 


### PR DESCRIPTION
this causes compile times to be a few seconds faster