### PR TITLE
Fix: insert deadlock #1380

### DIFF
--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -296,7 +296,8 @@ impl Subscribers {
 
                     for (_id, (waker, sender)) in subs.iter() {
                         let (tx, rx) = OneShot::pair();
-                        if sender.send(rx).is_err() {
+                        if let Err(err) = sender.try_send(rx) {
+                            error!("send error: {:?}", err);
                             continue;
                         }
                         subscribers.push((waker.clone(), tx));

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -205,8 +205,19 @@ impl Tree {
         let last_value = last_value.map(IVec::from);
 
         if value == last_value {
+            // NB: always broadcast event
+            if let Some(Some(res)) = subscriber_reservation.take() {
+                let event = subscriber::Event::single_update(
+                    self.clone(),
+                    key.as_ref().into(),
+                    value,
+                );
+
+                res.complete(&event);
+            }
+
             // short-circuit a no-op set or delete
-            return Ok(Ok(value));
+            return Ok(Ok(last_value));
         }
 
         let frag = if let Some(value) = value.clone() {


### PR DESCRIPTION
After 1024 insertions of the same key-value pair, the SyncSender blocks.

This fixes issue #1380 