### PR TITLE
[WIP] Use `fetch_max` instead of `bump_atomic_lsn`

### DIFF
--- a/SAFETY.md
+++ b/SAFETY.md
@@ -95,6 +95,7 @@ durability model
       * return None if last_lsn_in_batch >= self.max_lsn
     * batch requirement set to last reservation base + inline len - 1
       * reserve bumps
+	  	* TODO: Change this
         * bump_atomic_lsn(&self.iobufs.max_reserved_lsn, reservation_lsn + inline_buf_len as Lsn - 1);
 
 lock-free linearizability model

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -825,7 +825,7 @@ impl IoBufs {
         let max_header_stable_lsn = self.max_header_stable_lsn.clone();
         guard.defer(move || {
             trace!("bumping atomic header lsn to {}", stored_max_stable_lsn);
-            bump_atomic_lsn(&max_header_stable_lsn, stored_max_stable_lsn)
+            AtomicLsn::fetch_max(&max_header_stable_lsn, stored_max_stable_lsn, SeqCst)
         });
 
         guard.flush();

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
 use super::{
-    arr_to_lsn, arr_to_u32, assert_usize, bump_atomic_lsn, decompress, header,
+    arr_to_lsn, arr_to_u32, assert_usize, decompress, header,
     iobuf, lsn_to_arr, pread_exact, pread_exact_or_eof, roll_iobuf, u32_to_arr,
     Arc, BasedBuf, DiskPtr, HeapId, IoBuf, IoBufs, LogKind, LogOffset, Lsn,
     MessageKind, Reservation, Serialize, Snapshot, BATCH_MANIFEST_PID,
@@ -364,9 +364,10 @@ impl Log {
                 reservation_lid,
             );
 
-            bump_atomic_lsn(
+            AtomicLsn::fetch_max(
                 &self.iobufs.max_reserved_lsn,
                 reservation_lsn + inline_buf_len as Lsn - 1,
+                SeqCst
             );
 
             let (heap_reservation, heap_id) = if over_heap_threshold {


### PR DESCRIPTION
The relevant part of issue rust-lang/rust#48655 was resolved in rust-lang/rust#72324 so this PR should eventually fix the corresponding TODO in `pagecache`.

This initial PR does some of the grind work of replacing `bump_atomic_lsn`.

**NOTE**: I'm not familiar with Rust's atomics, so I don't know if SeqCst is actually what you want.

For `cargo test`, my OS (Windows 10, WSL) couldn't hole punch the heap, and I got a lot of 60 second timeouts. Also, the tests got stuck on my end at around `tree_bug_39`, so I had to kill the process. It might be better on your end.