### PR TITLE
node enhancements

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1116,7 +1116,7 @@ impl Node {
         let size_check = if cfg!(any(test, feature = "lock_free_delays")) {
             self.iter().take(6).count() > 5
         } else if self.is_index {
-            self.len > 1024 && self.iter().take(2).count() > 1
+            self.len > 1024 && self.iter().take(2).count() == 2
         } else {
             /*
             let threshold = match self.rewrite_generations {
@@ -1132,7 +1132,7 @@ impl Node {
             let threshold = 1024 - crate::MAX_MSG_HEADER_LEN;
             self.probation_ops_remaining == 0
                 && self.len > threshold
-                && self.iter().next().is_some()
+                && self.iter().take(2).count() == 2
         };
 
         let safety_checks = self.merging_child.is_none() && !self.merging;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1454,6 +1454,11 @@ impl Inner {
 
         let mut ret = uninitialized_node(tf!(total_node_storage_size));
 
+        if offset_bytes == 0 {
+            assert!(fixed_key_length.is_some());
+            assert!(fixed_value_length.is_some());
+        }
+
         *ret.header_mut() = Header {
             rewrite_generations: 0,
             activity_sketch: 0,


### PR DESCRIPTION
* node can now store up to 2^32 children
* values of fixed length 0 are now properly omitted, allowing both keys and values to potentially collapse to a single header, lo key and hi key storing all information for a node