### PR TITLE
Require threads on all platforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## Breaking Changes
 
+* #1399 Thread support is now required on all platforms.
 * #1135 The "no_metrics" anti-feature has been replaced with
   the "metrics" positive feature.
 * #1178 the `Event` enum has become a unified struct that allows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## Breaking Changes
 
+* #1399 Bump MSRV to 1.51.
 * #1399 Thread support is now required on all platforms.
 * #1135 The "no_metrics" anti-feature has been replaced with
   the "metrics" positive feature.
@@ -51,7 +52,6 @@
   doesn't make sense for things that must fit in memory anyway.
 * #1314 `Subscriber::next_timeout` now requires a mutable self
   reference.
-* #1337 Bump MSRV to 1.48.
 * #1349 The "measure_allocs" feature has been removed.
 * #1354 `Error` has been modified to be Copy, removing all
   heap-allocated variants.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ extreme::run(async move {
 
 # minimum supported Rust version (MSRV)
 
-We support Rust 1.48.0 and up.
+We support Rust 1.51.0 and up.
 
 # architecture
 

--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -12,10 +12,10 @@ rustup update --no-self-update
 
 RUSTFLAGS="--cfg miri" cargo check
 
-rustup toolchain install 1.48.0 --no-self-update
+rustup toolchain install 1.51.0 --no-self-update
 cargo clean
 rm Cargo.lock
-cargo +1.48.0 check
+cargo +1.51.0 check
 
 for target in $targets; do
   echo "setting up $target..."

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,19 +12,7 @@ pub struct Context {
     /// When the last high-level reference is dropped, it
     /// should trigger all background threads to clean
     /// up synchronously.
-    #[cfg(all(
-        not(miri),
-        any(
-            windows,
-            target_os = "linux",
-            target_os = "macos",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "openbsd",
-            target_os = "netbsd",
-            target_os = "ios",
-        )
-    ))]
+    #[cfg(not(miri))]
     pub(crate) flusher: Arc<Mutex<Option<flusher::Flusher>>>,
     #[doc(hidden)]
     pub pagecache: PageCache,
@@ -47,19 +35,7 @@ impl Context {
         Ok(Self {
             config,
             pagecache,
-            #[cfg(all(
-                not(miri),
-                any(
-                    windows,
-                    target_os = "linux",
-                    target_os = "macos",
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "openbsd",
-                    target_os = "netbsd",
-                    target_os = "ios",
-                )
-            ))]
+            #[cfg(not(miri))]
             flusher: Arc::new(parking_lot::Mutex::new(None)),
         })
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -53,19 +53,7 @@ impl Db {
 
         let context = Context::start(config)?;
 
-        #[cfg(all(
-            not(miri),
-            any(
-                windows,
-                target_os = "linux",
-                target_os = "macos",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "openbsd",
-                target_os = "netbsd",
-                target_os = "ios",
-            )
-        ))]
+        #[cfg(not(miri))]
         {
             let flusher_pagecache = context.pagecache.clone();
             let flusher = context.flush_every_ms.map(move |fem| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,19 +225,7 @@ pub mod fail;
 #[cfg(feature = "docs")]
 pub mod doc;
 
-#[cfg(all(
-    not(miri),
-    any(
-        windows,
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "ios",
-    )
-))]
+#[cfg(not(miri))]
 mod flusher;
 
 #[cfg(feature = "event_log")]

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -873,7 +873,7 @@ impl IoBufs {
         let max_header_stable_lsn = self.max_header_stable_lsn.clone();
         guard.defer(move || {
             trace!("bumping atomic header lsn to {}", stored_max_stable_lsn);
-            bump_atomic_lsn(&max_header_stable_lsn, stored_max_stable_lsn)
+            max_header_stable_lsn.fetch_max(stored_max_stable_lsn, SeqCst)
         });
         guard.flush();
         drop(guard);

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -1,9 +1,9 @@
 use std::fs::File;
 
 use super::{
-    arr_to_lsn, arr_to_u32, assert_usize, bump_atomic_lsn, decompress, header,
-    iobuf, lsn_to_arr, pread_exact, pread_exact_or_eof, roll_iobuf, u32_to_arr,
-    Arc, BasedBuf, DiskPtr, HeapId, IoBuf, IoBufs, LogKind, LogOffset, Lsn,
+    arr_to_lsn, arr_to_u32, assert_usize, decompress, header, iobuf,
+    lsn_to_arr, pread_exact, pread_exact_or_eof, roll_iobuf, u32_to_arr, Arc,
+    BasedBuf, DiskPtr, HeapId, IoBuf, IoBufs, LogKind, LogOffset, Lsn,
     MessageKind, Reservation, Serialize, Snapshot, BATCH_MANIFEST_PID,
     COUNTER_PID, MAX_MSG_HEADER_LEN, META_PID, SEG_HEADER_LEN,
 };
@@ -417,10 +417,9 @@ impl Log {
                 reservation_lid,
             );
 
-            bump_atomic_lsn(
-                &self.iobufs.max_reserved_lsn,
-                reservation_lsn + inline_buf_len as Lsn - 1,
-            );
+            self.iobufs
+                .max_reserved_lsn
+                .fetch_max(reservation_lsn + inline_buf_len as Lsn - 1, SeqCst);
 
             let (heap_reservation, heap_id) = if over_heap_threshold {
                 let heap_reservation = self

--- a/src/pagecache/mod.rs
+++ b/src/pagecache/mod.rs
@@ -1100,19 +1100,7 @@ impl PageCacheInner {
     /// move a page. Returns Ok(false) if there were no pages
     /// to GC. Returns an Err if we encountered an IO problem
     /// while performing this GC.
-    #[cfg(all(
-        not(miri),
-        any(
-            windows,
-            target_os = "linux",
-            target_os = "macos",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "openbsd",
-            target_os = "netbsd",
-            target_os = "ios",
-        )
-    ))]
+    #[cfg(not(miri))]
     pub(crate) fn attempt_gc(&self) -> Result<bool> {
         let guard = pin();
         let cc = concurrency_control::read();

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -4,19 +4,7 @@ use std::sync::Arc;
 
 use crate::{OneShot, Result};
 
-#[cfg(all(
-    not(miri),
-    any(
-        windows,
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "ios",
-    )
-))]
+#[cfg(not(miri))]
 mod queue {
     use std::{
         cell::RefCell,
@@ -220,19 +208,7 @@ where
     spawn_to(work, &queue::BLOCKING_QUEUE)
 }
 
-#[cfg(any(
-    miri,
-    not(any(
-        windows,
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "ios",
-    ))
-))]
+#[cfg(miri)]
 mod queue {
     /// This is the polyfill that just executes things synchronously.
     use crate::{OneShot, Result};


### PR DESCRIPTION
This change has been a long time coming, as needing to punt all maintenance work to any caller thread over time has really caused a lot of code complexity around logging and garbage collection to build-up. This change reasserts what sled began as, which is an embedded database with its first aim being to support higher scale distributed stateful systems, which will stand to benefit dramatically from being able to rely on thread support for specific logging and GC functionality over time. This change primarily unlocks some logging changes that I'd like to implement soon that should really simplify the writepath.