### PR TITLE
never spawn work from the threadpool back into the threadpool queue

### DIFF
--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -86,6 +86,14 @@ mod queue {
         };
 
         if is_worker() {
+            // NB this could prevent deadlocks because
+            // if a threadpool thread spawns work into
+            // the threadpool's queue, which it later
+            // blocks on the completion of, it would be
+            // possible for threadpool threads to block
+            // forever on the completion of work that
+            // exists in the queue but will never be
+            // scheduled.
             task();
         } else {
             queue.send(Box::new(task));


### PR DESCRIPTION
While performing work in a threadpool, always perform spawned work inline instead of chucking it into a queue, which could cause cyclical write stabilization dependencies. This should avoid some deadlock risk that I've been thinking may be possible.