### PR TITLE
Remove no-op #[cold] attributes

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -140,7 +140,6 @@ impl<T: ?Sized> Clone for Arc<T> {
             unsafe { (*self.ptr).rc.fetch_add(1, Ordering::Relaxed) };
 
         if last_count == usize::max_value() {
-            #[cold]
             std::process::abort();
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -733,7 +733,6 @@ impl Config {
         if ge.is_null() {
             Ok(())
         } else {
-            #[cold]
             #[allow(unsafe_code)]
             unsafe {
                 Err(ge.deref().clone())


### PR DESCRIPTION
Building with a recent nightly compiler yields a couple messages of `warning: attribute should be applied to a function`, and `warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!`. In these two places, `#[cold]` was applied to a statement or a block, whereas the attribute is only effective when applied to a function.

I don't think there is yet a good way to provide the intended hints to the compiler on stable, though if core_intrinsics is stabilized, the likely/unlikely intrinsics would work. Moreover, the #[cold] in src/arc.rs was on a call to std::process::abort(), and I'm hopeful that LLVM is able to infer that this branch is cold, because it ends with a call to a never-returning function.