### PR TITLE
Fix blob space leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Bug Fixes
+
+* #1202 Fix a space leak where blobs were not
+  removed when replaced by another blob.
+
 # 0.34.6
 
 ## Improvements

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -764,7 +764,10 @@ impl SegmentAccountant {
         // the underlying blob, as is the case with a single Blob
         // with nothing else.
         let schedule_rm_blob = !(old_cache_infos.len() == 1
-            && old_cache_infos[0].pointer.is_blob());
+            && old_cache_infos[0].pointer.is_blob()
+            && new_cache_info.pointer.is_blob()
+            && old_cache_infos[0].pointer.blob().1
+                == new_cache_info.pointer.blob().1);
 
         let mut removals = FastMap8::default();
 


### PR DESCRIPTION
Lone blobs were not being properly cleaned up upon replacement if they were replaced by another blob.