### PR TITLE
Don't require Vec in sled::Db::import, just Iterator.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -367,7 +367,7 @@ impl Db {
     /// ```
     pub fn import(
         &self,
-        export: Vec<(
+        export: impl IntoIterator<Item = (
             CollectionType,
             CollectionName,
             impl Iterator<Item = Vec<Vec<u8>>>,


### PR DESCRIPTION
Without this change, all those first byte vectors (thing's types and names?) from the all trees are needed to be known in advance, before feeding items into the first tree.

This interferes with stream-importing things into the database from something other than `sled::Db::export` (e.g. over the network).
  