### PR TITLE
Replace unsafe IVec code with equivalent safe code

### DIFF
--- a/src/ivec.rs
+++ b/src/ivec.rs
@@ -109,18 +109,8 @@ impl IVec {
 
     fn inline(slice: &[u8]) -> Self {
         assert!(is_inline_candidate(slice.len()));
-
         let mut data = Inner::default();
-
-        #[allow(unsafe_code)]
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                slice.as_ptr(),
-                data.as_mut_ptr(),
-                slice.len(),
-            );
-        }
-
+        data[..slice.len()].copy_from_slice(slice);
         Self(IVecInner::Inline(u8::try_from(slice.len()).unwrap(), data))
     }
 


### PR DESCRIPTION
This produces the same LLVM IR (modulo an SSA var name change) and assembly (literally identical).

<details><summary>The actual assembly, for curiosity's sake</summary>

```asm
inline:
	push	r15
	push	r14
	push	rbx
	sub	rsp, 32
	cmp	rdx, 22
	ja	.LBB7_2
	mov	rbx, rdx
	mov	r15, rsi
	mov	r14, rdi
	mov	edx, 22
	sub	rdx, rbx
	lea	rdi, [rsp + rbx]
	add	rdi, 10
	xor	esi, esi
	call	qword ptr [rip + memset@GOTPCREL]
	lea	rdi, [rsp + 10]
	mov	rsi, r15
	mov	rdx, rbx
	call	qword ptr [rip + memcpy@GOTPCREL]
	mov	byte ptr [r14], 0
	mov	byte ptr [r14 + 1], bl
	movups	xmm0, xmmword ptr [rsp + 10]
	movups	xmmword ptr [r14 + 2], xmm0
	mov	rax, qword ptr [rsp + 24]
	mov	qword ptr [r14 + 16], rax
	mov	rax, r14
	add	rsp, 32
	pop	rbx
	pop	r14
	pop	r15
	ret
```

</details>