### PR TITLE
Make IVec writable and sequentially readable (extend_from_slice, io::Write, io::Read, etc.)

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -145,9 +145,9 @@ pub(crate) fn ensure_arc_buffer_alloc<F>(arc: &mut Arc<[u8]>, len: usize, more: 
     where F: FnOnce(&mut [u8]),
 {
     let old_cap = arc.len();
-    assert!(more > 0 && len <= old_cap && Arc::strong_count(arc) > 0);
+    assert!(more > 0 && len <= old_cap);
     let need_len = len + more;
-    if need_len > old_cap {
+    if Arc::strong_count(arc) != 1 || need_len > old_cap {
         // need to re-allocate and copy
         let cap = need_len.next_power_of_two();
         unsafe {

--- a/src/ivec.rs
+++ b/src/ivec.rs
@@ -210,7 +210,7 @@ impl IVec {
             },
             IVecInner::Subslice { ref mut base, offset, len } => {
                 let slice = &base[*offset..*offset + *len];
-                //println!("subslice push, len={}, more={}", *len, more);
+                // always detach from slice
                 self.0 = IVecInner::Remote {
                     base: arc::arc_buffer_from_slice(more, slice, f),
                     len: *len + more,

--- a/src/ivec.rs
+++ b/src/ivec.rs
@@ -4,9 +4,10 @@ use std::{
     hash::{Hash, Hasher},
     iter::FromIterator,
     ops::{Deref, DerefMut},
+    io::{Read, Write, Result as IoResult},
 };
 
-use crate::Arc;
+use crate::{ Arc, arc };
 
 const CUTOFF: usize = 22;
 
@@ -26,7 +27,7 @@ impl Default for IVec {
 #[derive(Clone)]
 enum IVecInner {
     Inline(u8, Inner),
-    Remote(Arc<[u8]>),
+    Remote { base: Arc<[u8]>, len: usize },
     Subslice { base: Arc<[u8]>, offset: usize, len: usize },
 }
 
@@ -81,7 +82,7 @@ impl IVec {
         assert!(self.len().checked_sub(slice_offset).unwrap() >= len);
 
         let inner = match self.0 {
-            IVecInner::Remote(ref base) => IVecInner::Subslice {
+            IVecInner::Remote { ref base, .. } => IVecInner::Subslice {
                 base: base.clone(),
                 offset: slice_offset,
                 len,
@@ -106,6 +107,37 @@ impl IVec {
 
         IVec(inner)
     }
+    /// Allocate IVec with zero length and specified capacity
+    pub fn with_capacity(cap: usize) -> Self {
+        if is_inline_candidate(cap) {
+            Self(IVecInner::Inline(0, [0; CUTOFF]))
+        } else {
+            Self(IVecInner::Remote{ base: arc::new_arc_buffer(cap), len: 0 })
+        }
+    }
+    /// Create zero-length IVec with inline buffer
+    pub fn new() -> Self {
+        Self::with_capacity(CUTOFF)
+    }
+
+    /// Returns length of data
+    pub fn len(&self) -> usize {
+        // faster path, avoids deref
+        match self.0 {
+            IVecInner::Inline(len, ..) => len as usize,
+            IVecInner::Remote { len, .. } => len,
+            IVecInner::Subslice { len, .. } => len,
+        }
+    }
+
+    /// Current buffer capacity, may be equal or greater than length
+    pub fn capacity(&self) -> usize {
+        match self.0 {
+            IVecInner::Inline(..) => CUTOFF,
+            IVecInner::Remote { ref base, .. } => base.as_ref().len(),
+            IVecInner::Subslice { len, .. } => len,
+        }
+    }
 
     fn inline(slice: &[u8]) -> Self {
         assert!(is_inline_candidate(slice.len()));
@@ -124,23 +156,66 @@ impl IVec {
         Self(IVecInner::Inline(u8::try_from(slice.len()).unwrap(), data))
     }
 
-    fn remote(arc: Arc<[u8]>) -> Self {
-        Self(IVecInner::Remote(arc))
+    fn remote(base: Arc<[u8]>) -> Self {
+        let len = base.len();
+        Self(IVecInner::Remote{ base, len })
     }
 
     fn make_mut(&mut self) {
         match self.0 {
-            IVecInner::Remote(ref mut buf) if Arc::strong_count(buf) != 1 => {
-                self.0 = IVecInner::Remote(buf.to_vec().into());
+            IVecInner::Remote { ref mut base, len } if Arc::strong_count(base) != 1 => {
+                self.0 = IVecInner::Remote { base: base.as_ref().into(), len };
             }
             IVecInner::Subslice { ref mut base, offset, len }
-                if Arc::strong_count(base) != 1 =>
-            {
-                self.0 = IVecInner::Remote(
-                    base[offset..offset + len].to_vec().into(),
-                );
-            }
+            if Arc::strong_count(base) != 1 =>
+                {
+                    let new_base: Arc<[u8]> = base[offset..offset + len].as_ref().into();
+                    self.0 = IVecInner::Remote { base: new_base, len };
+                }
             _ => {}
+        }
+    }
+
+    /// Append single byte to IVec
+    pub fn push(&mut self, v: u8) {
+        self.push_data(1, |buf| { buf[0] = v } );
+    }
+
+    /// Extend IVec from slice of bytes
+    pub fn extend_from_slice(&mut self, s: &[u8]) {
+        self.push_data(s.len(), |buf| buf[..s.len()].copy_from_slice(s));
+    }
+
+    // push `more` bytes into ivec, call `f` to set data bytes
+    fn push_data<F>(&mut self, more: usize, f: F)
+        where F: FnOnce(&mut [u8])
+    {
+        match &mut self.0 {
+            IVecInner::Inline(len, inner) => {
+                let usize_len = *len as usize;
+                let new_len = usize_len + more;
+                if new_len <= CUTOFF {
+                    f(&mut inner[usize_len..]);
+                    *len = *len + (more as u8);
+                } else {
+                    self.0 = IVecInner::Remote {
+                        base: arc::arc_buffer_from_slice(more, &inner[..usize_len], f),
+                        len: new_len,
+                    };
+                }
+            },
+            IVecInner::Remote{ base, len } => {
+                arc::ensure_arc_buffer_alloc(base, *len, more, f);
+                *len = *len + more;
+            },
+            IVecInner::Subslice { ref mut base, offset, len } => {
+                let slice = &base[*offset..*offset + *len];
+                //println!("subslice push, len={}, more={}", *len, more);
+                self.0 = IVecInner::Remote {
+                    base: arc::arc_buffer_from_slice(more, slice, f),
+                    len: *len + more,
+                };
+            },
         }
     }
 }
@@ -243,11 +318,24 @@ impl Into<Arc<[u8]>> for IVec {
     fn into(self) -> Arc<[u8]> {
         match self.0 {
             IVecInner::Inline(..) => Arc::from(self.as_ref()),
-            IVecInner::Remote(arc) => arc,
+            IVecInner::Remote { base, len } => {
+                if base.len() == len {
+                    base
+                } else {
+                    Arc::from(&base[..len])
+                }
+            },
             IVecInner::Subslice { .. } => self.deref().into(),
         }
     }
 }
+
+impl Into<Vec<u8>> for IVec {
+    fn into(self) -> Vec<u8> {
+        Vec::from(self.as_ref())
+    }
+}
+
 
 impl Deref for IVec {
     type Target = [u8];
@@ -266,7 +354,9 @@ impl AsRef<[u8]> for IVec {
             IVecInner::Inline(sz, buf) => unsafe {
                 buf.get_unchecked(..*sz as usize)
             },
-            IVecInner::Remote(buf) => buf,
+            IVecInner::Remote{ base, len} => {
+                &base[..*len]
+            },
             IVecInner::Subslice { ref base, offset, len } => {
                 &base[*offset..*offset + *len]
             }
@@ -291,7 +381,9 @@ impl AsMut<[u8]> for IVec {
             IVecInner::Inline(ref sz, ref mut buf) => unsafe {
                 std::slice::from_raw_parts_mut(buf.as_mut_ptr(), *sz as usize)
             },
-            IVecInner::Remote(ref mut buf) => Arc::get_mut(buf).unwrap(),
+            IVecInner::Remote { ref mut base, ref len } => {
+                &mut Arc::get_mut(base).unwrap()[..*len]
+            },
             IVecInner::Subslice { ref mut base, offset, len } => {
                 &mut Arc::get_mut(base).unwrap()[*offset..*offset + *len]
             }
@@ -324,6 +416,26 @@ impl PartialEq<[u8]> for IVec {
 }
 
 impl Eq for IVec {}
+
+impl Read for IVec {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        let s = self.as_ref();
+        let amt = buf.len().min(s.len());
+        buf[..amt].copy_from_slice(&s[..amt]);
+        *self = self.subslice(amt, s.len() - amt);
+        Ok(amt)
+    }
+}
+
+impl Write for IVec {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> IoResult<()> {
+        Ok(())
+    }
+}
 
 impl fmt::Debug for IVec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -370,6 +482,73 @@ fn ivec_as_mut_identity() {
     assert_eq!(&*initial, &*iv);
     assert_eq!(&*initial, &mut *iv);
     assert_eq!(&*initial, iv.as_mut());
+}
+
+#[test]
+fn ivec_io_01() {
+    let mut iv = IVec::new();
+    let d = b"abcdef";
+    assert_eq!(iv.write(&d[..3]).unwrap(), 3);
+    assert_eq!(iv.write(&d[3..]).unwrap(), 3);
+    let mut buf1 = [0; 2];
+    let n = iv.read(&mut buf1).unwrap();
+    assert_eq!(n, 2);
+
+    assert_eq!(iv.len(), 4);
+    assert_eq!(iv.capacity(), CUTOFF);
+
+    let mut buf2 = [0; 3];
+    let n = iv.read(&mut buf2).unwrap();
+    assert_eq!(n, 3);
+    assert_eq!(&buf2[..n], &d[2..5]);
+
+    assert_eq!(iv.capacity(), CUTOFF);
+    assert_eq!(iv.len(), 1);
+
+    // check write after read
+    assert_eq!(iv.write(b"xyzzy").unwrap(), 5);
+    assert_eq!(iv.capacity(), CUTOFF);
+    assert_eq!(iv.len(), 6);
+    assert_eq!(iv, b"fxyzzy");
+}
+
+#[test]
+fn ivec_io_02() {
+    let mut iv = IVec::new();
+    let t1 = b"1234567890abcdefghijkl";
+    assert_eq!(t1.len(), CUTOFF);
+
+    assert_eq!(iv.write(t1).unwrap(), CUTOFF);
+    assert_eq!(iv.capacity(), CUTOFF);
+    assert_eq!(iv.len(), CUTOFF);
+
+    assert_eq!(CUTOFF.next_power_of_two(), 32);
+
+    // check realloc internal -> remote
+    assert_eq!(iv.write(b"X").unwrap(), 1);
+    assert_eq!(&iv[CUTOFF-2..CUTOFF+1], b"klX");
+    assert_eq!(iv.capacity(), 32);  // next power of 2 after CUTOFF
+    assert_eq!(iv.len(), CUTOFF + 1);
+
+    // check realloc remote -> remote
+    assert_eq!(iv.write(t1).unwrap(), t1.len());
+    assert_eq!(iv.capacity(), 64);
+    assert_eq!(iv.len(), CUTOFF*2 + 1);
+    assert_eq!(&iv[3..6], b"456");
+    assert_eq!(&iv[iv.len() - 3..], b"jkl");
+
+    // check realloc slice -> remote
+    let mut ivs = iv.subslice(1, 40);
+    assert_eq!(ivs.write(b"ZZT").unwrap(), 3);
+    assert_eq!(ivs.len(), 43);
+    assert_eq!(&iv[iv.len() - 3..], b"jkl"); // should not change
+    assert_eq!(&ivs[ivs.len() - 3..], b"ZZT");
+    assert_eq!(&ivs[0..3], b"234");
+
+    // check single-byte push
+    ivs.push(33);
+    assert_eq!(ivs.len(), 44);
+    assert_eq!(ivs[43], 33);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Implemented Vec-like methods `new()`, `with_capacity()`, `capacity()`, `extend_from_slice()`, `push()`, with COW semantics; this was easy because IVec uses shared Arc for buffer and already used COW for subslicing
- Implemented io::Write, io::Read traits for IVec (read works via subslicing)

With these changes, IVec becomes much more convenient to use with I/O methods,. serialization libraries like serde etc.

Internally, some minor refactoring and few utility methods for Arc<[u8]>, also added T: Copy trait bound for conversion trait impls for Arc owning slices, otherwise it may be unsound (e.g. Vec<T> -> Arc<[T]> uses bitwise copying).
