### PR TITLE
Add filtering and stderr output to no-harness test

### DIFF
--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -57,24 +57,24 @@ fn main() {
                     TESTS.to_vec()
                 };
 
-            eprintln!();
-            eprintln!(
+            println!();
+            println!(
                 "running {} test{}",
                 filtered.len(),
                 if filtered.len() == 1 { "" } else { "s" },
             );
             for (test_name, test_fn) in filtered.iter() {
-                eprint!("test {} ...", test_name);
+                print!("test {} ...", test_name);
                 test_fn();
-                eprintln!(" ok");
+                println!(" ok");
             }
-            eprintln!();
-            eprintln!(
+            println!();
+            println!(
                 "test result: ok. {} passed; {} filtered out",
                 filtered.len(),
                 TESTS.len() - filtered.len(),
             );
-            eprintln!();
+            println!();
         }
 
         Ok(ref s) if s == RECOVERY_DIR => run(),


### PR DESCRIPTION
This PR improves the ergonomics of the test_crash_recovery test. Since this integration test has `harness = false` set, it is up to us to handle test filtering, console output, etc. These changes add console output that approximates what we see from the standard library test harness, and allow filtering out tests using the same command line argument interface. Sample output:

```
david@desktop:~/Code/sled$ cargo test --features=testing -- crash_tx
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/debug/deps/sled-e06fd382104117c8

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 29 filtered out

     Running target/debug/deps/test_crash_recovery-83cd0a124e744f4b

running 1 test
test crash_tx ... ok

test result: ok. 1 passed; 3 filtered out

     Running target/debug/deps/test_log-440f4f40cf3c48f3

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out
...
```