### PR TITLE
Add contains_tree method to the Db, related to issue 1297

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -470,6 +470,18 @@ impl Db {
     pub fn space_amplification(&self) -> Result<f64> {
         self.context.pagecache.space_amplification()
     }
+
+    /// Returns a true value if one of the tree names linked
+    /// to the database is found, if not a false will be returned.
+    pub fn contains_tree<V: AsRef<[u8]>>(&self, name: V) -> Result<bool> {
+        Ok(
+            self
+            .tenants
+            .read()
+            .iter()
+            .any(|(tree_name, _)| tree_name.eq(&name))
+        )
+    }
 }
 
 /// These types provide the information that allows an entire

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -1059,13 +1059,17 @@ fn create_tree() {
 #[test]
 fn contains_tree() {
     let db = Config::new().temporary(true).flush_every_ms(None).open().unwrap();
-    let _tree_one = db.open_tree("tree 1").unwrap();
-    let _tree_two = db.open_tree("tree 2").unwrap();
+    let tree_one = db.open_tree("tree 1").unwrap();
+    let tree_two = db.open_tree("tree 2").unwrap();
+
+    drop(tree_one);
+    drop(tree_two);
+
     assert_eq!(false, db.contains_tree("tree 3").unwrap());
     assert_eq!(true, db.contains_tree("tree 1").unwrap());
     assert_eq!(true, db.contains_tree("tree 2").unwrap());
 
-    let _del_tree_one = db.drop_tree("tree 1").unwrap();
+    assert!(db.drop_tree("tree 1").unwrap());
     assert_eq!(false, db.contains_tree("tree 1").unwrap());
 }
 

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -1057,6 +1057,19 @@ fn create_tree() {
 }
 
 #[test]
+fn contains_tree() {
+    let db = Config::new().temporary(true).flush_every_ms(None).open().unwrap();
+    let _tree_one = db.open_tree("tree 1").unwrap();
+    let _tree_two = db.open_tree("tree 2").unwrap();
+    assert_eq!(false, db.contains_tree("tree 3").unwrap());
+    assert_eq!(true, db.contains_tree("tree 1").unwrap());
+    assert_eq!(true, db.contains_tree("tree 2").unwrap());
+
+    let _del_tree_one = db.drop_tree("tree 1").unwrap();
+    assert_eq!(false, db.contains_tree("tree 1").unwrap());
+}
+
+#[test]
 #[cfg_attr(miri, ignore)]
 fn tree_import_export() -> Result<()> {
     common::setup_logger();


### PR DESCRIPTION
Hello guys, this is my 1st contribution to the sled embedded database. This PR is to add a method to the db struct to be able to see if there is already a tree with that name in the database.