### PR TITLE
Fix for tree_names method in DB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -244,7 +244,11 @@ impl Db {
     /// Returns the trees names saved in this Db.
     pub fn tree_names(&self) -> Vec<IVec> {
         let tenants = self.tenants.read();
-        tenants.iter().map(|(name, _)| name.clone()).collect()
+        tenants
+            .iter()
+            .filter(|(name, _)| !DEFAULT_TREE_ID.eq(name.as_ref()))
+            .map(|(name, _)| name.clone())
+            .collect()
     }
 
     /// Returns `true` if the database was

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -1,0 +1,23 @@
+use sled::Config;
+
+#[test]
+fn test_exact_matching_of_tree_names() {
+    let db = Config::new().temporary(true).flush_every_ms(None).open().unwrap();
+    db.open_tree(String::from("X")).unwrap();
+    db.open_tree(String::from("Y")).unwrap();
+    db.open_tree(String::from("Z")).unwrap();
+
+    let raw_names = db.tree_names();
+    assert_eq!(raw_names.len(), 3);
+
+    let deserialized: Vec<String> = raw_names
+        .iter()
+        .map(|ivec| String::from_utf8(ivec.to_vec()))
+        .collect::<Result<Vec<String>, _>>()
+        .unwrap();
+
+    assert_eq!(deserialized.len(), 3);
+    assert!(deserialized.contains(&String::from("X")));
+    assert!(deserialized.contains(&String::from("Y")));
+    assert!(deserialized.contains(&String::from("Z")));
+}


### PR DESCRIPTION
During the implementation of my service, I encountered a problem related to deserialization of custom types, which could represent tree names. If you will try on code bellow, it will produce `Io(Kind(UnexpectedEof))` error because vector of names contains values serialized from `str [__sled__default]` and from `String [AAA, BBB, CCC]` both.

```rust
#[test]
fn bincode_db_names_test() {
    let db = sled::Config::default().temporary(true).open().unwrap();
    db.open_tree(bincode::serialize(&String::from("AAA")).unwrap()).unwrap();
    db.open_tree(bincode::serialize(&String::from("BBB")).unwrap()).unwrap();
    db.open_tree(bincode::serialize(&String::from("CCC")).unwrap()).unwrap();

    let names: Vec<String> = db
        .tree_names()
        .iter()
        .filter_map(|name| match bincode::deserialize::<String>(name) {
            Ok(value) => Some(value),
            Err(e) => {
                println!("Sled name={name:?} caused error: {e:?}");
                None
            }
        })
        .collect();

    println!("{:?}", names);
}
```
So, basically, we have a situation where the API for **creating a Tree** is more generic than the API that **lists created trees**. The main question here is - should Sled's specific/system data be a part of public API or not. I think - not.