### PR TITLE
feat: Enable the flusher for iOS

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -22,6 +22,7 @@ pub struct Context {
             target_os = "freebsd",
             target_os = "openbsd",
             target_os = "netbsd",
+            target_os = "ios",
         )
     ))]
     pub(crate) flusher: Arc<Mutex<Option<flusher::Flusher>>>,
@@ -56,6 +57,7 @@ impl Context {
                     target_os = "freebsd",
                     target_os = "openbsd",
                     target_os = "netbsd",
+                    target_os = "ios",
                 )
             ))]
             flusher: Arc::new(parking_lot::Mutex::new(None)),

--- a/src/db.rs
+++ b/src/db.rs
@@ -58,6 +58,7 @@ impl Db {
                 target_os = "freebsd",
                 target_os = "openbsd",
                 target_os = "netbsd",
+                target_os = "ios",
             )
         ))]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,7 @@ pub mod doc;
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
+        target_os = "ios",
     )
 ))]
 mod flusher;

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1109,6 +1109,7 @@ impl PageCacheInner {
             target_os = "freebsd",
             target_os = "openbsd",
             target_os = "netbsd",
+            target_os = "ios",
         )
     ))]
     pub(crate) fn attempt_gc(&self) -> Result<bool> {
@@ -1178,6 +1179,7 @@ impl PageCacheInner {
             target_os = "freebsd",
             target_os = "openbsd",
             target_os = "netbsd",
+            target_os = "ios",
         )
     ))]
     pub(crate) fn set_failpoint(&self, e: Error) {

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -14,6 +14,7 @@ use crate::{OneShot, Result};
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
+        target_os = "ios",
     )
 ))]
 mod queue {
@@ -178,6 +179,7 @@ where
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
+        target_os = "ios",
     ))
 ))]
 mod queue {


### PR DESCRIPTION
Hey there! Congrats on the awesome crate 🎉 .
While coding something on iOS we noticed the changes were not being synced.
From some commit messages I found that the rationale behind the cfg gate was to only enable the flusher in platforms with support for threads. This enables the flusher for iOS.

I can add some docs if that's a goal, just not sure where given that `Config`'s `flush_every_ms` options is `#[doc(hidden)]`.