### PR TITLE
apply cargo clippy fix

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -104,7 +104,7 @@ impl Debug for Histogram {
 impl Histogram {
     /// Record a value.
     #[inline]
-    pub const fn measure(&self, raw_value: u64) {
+    pub fn measure(&self, raw_value: u64) {
         #[cfg(feature = "metrics")]
         {
             let value_float: f64 = raw_value as f64;
@@ -123,7 +123,7 @@ impl Histogram {
 
     /// Retrieve a percentile [0-100]. Returns NAN if no metrics have been
     /// collected yet.
-    pub const fn percentile(&self, p: f64) -> f64 {
+    pub fn percentile(&self, p: f64) -> f64 {
         #[cfg(feature = "metrics")]
         {
             assert!(p <= 100., "percentiles must not exceed 100.0");

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -104,7 +104,7 @@ impl Debug for Histogram {
 impl Histogram {
     /// Record a value.
     #[inline]
-    pub fn measure(&self, raw_value: u64) {
+    pub const fn measure(&self, raw_value: u64) {
         #[cfg(feature = "metrics")]
         {
             let value_float: f64 = raw_value as f64;
@@ -123,7 +123,7 @@ impl Histogram {
 
     /// Retrieve a percentile [0-100]. Returns NAN if no metrics have been
     /// collected yet.
-    pub fn percentile(&self, p: f64) -> f64 {
+    pub const fn percentile(&self, p: f64) -> f64 {
         #[cfg(feature = "metrics")]
         {
             assert!(p <= 100., "percentiles must not exceed 100.0");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -200,23 +200,23 @@ impl Metrics {
     pub fn format_profile(&self) -> String {
         let mut ret = String::new();
         ret.push_str(&format!(
-            "sled profile:\n\
+                "sled profile:\n\
              {0: >17} | {1: >10} | {2: >10} | {3: >10} | {4: >10} | {5: >10} | {6: >10} | {7: >10} | {8: >10} | {9: >10}\n",
-            "op",
-            "min (us)",
-            "med (us)",
-            "90 (us)",
-            "99 (us)",
-            "99.9 (us)",
-            "99.99 (us)",
-            "max (us)",
-            "count",
-            "sum (s)"
-        ));
+             "op",
+             "min (us)",
+             "med (us)",
+             "90 (us)",
+             "99 (us)",
+             "99.9 (us)",
+             "99.99 (us)",
+             "max (us)",
+             "count",
+             "sum (s)"
+             ));
         ret.push_str(&format!(
-            "{}\n",
-            std::iter::repeat("-").take(134).collect::<String>()
-        ));
+                "{}\n",
+                "-".repeat(134)
+                ));
 
         let p =
             |mut tuples: Vec<(String, _, _, _, _, _, _, _, _, _)>| -> String {
@@ -224,11 +224,11 @@ impl Metrics {
                 let mut ret = String::new();
                 for v in tuples {
                     ret.push_str(&format!(
-                        "{0: >17} | {1: >10.1} | {2: >10.1} | {3: >10.1} \
+                            "{0: >17} | {1: >10.1} | {2: >10.1} | {3: >10.1} \
                      | {4: >10.1} | {5: >10.1} | {6: >10.1} | {7: >10.1} \
                      | {8: >10.1} | {9: >10.1}\n",
-                        v.0, v.1, v.2, v.3, v.4, v.5, v.6, v.7, v.8, v.9,
-                    ));
+                     v.0, v.1, v.2, v.3, v.4, v.5, v.6, v.7, v.8, v.9,
+                     ));
                 }
                 ret
             };
@@ -245,7 +245,7 @@ impl Metrics {
                 histo.percentile(100.) / 1e3,
                 histo.count(),
                 histo.sum() as f64 / 1e9,
-            )
+                )
         };
 
         let sz = |name: &str, histo: &Histogram| {
@@ -260,20 +260,20 @@ impl Metrics {
                 histo.percentile(100.),
                 histo.count(),
                 histo.sum() as f64,
-            )
+                )
         };
 
         ret.push_str("tree:\n");
 
         ret.push_str(&p(vec![
-            lat("traverse", &self.tree_traverse),
-            lat("get", &self.tree_get),
-            lat("set", &self.tree_set),
-            lat("merge", &self.tree_merge),
-            lat("del", &self.tree_del),
-            lat("cas", &self.tree_cas),
-            lat("scan", &self.tree_scan),
-            lat("rev scan", &self.tree_reverse_scan),
+                        lat("traverse", &self.tree_traverse),
+                        lat("get", &self.tree_get),
+                        lat("set", &self.tree_set),
+                        lat("merge", &self.tree_merge),
+                        lat("del", &self.tree_del),
+                        lat("cas", &self.tree_cas),
+                        lat("scan", &self.tree_scan),
+                        lat("rev scan", &self.tree_reverse_scan),
         ]));
         let total_loops = self.tree_loops.load(Acquire);
         let total_ops = self.tree_get.count()
@@ -285,34 +285,34 @@ impl Metrics {
             + self.tree_reverse_scan.count();
         let loop_pct = total_loops * 100 / (total_ops + 1);
         ret.push_str(&format!(
-            "tree contention loops: {} ({}% retry rate)\n",
-            total_loops, loop_pct
-        ));
+                "tree contention loops: {} ({}% retry rate)\n",
+                total_loops, loop_pct
+                ));
         ret.push_str(&format!(
-            "tree split success rates: child({}/{}) parent({}/{}) root({}/{})\n",
-            self.tree_child_split_success.load(Acquire)
-                    .to_formatted_string(&Locale::en)
-            ,
-            self.tree_child_split_attempt.load(Acquire)
-                    .to_formatted_string(&Locale::en)
-            ,
-            self.tree_parent_split_success.load(Acquire)
-                    .to_formatted_string(&Locale::en)
-            ,
-            self.tree_parent_split_attempt.load(Acquire)
-                    .to_formatted_string(&Locale::en)
-            ,
-            self.tree_root_split_success.load(Acquire)
-                    .to_formatted_string(&Locale::en)
-            ,
-            self.tree_root_split_attempt.load(Acquire)
-                    .to_formatted_string(&Locale::en)
-            ,
-        ));
+                "tree split success rates: child({}/{}) parent({}/{}) root({}/{})\n",
+                self.tree_child_split_success.load(Acquire)
+                .to_formatted_string(&Locale::en)
+                ,
+                self.tree_child_split_attempt.load(Acquire)
+                .to_formatted_string(&Locale::en)
+                ,
+                self.tree_parent_split_success.load(Acquire)
+                .to_formatted_string(&Locale::en)
+                ,
+                self.tree_parent_split_attempt.load(Acquire)
+                .to_formatted_string(&Locale::en)
+                ,
+                self.tree_root_split_success.load(Acquire)
+                .to_formatted_string(&Locale::en)
+                ,
+                self.tree_root_split_attempt.load(Acquire)
+                .to_formatted_string(&Locale::en)
+                ,
+                ));
 
         ret.push_str(&format!(
-            "{}\n",
-            std::iter::repeat("-").take(134).collect::<String>()
+                "{}\n",
+                "-".repeat(134)
         ));
         ret.push_str("pagecache:\n");
         ret.push_str(&p(vec![
@@ -331,7 +331,7 @@ impl Metrics {
 
         ret.push_str(&format!(
             "{}\n",
-            std::iter::repeat("-").take(134).collect::<String>()
+            "-".repeat(134)
         ));
         ret.push_str("serialization and compression:\n");
         ret.push_str(&p(vec![
@@ -345,7 +345,7 @@ impl Metrics {
 
         ret.push_str(&format!(
             "{}\n",
-            std::iter::repeat("-").take(134).collect::<String>()
+            "-".repeat(134)
         ));
         ret.push_str("log:\n");
         ret.push_str(&p(vec![
@@ -407,7 +407,7 @@ impl Metrics {
 
         ret.push_str(&format!(
             "{}\n",
-            std::iter::repeat("-").take(134).collect::<String>()
+            "-".repeat(134)
         ));
         ret.push_str("segment accountant:\n");
         ret.push_str(&p(vec![
@@ -421,7 +421,7 @@ impl Metrics {
 
         ret.push_str(&format!(
             "{}\n",
-            std::iter::repeat("-").take(134).collect::<String>()
+            "-".repeat(134)
         ));
         ret.push_str("recovery:\n");
         ret.push_str(&p(vec![

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -447,7 +447,7 @@ fn check_contiguity_in_unstable_tail(
     };
 
     // run the iterator to completion
-    while let Some(_) = iter.next() {}
+    for _ in &mut iter {}
 
     // `cur_lsn` is set to the beginning
     // of the next message

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -840,7 +840,7 @@ impl PageCache {
             // changing.
             let ts = old.ts() + 1;
 
-            let cache_info = CacheInfo { lsn, pointer, ts };
+            let cache_info = CacheInfo { ts, lsn, pointer };
 
             let mut new_cache_infos =
                 Vec::with_capacity(old.cache_infos.len() + 1);
@@ -944,13 +944,13 @@ impl PageCache {
             'inner: loop {
                 let pg_view = self.inner.get(pid, &guard);
 
-                match &*pg_view.cache_infos {
-                    &[_single_cache_info] => {
+                match *pg_view.cache_infos {
+                    [_single_cache_info] => {
                         let page_state = pg_view.to_page_state();
                         page_states.push(page_state);
                         break 'inner;
                     }
-                    &[_first_of_several, ..] => {
+                    [_first_of_several, ..] => {
                         // If a page has multiple disk locations,
                         // rewrite it to a single one before storing
                         // a single 8-byte pointer to its cold location.
@@ -965,7 +965,7 @@ impl PageCache {
                         }
                         continue 'inner;
                     }
-                    &[] => {
+                    [] => {
                         // there is a benign race with the thread
                         // that is allocating this page. the allocating
                         // thread has not yet written the new page to disk,

--- a/src/pagecache/snapshot.rs
+++ b/src/pagecache/snapshot.rs
@@ -264,7 +264,7 @@ fn advance_snapshot(
 
     let old_stable_lsn = snapshot.stable_lsn;
 
-    while let Some((log_kind, pid, lsn, ptr)) = iter.next() {
+    for (log_kind, pid, lsn, ptr) in &mut iter {
         trace!(
             "in advance_snapshot looking at item with pid {} lsn {} ptr {}",
             pid,
@@ -310,19 +310,17 @@ fn advance_snapshot(
     #[cfg(feature = "testing")]
     let mut shred_point = None;
 
-    let snapshot = if db_is_empty {
+    if db_is_empty {
         trace!("db is empty, returning default snapshot");
         if snapshot != Snapshot::default() {
             error!("expected snapshot to be Snapshot::default");
             return Err(Error::corruption(None));
         }
-        snapshot
     } else if iter.cur_lsn.is_none() {
         trace!(
             "no recovery progress happened since the last snapshot \
             was generated, returning the previous one"
         );
-        snapshot
     } else {
         let iterated_lsn = iter.cur_lsn.unwrap();
 
@@ -391,8 +389,6 @@ fn advance_snapshot(
         snapshot.stable_lsn = Some(stable_lsn);
         snapshot.active_segment = active_segment;
         snapshot.filter_inner_heap_ids();
-
-        snapshot
     };
 
     trace!("generated snapshot: {:?}", snapshot);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -435,7 +435,7 @@ const fn unshift_i64_opt(value: i64) -> Option<i64> {
     if value == 0 {
         return None
     }
-    let subtract = value < 0;
+    let subtract = value > 0;
     Some(value - subtract as i64)
 }
 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -433,12 +433,10 @@ fn shift_i64_opt(value_opt: &Option<i64>) -> i64 {
 
 const fn unshift_i64_opt(value: i64) -> Option<i64> {
     if value == 0 {
-        None
-    } else if value < 0 {
-        Some(value)
-    } else {
-        Some(value - 1)
+        return None
     }
+    let subtract = value < 0;
+    Some(value - subtract as i64)
 }
 
 impl Serialize for Snapshot {


### PR DESCRIPTION
By using cargo clippy on normal mode and with the testing feature on, I got rid of some cargo warnings that I got out of my own build and that of the pipeline.

The only warning I could not get through was on src/result.rs file on 84. So the fix was instead of cloning the bt variable, I just dereferenced it. But this made compiling with testing feature not work.