### PR TITLE
push blobs to snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+## Breaking Changes
+
+* #1203 Snapshot files have had their on-disk
+  structure modified to facilitate the handling
+  of fuzzy snapshots.
+
 ## Bug Fixes
 
 * #1202 Fix a space leak where blobs were not

--- a/src/atomic_shim.rs
+++ b/src/atomic_shim.rs
@@ -17,7 +17,7 @@ mod shim {
     }
 
     impl AtomicU64 {
-        pub fn new(v: u64) -> Self {
+        pub const fn new(v: u64) -> Self {
             Self { value: ShardedLock::new(v) }
         }
 

--- a/src/atomic_shim.rs
+++ b/src/atomic_shim.rs
@@ -8,7 +8,7 @@
 pub use std::sync::atomic::{AtomicI64, AtomicU64};
 #[cfg(any(target_arch = "mips", target_arch = "powerpc", feature = "mutex"))]
 mod shim {
-    use parking_lot::RwLock;
+    use parking_lot::{const_rwlock, RwLock};
     use std::sync::atomic::Ordering;
 
     #[derive(Debug, Default)]
@@ -18,33 +18,23 @@ mod shim {
 
     impl AtomicU64 {
         pub const fn new(v: u64) -> Self {
-            Self { value: RwLock::new(v) }
-        }
-
-        #[allow(dead_code)]
-        pub fn get_mut(&mut self) -> &mut u64 {
-            self.value.get_mut().unwrap()
-        }
-
-        #[allow(dead_code)]
-        pub fn into_inner(self) -> u64 {
-            self.value.into_inner().unwrap()
+            Self { value: const_rwlock(v) }
         }
 
         #[allow(dead_code)]
         pub fn load(&self, _: Ordering) -> u64 {
-            *self.value.read().unwrap()
+            *self.value.read()
         }
 
         #[allow(dead_code)]
         pub fn store(&self, value: u64, _: Ordering) {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             *lock = value;
         }
 
         #[allow(dead_code)]
         pub fn swap(&self, value: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = value;
             prev
@@ -57,7 +47,7 @@ mod shim {
             new: u64,
             _: Ordering,
         ) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             if prev == current {
                 *lock = new;
@@ -73,7 +63,7 @@ mod shim {
             _: Ordering,
             _: Ordering,
         ) -> Result<u64, u64> {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             if prev == current {
                 *lock = new;
@@ -96,7 +86,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_add(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev.wrapping_add(val);
             prev
@@ -104,7 +94,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_sub(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev.wrapping_sub(val);
             prev
@@ -112,7 +102,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_and(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev & val;
             prev
@@ -120,7 +110,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_nand(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = !(prev & val);
             prev
@@ -128,7 +118,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev | val;
             prev
@@ -136,7 +126,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_xor(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev ^ val;
             prev
@@ -156,33 +146,23 @@ mod shim {
 
     impl AtomicI64 {
         pub fn new(v: i64) -> Self {
-            Self { value: RwLock::new(v) }
-        }
-
-        #[allow(dead_code)]
-        pub fn get_mut(&mut self) -> &mut i64 {
-            self.value.get_mut().unwrap()
-        }
-
-        #[allow(dead_code)]
-        pub fn into_inner(self) -> i64 {
-            self.value.into_inner().unwrap()
+            Self { value: const_rwlock(v) }
         }
 
         #[allow(dead_code)]
         pub fn load(&self, _: Ordering) -> i64 {
-            *self.value.read().unwrap()
+            *self.value.read()
         }
 
         #[allow(dead_code)]
         pub fn store(&self, value: i64, _: Ordering) {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             *lock = value;
         }
 
         #[allow(dead_code)]
         pub fn swap(&self, value: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = value;
             prev
@@ -195,7 +175,7 @@ mod shim {
             new: i64,
             _: Ordering,
         ) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             if prev == current {
                 *lock = new;
@@ -211,7 +191,7 @@ mod shim {
             _: Ordering,
             _: Ordering,
         ) -> Result<i64, i64> {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             if prev == current {
                 *lock = new;
@@ -234,7 +214,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_add(&self, val: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev.wrapping_add(val);
             prev
@@ -242,7 +222,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_sub(&self, val: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev.wrapping_sub(val);
             prev
@@ -250,7 +230,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_and(&self, val: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev & val;
             prev
@@ -258,7 +238,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_nand(&self, val: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = !(prev & val);
             prev
@@ -266,7 +246,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_or(&self, val: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev | val;
             prev
@@ -274,7 +254,7 @@ mod shim {
 
         #[allow(dead_code)]
         pub fn fetch_xor(&self, val: i64, _: Ordering) -> i64 {
-            let mut lock = self.value.write().unwrap();
+            let mut lock = self.value.write();
             let prev = *lock;
             *lock = prev ^ val;
             prev

--- a/src/atomic_shim.rs
+++ b/src/atomic_shim.rs
@@ -1,4 +1,4 @@
-///! Inline of https://github.com/bltavares/atomic-shim
+///! Inline of `https://github.com/bltavares/atomic-shim`
 
 #[cfg(not(any(
     target_arch = "mips",

--- a/src/atomic_shim.rs
+++ b/src/atomic_shim.rs
@@ -8,17 +8,17 @@
 pub use std::sync::atomic::{AtomicI64, AtomicU64};
 #[cfg(any(target_arch = "mips", target_arch = "powerpc", feature = "mutex"))]
 mod shim {
-    use crossbeam_utils::sync::ShardedLock;
+    use parking_lot::RwLock;
     use std::sync::atomic::Ordering;
 
     #[derive(Debug, Default)]
     pub struct AtomicU64 {
-        value: ShardedLock<u64>,
+        value: RwLock<u64>,
     }
 
     impl AtomicU64 {
         pub const fn new(v: u64) -> Self {
-            Self { value: ShardedLock::new(v) }
+            Self { value: RwLock::new(v) }
         }
 
         #[allow(dead_code)]
@@ -151,12 +151,12 @@ mod shim {
 
     #[derive(Debug, Default)]
     pub struct AtomicI64 {
-        value: ShardedLock<i64>,
+        value: RwLock<i64>,
     }
 
     impl AtomicI64 {
         pub fn new(v: i64) -> Self {
-            Self { value: ShardedLock::new(v) }
+            Self { value: RwLock::new(v) }
         }
 
         #[allow(dead_code)]

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,13 +1,5 @@
 #![allow(unused_results)]
 
-#[cfg(not(feature = "testing"))]
-use std::collections::HashMap as Map;
-
-// we avoid HashMap while testing because
-// it makes tests non-deterministic
-#[cfg(feature = "testing")]
-use std::collections::BTreeMap as Map;
-
 use super::*;
 
 /// A batch of updates that will

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fs,
     fs::File,
     io,
@@ -56,7 +55,7 @@ impl StorageParameters {
     pub fn deserialize(bytes: &[u8]) -> Result<StorageParameters> {
         let reader = BufReader::new(bytes);
 
-        let mut lines = HashMap::new();
+        let mut lines = Map::new();
 
         for line in reader.lines() {
             let line = if let Ok(l) = line {

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -22,8 +22,6 @@
 //! 4.
 #![allow(missing_docs)]
 
-use std::collections::HashMap;
-
 use crate::pagecache::DiskPtr;
 use crate::*;
 
@@ -32,8 +30,8 @@ use crate::stack::{Iter as StackIter, Stack};
 /// A thing that happens at a certain time.
 #[derive(Debug, Clone)]
 enum Event {
-    PagesOnShutdown { pages: HashMap<PageId, Vec<DiskPtr>> },
-    PagesOnRecovery { pages: HashMap<PageId, Vec<DiskPtr>> },
+    PagesOnShutdown { pages: Map<PageId, Vec<DiskPtr>> },
+    PagesOnRecovery { pages: Map<PageId, Vec<DiskPtr>> },
     MetaOnShutdown { meta: Meta },
     MetaOnRecovery { meta: Meta },
     RecoveredLsn(Lsn),
@@ -98,7 +96,7 @@ impl EventLog {
                             .chain(
                                 pages.iter().map(|(pid, _frag_locations)| *pid),
                             )
-                            .collect::<std::collections::HashSet<_>>()
+                            .collect::<Set<_>>()
                             .into_iter();
 
                         for pid in pids {
@@ -144,16 +142,13 @@ impl EventLog {
 
     pub(crate) fn pages_before_restart(
         &self,
-        pages: HashMap<PageId, Vec<DiskPtr>>,
+        pages: Map<PageId, Vec<DiskPtr>>,
     ) {
         let guard = pin();
         self.inner.push(Event::PagesOnShutdown { pages }, &guard);
     }
 
-    pub(crate) fn pages_after_restart(
-        &self,
-        pages: HashMap<PageId, Vec<DiskPtr>>,
-    ) {
+    pub(crate) fn pages_after_restart(&self, pages: Map<PageId, Vec<DiskPtr>>) {
         let guard = pin();
         self.inner.push(Event::PagesOnRecovery { pages }, &guard);
     }

--- a/src/fail.rs
+++ b/src/fail.rs
@@ -1,14 +1,8 @@
-use std::collections::HashMap;
-
 use parking_lot::Mutex;
 
-use crate::Lazy;
+use crate::{Lazy, Map};
 
-type HM = HashMap<
-    &'static str,
-    u64,
-    std::hash::BuildHasherDefault<fxhash::FxHasher64>,
->;
+type HM = Map<&'static str, u64>;
 
 static ACTIVE: Lazy<Mutex<HM>, fn() -> Mutex<HM>> = Lazy::new(init);
 

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -167,16 +167,11 @@ impl Drop for Flusher {
             let _notified = self.sc.notify_all();
         }
 
-        #[cfg(feature = "testing")]
-        {
-            let mut count = 0;
-        }
+        #[allow(unused_variables)]
+        let mut count = 0;
         while !shutdown.is_shutdown() {
             let _ = self.sc.wait_for(&mut shutdown, Duration::from_millis(100));
-            #[cfg(feature = "testing")]
-            {
-                count += 1;
-            }
+            count += 1;
 
             testing_assert!(count < 5);
         }

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -167,8 +167,12 @@ impl Drop for Flusher {
             let _notified = self.sc.notify_all();
         }
 
+        let mut _count = 0;
         while !shutdown.is_shutdown() {
             let _ = self.sc.wait_for(&mut shutdown, Duration::from_millis(100));
+            _count += 1;
+
+            testing_assert!(_count < 5);
         }
 
         let mut join_handle_opt = self.join_handle.lock();

--- a/src/flusher.rs
+++ b/src/flusher.rs
@@ -167,12 +167,18 @@ impl Drop for Flusher {
             let _notified = self.sc.notify_all();
         }
 
-        let mut _count = 0;
+        #[cfg(feature = "testing")]
+        {
+            let mut count = 0;
+        }
         while !shutdown.is_shutdown() {
             let _ = self.sc.wait_for(&mut shutdown, Duration::from_millis(100));
-            _count += 1;
+            #[cfg(feature = "testing")]
+            {
+                count += 1;
+            }
 
-            testing_assert!(_count < 5);
+            testing_assert!(count < 5);
         }
 
         let mut join_handle_opt = self.join_handle.lock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,18 +420,34 @@ pub(crate) enum Link {
 
 /// A fast map that is not resistant to collision attacks. Works
 /// on 8 bytes at a time.
+#[cfg(not(feature = "testing"))]
 pub(crate) type FastMap8<K, V> = std::collections::HashMap<
     K,
     V,
     std::hash::BuildHasherDefault<fxhash::FxHasher64>,
 >;
 
+#[cfg(feature = "testing")]
+pub(crate) type FastMap8<K, V> = BTreeMap<K, V>;
+
 /// A fast set that is not resistant to collision attacks. Works
 /// on 8 bytes at a time.
+#[cfg(not(feature = "testing"))]
 pub(crate) type FastSet8<V> = std::collections::HashSet<
     V,
     std::hash::BuildHasherDefault<fxhash::FxHasher64>,
 >;
+
+#[cfg(feature = "testing")]
+pub(crate) type FastSet8<V> = std::collections::BTreeSet<V>;
+
+#[cfg(not(feature = "testing"))]
+use std::collections::HashMap as Map;
+
+// we avoid HashMap while testing because
+// it makes tests non-deterministic
+#[cfg(feature = "testing")]
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
 
 /// A function that may be configured on a particular shared `Tree`
 /// that will be applied as a kind of read-modify-write operator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ macro_rules! io_fail {
 
 macro_rules! testing_assert {
     ($($e:expr),*) => {
-        #[cfg(feature = "lock_free_delays")]
+        #[cfg(feature = "testing")]
         assert!($($e),*)
     };
 }

--- a/src/pagecache/blob_io.rs
+++ b/src/pagecache/blob_io.rs
@@ -58,7 +58,7 @@ pub(crate) fn read_blob(
     } else {
         warn!("blob {} failed crc check!", blob_ptr);
 
-        Err(Error::corruption(Some(DiskPtr::Blob(0, blob_ptr))))
+        Err(Error::corruption(Some(DiskPtr::Blob(None, blob_ptr))))
     }
 }
 

--- a/src/pagecache/blob_io.rs
+++ b/src/pagecache/blob_io.rs
@@ -52,8 +52,7 @@ pub(crate) fn read_blob(
     let crc_actual = hasher.finalize();
 
     if crc_expected == crc_actual {
-        let buf =
-            if config.use_compression { maybe_decompress(buf)? } else { buf };
+        let buf = if config.use_compression { decompress(buf) } else { buf };
         Ok((MessageKind::from(kind_byte[0]), buf))
     } else {
         warn!("blob {} failed crc check!", blob_ptr);
@@ -146,12 +145,13 @@ pub(crate) fn gc_blobs(config: &Config, stable_lsn: Lsn) -> Result<()> {
 
 pub(crate) fn remove_blob(id: Lsn, config: &Config) -> Result<()> {
     let path = config.blob_path(id);
-    if let Err(e) = std::fs::remove_file(&path) {
+    let res = std::fs::remove_file(&path);
+    if let Err(e) = res {
         debug!("removing blob at {:?} failed: {}", path, e);
+        return Err(e.into());
     } else {
         trace!("successfully removed blob at {:?}", path);
     }
 
-    // TODO return a future
     Ok(())
 }

--- a/src/pagecache/disk_pointer.rs
+++ b/src/pagecache/disk_pointer.rs
@@ -30,17 +30,17 @@ impl DiskPtr {
 
     pub(crate) fn is_blob(&self) -> bool {
         match self {
-            DiskPtr::Blob(_, _) => true,
             DiskPtr::Inline(_) => false,
+            DiskPtr::Blob(_, _) => true,
         }
     }
 
     pub(crate) fn blob(&self) -> (Option<LogOffset>, BlobPointer) {
         match self {
-            DiskPtr::Blob(lid, ptr) => (lid.map(|l| l.get()), *ptr),
             DiskPtr::Inline(_) => {
                 panic!("blob called on Internal disk pointer")
             }
+            DiskPtr::Blob(lid, ptr) => (lid.map(|l| l.get()), *ptr),
         }
     }
 
@@ -55,16 +55,20 @@ impl DiskPtr {
     #[doc(hidden)]
     pub fn lid(&self) -> Option<LogOffset> {
         match self {
-            DiskPtr::Blob(lid, _) => lid.map(|l| l.get()),
             DiskPtr::Inline(lid) => Some(*lid),
+            DiskPtr::Blob(lid, _) => lid.map(|l| l.get()),
         }
     }
 
     pub(crate) fn forget_blob_log_coordinates(&mut self) {
         match self {
-            DiskPtr::Blob(ref mut opt, _blob_pointer) => *opt = None,
             DiskPtr::Inline(_) => {}
+            DiskPtr::Blob(ref mut opt, _blob_pointer) => *opt = None,
         }
+    }
+
+    pub(crate) fn blob_pointer_merged_into_snapshot(&self) -> bool {
+        if let DiskPtr::Blob(None, _) = self { true } else { false }
     }
 }
 

--- a/src/pagecache/disk_pointer.rs
+++ b/src/pagecache/disk_pointer.rs
@@ -59,6 +59,13 @@ impl DiskPtr {
             DiskPtr::Inline(lid) => Some(*lid),
         }
     }
+
+    pub(crate) fn forget_blob_log_coordinates(&mut self) {
+        match self {
+            DiskPtr::Blob(ref mut opt, _blob_pointer) => *opt = None,
+            DiskPtr::Inline(_) => {}
+        }
+    }
 }
 
 impl fmt::Display for DiskPtr {

--- a/src/pagecache/disk_pointer.rs
+++ b/src/pagecache/disk_pointer.rs
@@ -40,7 +40,7 @@ impl DiskPtr {
             DiskPtr::Inline(_) => {
                 panic!("blob called on Internal disk pointer")
             }
-            DiskPtr::Blob(lid, ptr) => (lid.map(|l| l.get()), *ptr),
+            DiskPtr::Blob(lid, ptr) => (lid.map(NonZeroU64::get), *ptr),
         }
     }
 
@@ -56,7 +56,7 @@ impl DiskPtr {
     pub fn lid(&self) -> Option<LogOffset> {
         match self {
             DiskPtr::Inline(lid) => Some(*lid),
-            DiskPtr::Blob(lid, _) => lid.map(|l| l.get()),
+            DiskPtr::Blob(lid, _) => lid.map(NonZeroU64::get),
         }
     }
 

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -163,11 +163,7 @@ impl IoBuf {
     ) -> std::result::Result<Header, Header> {
         debug_delay();
         let res = self.header.compare_and_swap(old, new, SeqCst);
-        if res == old {
-            Ok(new)
-        } else {
-            Err(res)
-        }
+        if res == old { Ok(new) } else { Err(res) }
     }
 }
 
@@ -437,7 +433,6 @@ impl IoBufs {
     pub(in crate::pagecache) fn sa_mark_replace(
         &self,
         pid: PageId,
-        lsn: Lsn,
         old_cache_infos: &[CacheInfo],
         new_cache_info: CacheInfo,
         guard: &Guard,
@@ -445,7 +440,7 @@ impl IoBufs {
         debug_delay();
         if let Some(mut sa) = self.segment_accountant.try_lock() {
             let start = clock();
-            sa.mark_replace(pid, lsn, old_cache_infos, new_cache_info)?;
+            sa.mark_replace(pid, old_cache_infos, new_cache_info)?;
             for op in self.deferred_segment_ops.take_iter(guard) {
                 sa.apply_op(op)?;
             }
@@ -453,7 +448,6 @@ impl IoBufs {
         } else {
             let op = SegmentOp::Replace {
                 pid,
-                lsn,
                 old_cache_infos: old_cache_infos.to_vec(),
                 new_cache_info,
             };

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -393,7 +393,7 @@ fn scan_segment_headers_and_tail(
             max_header_stable_lsn,
             &ordering,
             config,
-        )?;
+        );
 
     Ok((ordering, end_of_last_contiguous_message_in_unstable_tail))
 }
@@ -407,7 +407,7 @@ fn check_contiguity_in_unstable_tail(
     max_header_stable_lsn: Lsn,
     ordering: &BTreeMap<Lsn, LogOffset>,
     config: &RunningConfig,
-) -> Result<Lsn> {
+) -> Lsn {
     let segment_size = config.segment_size as Lsn;
 
     // -1..(2 *  segment_size) - 1 => 0
@@ -463,7 +463,7 @@ fn check_contiguity_in_unstable_tail(
         end_of_last_message,
     );
 
-    Ok(end_of_last_message)
+    end_of_last_message
 }
 
 /// Returns a log iterator, the max stable lsn,

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io};
+use std::{collections::BTreeMap, io, num::NonZeroU64};
 
 use super::{
     pread_exact_or_eof, read_message, read_segment_header, BasedBuf, DiskPtr,
@@ -88,7 +88,10 @@ impl Iterator for LogIter {
                         LogKind::from(header.kind),
                         header.pid,
                         lsn,
-                        DiskPtr::Blob(lid, blob_ptr),
+                        DiskPtr::Blob(
+                            Some(NonZeroU64::new(lid).unwrap()),
+                            blob_ptr,
+                        ),
                         u64::from(inline_len),
                     ));
                 }

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -59,7 +59,12 @@ impl Log {
         if ptr.is_inline() {
             iobuf::make_durable(&self.iobufs, lsn)?;
             let f = &self.config.file;
-            read_message(&**f, ptr.lid(), expected_segment_number, &self.config)
+            read_message(
+                &**f,
+                ptr.lid().unwrap(),
+                expected_segment_number,
+                &self.config,
+            )
         } else {
             // we short-circuit the inline read
             // here because it might not still

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -1,10 +1,10 @@
 use std::fs::File;
 
 use super::{
-    arr_to_lsn, arr_to_u32, assert_usize, bump_atomic_lsn, header, iobuf,
-    lsn_to_arr, maybe_decompress, pread_exact, pread_exact_or_eof, read_blob,
-    roll_iobuf, u32_to_arr, Arc, BasedBuf, BlobPointer, DiskPtr, IoBuf, IoBufs,
-    LogKind, LogOffset, Lsn, MessageKind, Reservation, Serialize, Snapshot,
+    arr_to_lsn, arr_to_u32, assert_usize, bump_atomic_lsn, decompress, header,
+    iobuf, lsn_to_arr, pread_exact, pread_exact_or_eof, read_blob, roll_iobuf,
+    u32_to_arr, Arc, BasedBuf, BlobPointer, DiskPtr, IoBuf, IoBufs, LogKind,
+    LogOffset, Lsn, MessageKind, Reservation, Serialize, Snapshot,
     BATCH_MANIFEST_PID, COUNTER_PID, MAX_MSG_HEADER_LEN, META_PID,
     MINIMUM_ITEMS_PER_SEGMENT, SEG_HEADER_LEN,
 };
@@ -835,11 +835,8 @@ pub(crate) fn read_message<R: ReadAt>(
         | MessageKind::Free
         | MessageKind::Counter => {
             trace!("read a successful inline message");
-            let buf = if config.use_compression {
-                maybe_decompress(buf)?
-            } else {
-                buf
-            };
+            let buf =
+                if config.use_compression { decompress(buf) } else { buf };
 
             Ok(LogRead::Inline(header, buf, inline_len))
         }

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1264,9 +1264,10 @@ impl PageCache {
 
                 let (log_reservation, cache_info) = if skip_log {
                     trace!(
-                        "allowing blob pointer with original lsn of {} \
+                        "allowing blob pointer for pid {} with original lsn of {} \
                         to be forgotten from the log, as it is contained in the \
                         snapshot which has a minimum lsn of {}",
+                        pid,
                         original_lsn,
                         snapshot_min_lsn
                     );

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -536,14 +536,12 @@ impl Debug for PageCache {
 #[cfg(feature = "event_log")]
 impl Drop for PageCache {
     fn drop(&mut self) {
-        use std::collections::HashMap;
-
         trace!("dropping pagecache");
 
         // we can't as easily assert recovery
         // invariants across failpoints for now
         if self.log.iobufs.config.global_error().is_ok() {
-            let mut pages_before_restart = HashMap::new();
+            let mut pages_before_restart = Map::default();
 
             let guard = pin();
 
@@ -664,13 +662,11 @@ impl PageCache {
 
         #[cfg(feature = "testing")]
         {
-            use std::collections::HashMap;
-
             // NB this must be before idgen/meta are initialized
             // because they may cas_page on initial page-in.
             let guard = pin();
 
-            let mut pages_after_restart = HashMap::new();
+            let mut pages_after_restart = Map::default();
 
             for pid in 0..*pc.next_pid_to_allocate.lock() {
                 let pte = if let Some(pte) = pc.inner.get(pid, &guard) {

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -256,7 +256,7 @@ pub(crate) fn u32_to_arr(number: u32) -> [u8; 4] {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub(crate) fn maybe_decompress(in_buf: Vec<u8>) -> std::io::Result<Vec<u8>> {
+pub(crate) fn decompress(in_buf: Vec<u8>) -> Vec<u8> {
     #[cfg(feature = "compression")]
     {
         use zstd::stream::decode_all;
@@ -272,11 +272,11 @@ pub(crate) fn maybe_decompress(in_buf: Vec<u8>) -> std::io::Result<Vec<u8>> {
              fix this critical issue ASAP. Thank you :)",
         );
 
-        Ok(out_buf)
+        out_buf
     }
 
     #[cfg(not(feature = "compression"))]
-    Ok(in_buf)
+    in_buf
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1111,7 +1111,7 @@ impl PageCache {
                         to_evict
                     );
                     if !to_evict.is_empty() {
-                        self.page_out(to_evict, guard)?;
+                        self.page_out(to_evict, guard);
                     }
 
                     old.read = new_shared;
@@ -1344,7 +1344,7 @@ impl PageCache {
                         to_evict
                     );
                     if !to_evict.is_empty() {
-                        self.page_out(to_evict, guard)?;
+                        self.page_out(to_evict, guard);
                     }
 
                     trace!("rewriting pid {} succeeded", pid);
@@ -1582,7 +1582,7 @@ impl PageCache {
                         to_evict
                     );
                     if !to_evict.is_empty() {
-                        self.page_out(to_evict, guard)?;
+                        self.page_out(to_evict, guard);
                     }
 
                     return Ok(Ok(PageView {
@@ -1722,7 +1722,7 @@ impl PageCache {
                     to_evict
                 );
                 if !to_evict.is_empty() {
-                    self.page_out(to_evict, guard)?;
+                    self.page_out(to_evict, guard);
                 }
                 return Ok(Some(NodeView(page_view)));
             }
@@ -1793,7 +1793,7 @@ impl PageCache {
             let to_evict = self.lru.accessed(pid, total_page_size, guard);
             trace!("accessed pid {} -> paging out pids {:?}", pid, to_evict);
             if !to_evict.is_empty() {
-                self.page_out(to_evict, guard)?;
+                self.page_out(to_evict, guard);
             }
 
             let mut page_view = page_view;
@@ -1950,7 +1950,7 @@ impl PageCache {
         }
     }
 
-    fn page_out(&self, to_evict: Vec<PageId>, guard: &Guard) -> Result<()> {
+    fn page_out(&self, to_evict: Vec<PageId>, guard: &Guard) {
         let _measure = Measure::new(&M.page_out);
         for pid in to_evict {
             if pid == COUNTER_PID
@@ -1992,7 +1992,6 @@ impl PageCache {
                 }
             }
         }
-        Ok(())
     }
 
     fn pull(&self, pid: PageId, lsn: Lsn, pointer: DiskPtr) -> Result<Update> {

--- a/src/pagecache/reservation.rs
+++ b/src/pagecache/reservation.rs
@@ -82,7 +82,7 @@ impl<'a> Reservation<'a> {
     pub fn mark_writebatch(self, peg_lsn: Lsn) -> Result<(Lsn, DiskPtr)> {
         trace!(
             "writing batch required stable lsn {} into \
-             BatchManifest at lid {} peg_lsn {}",
+             BatchManifest at lid {:?} peg_lsn {}",
             peg_lsn,
             self.pointer.lid(),
             self.lsn

--- a/src/pagecache/segment.rs
+++ b/src/pagecache/segment.rs
@@ -767,7 +767,6 @@ impl SegmentAccountant {
             && old_cache_infos[0].pointer.is_blob());
 
         let mut removals = FastMap8::default();
-        dbg!(&old_cache_infos);
 
         for old_cache_info in old_cache_infos {
             let old_ptr = &old_cache_info.pointer;
@@ -798,9 +797,7 @@ impl SegmentAccountant {
             *entry += old_cache_info.log_size;
         }
 
-        dbg!(&removals);
         for (old_idx, replaced_size) in removals {
-            dbg!((pid, old_idx));
             self.segments[old_idx].remove_pid(
                 pid,
                 lsn,
@@ -1133,7 +1130,7 @@ impl SegmentAccountant {
         Ok(())
     }
 
-    fn segment_id(&mut self, lid: LogOffset) -> SegmentId {
+    fn segment_id(&mut self, lid: LogOffset) -> usize {
         let idx = assert_usize(lid / self.config.segment_size as LogOffset);
 
         // TODO never resize like this, make it a single

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -214,10 +214,12 @@ impl Snapshot {
     fn filter_inner_blob_pointers(&mut self) {
         for page in &mut self.pt {
             match page {
-                PageState::Free(_lsn, ptr) => ptr.forget_blob_log_coordinates(),
-                PageState::Present { base, frags } => {
+                PageState::Free(_lsn, ref mut ptr) => {
+                    ptr.forget_blob_log_coordinates()
+                }
+                PageState::Present { ref mut base, ref mut frags } => {
                     base.1.forget_blob_log_coordinates();
-                    for (_, ptr, _) in frags {
+                    for (_, ref mut ptr, _) in frags {
                         ptr.forget_blob_log_coordinates();
                     }
                 }

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -371,9 +371,9 @@ fn advance_snapshot(
 
     #[cfg(feature = "testing")]
     let reverse_segments = {
-        use std::collections::{HashMap, HashSet};
+        use crate::{Map, Set};
         let shred_base = shred_point.unwrap_or(LogOffset::max_value());
-        let mut reverse_segments = HashMap::new();
+        let mut reverse_segments = Map::new();
         for (pid, page) in snapshot.pt.iter().enumerate() {
             let offsets = page.offsets();
             for offset_option in offsets {
@@ -394,9 +394,8 @@ fn advance_snapshot(
                         shred_base
                     );
                 }
-                let entry = reverse_segments
-                    .entry(segment)
-                    .or_insert_with(HashSet::new);
+                let entry =
+                    reverse_segments.entry(segment).or_insert_with(Set::new);
                 entry.insert((pid, offset));
             }
         }

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -391,7 +391,6 @@ fn advance_snapshot(
 
     #[cfg(feature = "testing")]
     let reverse_segments = {
-        use crate::{Map, Set};
         let shred_base = shred_point.unwrap_or(LogOffset::max_value());
         let mut reverse_segments = Map::new();
         for (pid, page) in snapshot.pt.iter().enumerate() {

--- a/src/result.rs
+++ b/src/result.rs
@@ -149,8 +149,7 @@ impl From<Error> for io::Error {
         use std::io::ErrorKind;
         match error {
             Io(ioe) => ioe,
-            CollectionNotFound(name) =>
-                io::Error::new(
+            CollectionNotFound(name) => io::Error::new(
                 ErrorKind::NotFound,
                 format!("collection not found: {:?}", name),
             ),
@@ -160,17 +159,17 @@ impl From<Error> for io::Error {
             ),
             ReportableBug(what) => io::Error::new(
                 ErrorKind::Other,
-                format!("unexpected bug! please report this bug at <github.rs/spacejam/sled>: {:?}", what),
+                format!(
+                    "unexpected bug! please report this bug at <github.rs/spacejam/sled>: {:?}",
+                    what
+                ),
             ),
             Corruption { .. } => io::Error::new(
                 ErrorKind::InvalidData,
                 format!("corruption encountered: {:?}", error),
             ),
             #[cfg(feature = "failpoints")]
-            FailPoint => io::Error::new(
-                ErrorKind::Other,
-                "failpoint"
-            ),
+            FailPoint => io::Error::new(ErrorKind::Other, "failpoint"),
         }
     }
 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -9,14 +9,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(not(feature = "testing"))]
-use std::collections::HashMap as Map;
-
-// we avoid HashMap while testing because
-// it makes tests non-deterministic
-#[cfg(feature = "testing")]
-use std::collections::BTreeMap as Map;
-
 use crate::*;
 
 static ID_GEN: AtomicUsize = AtomicUsize::new(0);

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::VecDeque,
     sync::atomic::{
-        AtomicBool, AtomicU64,
+        AtomicBool,
         Ordering::{Acquire, Relaxed, Release, SeqCst},
     },
     thread,
@@ -12,7 +12,9 @@ use std::{
 
 use parking_lot::{Condvar, Mutex};
 
-use crate::{debug_delay, warn, AtomicUsize, Error, Lazy, OneShot, Result};
+use crate::{
+    debug_delay, warn, AtomicU64, AtomicUsize, Error, Lazy, OneShot, Result,
+};
 
 // This is lower for CI reasons.
 #[cfg(windows)]
@@ -89,7 +91,7 @@ impl Queue {
     }
 }
 
-fn perform_work(is_immortal: bool) -> Result<()> {
+fn perform_work(is_immortal: bool) {
     let wait_limit = Duration::from_secs(1);
 
     let mut performed = 0;
@@ -126,7 +128,6 @@ fn perform_work(is_immortal: bool) -> Result<()> {
             contiguous_overshoots = 0;
         }
     }
-    Ok(())
 }
 
 // Create up to MAX_THREADS dynamic blocking task worker threads.

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -2,17 +2,17 @@
 
 use std::{
     collections::VecDeque,
-    sync::atomic::{AtomicBool, Ordering::Relaxed},
+    sync::atomic::{
+        AtomicBool, AtomicU64,
+        Ordering::{Acquire, Relaxed, Release, SeqCst},
+    },
     thread,
     time::{Duration, Instant},
 };
 
 use parking_lot::{Condvar, Mutex};
 
-use crate::{
-    debug_delay, warn, Acquire, AtomicUsize, Error, Lazy, OneShot, Result,
-    SeqCst,
-};
+use crate::{debug_delay, warn, AtomicUsize, Error, Lazy, OneShot, Result};
 
 // This is lower for CI reasons.
 #[cfg(windows)]
@@ -27,8 +27,23 @@ static WAITING_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 static TOTAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 static SPAWNS: AtomicUsize = AtomicUsize::new(0);
 static SPAWNING: AtomicBool = AtomicBool::new(false);
+static SUBMITTED: AtomicU64 = AtomicU64::new(0);
+static COMPLETED: AtomicU64 = AtomicU64::new(0);
+static QUEUE: Lazy<Queue, fn() -> Queue> = Lazy::new(init_queue);
+static BROKEN: AtomicBool = AtomicBool::new(false);
 
 type Work = Box<dyn FnOnce() + Send + 'static>;
+
+fn init_queue() -> Queue {
+    debug_delay();
+    for _ in 0..DESIRED_WAITING_THREADS {
+        debug_delay();
+        if let Err(e) = spawn_new_thread(true) {
+            log::error!("failed to initialize threadpool: {:?}", e);
+        }
+    }
+    Queue { cv: Condvar::new(), mu: Mutex::new(VecDeque::new()) }
+}
 
 struct Queue {
     cv: Condvar,
@@ -74,21 +89,7 @@ impl Queue {
     }
 }
 
-static QUEUE: Lazy<Queue, fn() -> Queue> = Lazy::new(init_queue);
-static BROKEN: AtomicBool = AtomicBool::new(false);
-
-fn init_queue() -> Queue {
-    debug_delay();
-    for _ in 0..DESIRED_WAITING_THREADS {
-        debug_delay();
-        if let Err(e) = spawn_new_thread(true) {
-            log::error!("failed to initialize threadpool: {:?}", e);
-        }
-    }
-    Queue { cv: Condvar::new(), mu: Mutex::new(VecDeque::new()) }
-}
-
-fn perform_work(is_immortal: bool) {
+fn perform_work(is_immortal: bool) -> Result<()> {
     let wait_limit = Duration::from_secs(1);
 
     let mut performed = 0;
@@ -101,6 +102,7 @@ fn perform_work(is_immortal: bool) {
         if let Some(task) = task_res {
             WAITING_THREAD_COUNT.fetch_sub(1, SeqCst);
             (task)();
+            COMPLETED.fetch_add(1, Release);
             WAITING_THREAD_COUNT.fetch_add(1, SeqCst);
             performed += 1;
         }
@@ -109,6 +111,7 @@ fn perform_work(is_immortal: bool) {
             debug_delay();
             WAITING_THREAD_COUNT.fetch_sub(1, SeqCst);
             (task)();
+            COMPLETED.fetch_add(1, Release);
             WAITING_THREAD_COUNT.fetch_add(1, SeqCst);
             performed += 1;
         }
@@ -123,6 +126,7 @@ fn perform_work(is_immortal: bool) {
             contiguous_overshoots = 0;
         }
     }
+    Ok(())
 }
 
 // Create up to MAX_THREADS dynamic blocking task worker threads.
@@ -166,14 +170,14 @@ fn spawn_new_thread(is_immortal: bool) -> Result<()> {
             debug_delay();
             let res = std::panic::catch_unwind(|| perform_work(is_immortal));
             TOTAL_THREAD_COUNT.fetch_sub(1, SeqCst);
-            if is_immortal || res.is_err() {
+            if is_immortal {
                 // IO thread panicked, shut down the system
-                log::error!(
-                    "IO thread unexpectedly terminated.
-                    please report this error at the sled github repo. {:?}",
+                BROKEN.store(true, SeqCst);
+                panic!(
+                    "IO thread unexpectedly panicked. please report \
+                    this bug on the sled github repo. error: {:?}",
                     res
                 );
-                BROKEN.store(true, SeqCst);
             }
         });
 
@@ -200,10 +204,10 @@ where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static + Sized,
 {
+    SUBMITTED.fetch_add(1, Acquire);
     let (promise_filler, promise) = OneShot::pair();
     let task = move || {
-        let result = (work)();
-        promise_filler.fill(result);
+        promise_filler.fill((work)());
     };
 
     let depth = QUEUE.send(Box::new(task));
@@ -213,4 +217,23 @@ where
     }
 
     Ok(promise)
+}
+
+/// Wait for all submitted tasks to complete
+#[cfg(feature = "testing")]
+pub fn drain() -> Result<()> {
+    let submitted = SUBMITTED.load(Acquire);
+
+    while COMPLETED.load(Acquire) < submitted {
+        if BROKEN.load(Relaxed) {
+            return Err(Error::ReportableBug(
+                "IO thread unexpectedly panicked. please report \
+            this bug on the sled github repo."
+                    .to_string(),
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    Ok(())
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -373,8 +373,8 @@ pub struct TransactionalTrees {
 }
 
 impl TransactionalTrees {
-    fn stage(&self) -> UnabortableTransactionResult<Protector<'_>> {
-        Ok(concurrency_control::write())
+    fn stage(&self) -> Protector<'_> {
+        concurrency_control::write()
     }
 
     fn unstage(&self) {
@@ -454,12 +454,7 @@ pub trait Transactional<E = ()> {
             let view = Self::view_overlay(&tt);
 
             // NB locks must exist until this function returns.
-            let locks = if let Ok(l) = tt.stage() {
-                l
-            } else {
-                tt.unstage();
-                continue;
-            };
+            let locks = tt.stage();
             let ret = f(&view);
             if !tt.validate() {
                 tt.unstage();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -75,17 +75,9 @@
 #![allow(clippy::module_name_repetitions)]
 use std::{cell::RefCell, fmt, rc::Rc};
 
-#[cfg(not(feature = "testing"))]
-use std::collections::HashMap as Map;
-
-// we avoid HashMap while testing because
-// it makes tests non-deterministic
-#[cfg(feature = "testing")]
-use std::collections::BTreeMap as Map;
-
 use crate::{
-    concurrency_control, pin, Batch, Error, Guard, IVec, Protector, Result,
-    Tree,
+    concurrency_control, pin, Batch, Error, Guard, IVec, Map, Protector,
+    Result, Tree,
 };
 
 /// A transaction that will
@@ -268,8 +260,7 @@ impl TransactionalTree {
     {
         let old = self.get(key.as_ref())?;
         let mut writes = self.writes.borrow_mut();
-        let _last_write =
-            writes.insert(key.into(), Some(value.into()));
+        let _last_write = writes.insert(key.into(), Some(value.into()));
         Ok(old)
     }
 

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -29,8 +29,8 @@ const TX_DIR: &str = "crash_tx";
 const CRASH_CHANCE: u32 = 250;
 
 fn main() {
-    // Don't actually run this harness=false test under miri, as it requires spawning and killing
-    // child processes.
+    // Don't actually run this harness=false test under miri, as it requires
+    // spawning and killing child processes.
     if cfg!(miri) {
         return;
     }


### PR DESCRIPTION
This facilitates the migration of metadata for tracking blob locations from the log + GC into the snapshot once the snapshot is known to contain the blob's lookup metadata. This is a step toward a more fully-fledged 2-component storage architecture where hot data remains in the log, but eventually is aged out into a lower-fragmentation place better suited to cold storage. The next step is to enable the fuzzy snapshotting code that already exists, which, combined with this work, will facilitate live migration of cold items out of the log.