### PR TITLE
metrics: fix log_reservation_attempts subtract overflow

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -321,7 +321,7 @@ impl Metrics {
         let log_reservations =
             std::cmp::max(1, self.log_reservations.load(Acquire));
         let log_reservation_attempts =
-            self.log_reservation_attempts.load(Acquire);
+            std::cmp::max(1, self.log_reservation_attempts.load(Acquire));
         let log_reservation_retry_rate =
             (log_reservation_attempts - log_reservations) * 100
                 / (log_reservations + 1);


### PR DESCRIPTION
Change-Id: If2c4c2d8485ef30e6e68eb107f9c23ebb40352a4

I have encountered subtract overflow panic during development. I have a made a fix identical to `log_reservations` approach using `cmp::max`.

```
thread 'main' panicked at 'attempt to subtract with overflow', /home/ow/dev/rust/sled/src/metrics.rs:331:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

full backtrace

```
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1076
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1537
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:477
  11: rust_begin_unwind
             at src/libstd/panicking.rs:385
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:86
  13: core::panicking::panic
             at src/libcore/panicking.rs:51
  14: sled::metrics::Metrics::print_profile
             at /home/ow/dev/rust/sled/src/metrics.rs:328
  15: <sled::config::Inner as core::ops::drop::Drop>::drop
             at /home/ow/dev/rust/sled/src/config.rs:808
  16: core::ptr::drop_in_place
             at /home/ow/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/ptr/mod.rs:184
  17: core::ptr::drop_in_place
             at /home/ow/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/ptr/mod.rs:184
  18: core::ptr::drop_in_place
             at /home/ow/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/ptr/mod.rs:184
  19: <sled::arc::Arc<T> as core::ops::drop::Drop>::drop

```