### PR TITLE
Add a method that gives a subscriber where the channel size can be chosen

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -474,13 +474,7 @@ impl Db {
     /// Returns a true value if one of the tree names linked
     /// to the database is found, if not a false will be returned.
     pub fn contains_tree<V: AsRef<[u8]>>(&self, name: V) -> Result<bool> {
-        Ok(
-            self
-            .tenants
-            .read()
-            .iter()
-            .any(|(tree_name, _)| tree_name.eq(&name))
-        )
+        Ok(self.tenants.read().iter().any(|(tree_name, _)| tree_name.eq(&name)))
     }
 }
 

--- a/src/fastlock.rs
+++ b/src/fastlock.rs
@@ -60,6 +60,10 @@ impl<T> FastLock<T> {
 
         let success = lock_result.is_ok();
 
-        if success { Some(FastLockGuard { mu: self }) } else { None }
+        if success {
+            Some(FastLockGuard { mu: self })
+        } else {
+            None
+        }
     }
 }

--- a/src/pagecache/disk_pointer.rs
+++ b/src/pagecache/disk_pointer.rs
@@ -36,7 +36,11 @@ impl DiskPtr {
     }
 
     pub(crate) fn heap_id(&self) -> Option<HeapId> {
-        if let DiskPtr::Heap(_, heap_id) = self { Some(*heap_id) } else { None }
+        if let DiskPtr::Heap(_, heap_id) = self {
+            Some(*heap_id)
+        } else {
+            None
+        }
     }
 
     #[doc(hidden)]
@@ -62,7 +66,11 @@ impl DiskPtr {
     }
 
     pub(crate) fn heap_pointer_merged_into_snapshot(&self) -> bool {
-        if let DiskPtr::Heap(None, _) = self { true } else { false }
+        if let DiskPtr::Heap(None, _) = self {
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -227,7 +227,11 @@ impl Drop for Subscribers {
 }
 
 impl Subscribers {
-    pub(crate) fn register(&self, prefix: &[u8]) -> Subscriber {
+    pub(crate) fn register(
+        &self,
+        prefix: &[u8],
+        channel_limit: usize,
+    ) -> Subscriber {
         self.ever_used.store(true, Relaxed);
         let r_mu = {
             let r_mu = self.watched.read();
@@ -248,7 +252,7 @@ impl Subscribers {
             }
         };
 
-        let (tx, rx) = sync_channel(1024);
+        let (tx, rx) = sync_channel(channel_limit);
 
         let arc_senders = &r_mu[prefix];
         let mut w_senders = arc_senders.write();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -897,7 +897,8 @@ impl Tree {
     /// Oneshot like subscriber, takes 1 event at the time. If you do more than 1 insert or remove 
     /// one after the other without taking the event in the subscriber it will block the program.:
     /// ```
-    /// let config = Config::new().temporary(true).flush_every_ms(Some(1)).open().unwrap();
+    /// use sled::Config;
+    /// let db = Config::new().temporary(true).flush_every_ms(Some(1)).open().unwrap();
     /// let mut s1 = db.watch_prefix_limited(b"".to_vec(), 1);
     /// 
     /// db.insert(b"pim", b"pam".to_vec()).unwrap();

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -1074,6 +1074,19 @@ fn contains_tree() {
 }
 
 #[test]
+fn one_shot_subscriber() {
+    let db = Config::new().temporary(true).flush_every_ms(Some(1)).open().unwrap();
+    let mut s1 = db.watch_prefix_limited(b"".to_vec(), 1);
+
+    db.insert(b"pim", b"pam".to_vec()).unwrap();
+    assert_eq!(s1.next().unwrap().iter().next().unwrap().2.to_owned().unwrap(),b"pam");
+    db.remove(b"pim").unwrap();
+    assert_eq!(s1.next().unwrap().iter().next().unwrap().1.to_owned(),b"pim");
+
+    assert_eq!(db.len(), 0);
+}
+
+#[test]
 #[cfg_attr(miri, ignore)]
 fn tree_import_export() -> Result<()> {
     common::setup_logger();

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -1075,6 +1075,7 @@ fn contains_tree() {
 
 #[test]
 fn one_shot_subscriber() {
+    use sled::Config;
     let db = Config::new().temporary(true).flush_every_ms(Some(1)).open().unwrap();
     let mut s1 = db.watch_prefix_limited(b"".to_vec(), 1);
 


### PR DESCRIPTION
This PR is made to address the issue https://github.com/spacejam/sled/issues/1177. It gives a 2nd method to watch_prefix to get a subscriber given a prefix. But the method gives the choice to decide how large the subscriber channel is. I have also used the line, cargo fmt this means it also includes a reformatted code.