### PR TITLE
pagecache simplifications

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -100,7 +100,7 @@ impl Db {
 
         let mut tenants = ret.tenants.write();
 
-        for (id, root) in context.pagecache.get_meta(&guard)?.tenants() {
+        for (id, root) in context.pagecache.get_meta(&guard).tenants() {
             let tree = Tree(Arc::new(TreeInner {
                 tree_id: id.clone(),
                 subscribers: Subscribers::default(),

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -365,7 +365,7 @@ impl Update {
         }
     }
 
-    pub(crate) fn as_meta(&self) -> &Meta {
+    fn as_meta(&self) -> &Meta {
         if let Update::Meta(meta) = self {
             meta
         } else {
@@ -373,19 +373,11 @@ impl Update {
         }
     }
 
-    pub(crate) fn as_counter(&self) -> u64 {
+    fn as_counter(&self) -> u64 {
         if let Update::Counter(counter) = self {
             *counter
         } else {
             panic!("called as_counter on {:?}", self)
-        }
-    }
-
-    fn is_free(&self) -> bool {
-        if let Update::Free = self {
-            true
-        } else {
-            false
         }
     }
 }
@@ -421,12 +413,12 @@ impl<'a> RecoveryGuard<'a> {
 /// with associated storage parameters like disk pos, lsn, time.
 #[derive(Debug, Clone)]
 pub struct Page {
-    pub(crate) update: Option<Update>,
-    pub(crate) cache_infos: Vec<CacheInfo>,
+    update: Option<Update>,
+    cache_infos: Vec<CacheInfo>,
 }
 
 impl Page {
-    pub(crate) fn to_page_state(&self) -> PageState {
+    fn to_page_state(&self) -> PageState {
         let base = &self.cache_infos[0];
         if self.is_free() {
             PageState::Free(base.lsn, base.pointer)
@@ -448,24 +440,27 @@ impl Page {
         }
     }
 
-    pub(crate) fn as_node(&self) -> &Node {
+    fn as_node(&self) -> &Node {
         self.update.as_ref().unwrap().as_node()
     }
 
-    pub(crate) fn as_meta(&self) -> &Meta {
+    fn as_meta(&self) -> &Meta {
         self.update.as_ref().unwrap().as_meta()
     }
 
-    pub(crate) fn as_counter(&self) -> u64 {
+    fn as_counter(&self) -> u64 {
         self.update.as_ref().unwrap().as_counter()
     }
 
-    pub(crate) fn is_free(&self) -> bool {
-        self.update.as_ref().map_or(false, Update::is_free)
-            || self.cache_infos.is_empty()
+    fn is_free(&self) -> bool {
+        if let Some(Update::Free) = self.update {
+            true
+        } else {
+            false
+        }
     }
 
-    pub(crate) fn last_lsn(&self) -> Lsn {
+    fn last_lsn(&self) -> Lsn {
         self.cache_infos.last().map(|ci| ci.lsn).unwrap()
     }
 

--- a/src/pagecache/pagetable.rs
+++ b/src/pagecache/pagetable.rs
@@ -130,24 +130,38 @@ impl PageTable {
     }
 
     /// Try to get a value from the tree.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the page has never been allocated.
     pub(crate) fn get<'g>(
         &self,
         pid: PageId,
         guard: &'g Guard,
-    ) -> Option<PageView<'g>> {
+    ) -> PageView<'g> {
         let _measure = Measure::new(&M.get_pagetable);
         debug_delay();
         let tip = self.traverse(pid, guard);
 
         debug_delay();
         let res = tip.load(Acquire, guard);
-        if res.is_null() {
-            None
-        } else {
-            let page_view = PageView { read: res, entry: tip };
 
-            Some(page_view)
-        }
+        assert!(!res.is_null());
+
+        let page_view = PageView { read: res, entry: tip };
+
+        page_view
+    }
+
+    pub(crate) fn contains_pid(&self, pid: PageId, guard: &Guard) -> bool {
+        let _measure = Measure::new(&M.get_pagetable);
+        debug_delay();
+        let tip = self.traverse(pid, guard);
+
+        debug_delay();
+        let res = tip.load(Acquire, guard);
+
+        !res.is_null()
     }
 
     fn traverse<'g>(&self, k: PageId, guard: &'g Guard) -> &'g Atomic<Page> {

--- a/src/pagecache/pagetable.rs
+++ b/src/pagecache/pagetable.rs
@@ -148,9 +148,7 @@ impl PageTable {
 
         assert!(!res.is_null());
 
-        let page_view = PageView { read: res, entry: tip };
-
-        page_view
+        PageView { read: res, entry: tip }
     }
 
     pub(crate) fn contains_pid(&self, pid: PageId, guard: &Guard) -> bool {


### PR DESCRIPTION
Make get_meta and get_idgen infallible. Make PageTable::get always return a PageView, as allocate enforces that pages are present at all times with an allocation mutex