### PR TITLE
Added TransactionalTree::generate_id()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -122,7 +122,8 @@ impl Context {
     /// a blocking flush to fsync the latest counter, ensuring
     /// that we will never give out the same counter twice.
     pub fn generate_id(&self) -> Result<u64> {
-        self.pagecache.generate_id()
+        let _cc = concurrency_control::read();
+        self.pagecache.generate_id_inner()
     }
 
     pub(crate) fn pin_log(&self, guard: &Guard) -> Result<RecoveryGuard<'_>> {

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1793,8 +1793,7 @@ impl PageCache {
     /// previous persisted counter wasn't synced to disk yet, we will do
     /// a blocking flush to fsync the latest counter, ensuring
     /// that we will never give out the same counter twice.
-    pub(crate) fn generate_id(&self) -> Result<u64> {
-        let _cc = concurrency_control::read();
+    pub(crate) fn generate_id_inner(&self) -> Result<u64> {
         let ret = self.idgen.fetch_add(1, Release);
 
         trace!("generating ID {}", ret);


### PR DESCRIPTION
Added TransactionalTree::generate_id()
- renamed PageCache::generate_id() to PageCache::generate_id_inner()
- moved concurrency lock from PageCache::generate_id_inner() to Context::generate_id()
- TransactionalTree::generate_id() uses PageCache::generate_id_inner() with lock obtained in stage(), thus avoiding deadlock
and providing fix for #1139
