### PR TITLE
Apply `rustfmt` and `clippy` fixes across crate

### DIFF
--- a/examples/structured.rs
+++ b/examples/structured.rs
@@ -197,7 +197,7 @@ fn hash_join(db: &sled::Db) -> sled::Result<()> {
             LayoutVerified::new_from_prefix(&*value_bytes).unwrap();
         let (ref mut cat_names, _dog_names) =
             join.entry(home_name.to_vec()).or_insert((vec![], vec![]));
-        cat_names.push(std::str::from_utf8(&*name).unwrap().to_string());
+        cat_names.push(std::str::from_utf8(&name).unwrap().to_string());
     }
 
     for name_value_res in &dogs {
@@ -212,7 +212,7 @@ fn hash_join(db: &sled::Db) -> sled::Result<()> {
             LayoutVerified::new_from_suffix(&*value_bytes).unwrap();
 
         if let Some((_cat_names, ref mut dog_names)) = join.get_mut(home_name) {
-            dog_names.push(std::str::from_utf8(&*name).unwrap().to_string());
+            dog_names.push(std::str::from_utf8(&name).unwrap().to_string());
         }
     }
 

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -6,12 +6,13 @@ const SPIN_LIMIT: u32 = 6;
 
 /// Performs exponential backoff in spin loops.
 ///
-/// Backing off in spin loops reduces contention and improves overall performance.
+/// Backing off in spin loops reduces contention and improves overall
+/// performance.
 ///
-/// This primitive can execute *YIELD* and *PAUSE* instructions, yield the current thread to the OS
-/// scheduler, and tell when is a good time to block the thread using a different synchronization
-/// mechanism. Each step of the back off procedure takes roughly twice as long as the previous
-/// step.
+/// This primitive can execute *YIELD* and *PAUSE* instructions, yield the
+/// current thread to the OS scheduler, and tell when is a good time to block
+/// the thread using a different synchronization mechanism. Each step of the
+/// back off procedure takes roughly twice as long as the previous step.
 pub struct Backoff {
     step: Cell<u32>,
 }
@@ -24,8 +25,8 @@ impl Backoff {
 
     /// Backs off in a lock-free loop.
     ///
-    /// This method should be used when we need to retry an operation because another thread made
-    /// progress.
+    /// This method should be used when we need to retry an operation because
+    /// another thread made progress.
     ///
     /// The processor may yield using the *YIELD* or *PAUSE* instruction.
     #[inline]

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -2,15 +2,16 @@
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 
-// Starting from Intel's Sandy Bridge, spatial prefetcher is now pulling pairs of 64-byte cache
-// lines at a time, so we have to align to 128 bytes rather than 64.
+// Starting from Intel's Sandy Bridge, spatial prefetcher is now pulling pairs
+// of 64-byte cache lines at a time, so we have to align to 128 bytes rather
+// than 64.
 //
 // Sources:
 // - https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-optimization-manual.pdf
 // - https://github.com/facebook/folly/blob/1b5288e6eea6df074758f877c849b6e73bbb9fbb/folly/lang/Align.h#L107
 //
-// ARM's big.LITTLE architecture has asymmetric cores and "big" cores have 128 byte cache line size
-// Sources:
+// ARM's big.LITTLE architecture has asymmetric cores and "big" cores have 128
+// byte cache line size Sources:
 // - https://www.mono-project.com/news/2016/09/12/arm64-icache/
 //
 #[cfg_attr(
@@ -21,7 +22,7 @@ use core::ops::{Deref, DerefMut};
     not(any(target_arch = "x86_64", target_arch = "aarch64")),
     repr(align(64))
 )]
-#[derive(Default, PartialEq)]
+#[derive(Default, PartialEq, Eq)]
 pub struct CachePadded<T> {
     value: T,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -619,7 +619,7 @@ impl Config {
 
     fn write_config(&self) -> Result<()> {
         let bytes = self.serialize();
-        let crc: u32 = crc32(&*bytes);
+        let crc: u32 = crc32(&bytes);
         let crc_arr = u32_to_arr(crc);
 
         let temp_path = self.get_path().join("conf.tmp");
@@ -629,7 +629,7 @@ impl Config {
             fs::OpenOptions::new().write(true).create(true).open(&temp_path)?;
 
         io_fail!(self, "write_config bytes");
-        f.write_all(&*bytes)?;
+        f.write_all(&bytes)?;
         io_fail!(self, "write_config crc");
         f.write_all(&crc_arr)?;
         io_fail!(self, "write_config fsync");
@@ -672,7 +672,7 @@ impl Config {
         f.read_exact(&mut crc_arr)?;
         let crc_expected = arr_to_u32(&crc_arr);
 
-        let crc_actual = crc32(&*buf);
+        let crc_actual = crc32(&buf);
 
         if crc_expected != crc_actual {
             warn!(

--- a/src/db.rs
+++ b/src/db.rs
@@ -143,7 +143,7 @@ impl Db {
 
         let mut tenants = self.tenants.write();
 
-        let tree = if let Some(tree) = tenants.remove(&*name_ref) {
+        let tree = if let Some(tree) = tenants.remove(name_ref) {
             tree
         } else {
             return Ok(false);

--- a/src/doc/sled_architectural_outlook/mod.rs
+++ b/src/doc/sled_architectural_outlook/mod.rs
@@ -1,8 +1,8 @@
-//! Here's a look at where sled is at, and where it's going architecturally. The system is very
-//! much under active development, and we have a ways to go. If specific areas are interesting to
-//! you, I'd love to [work together](https://github.com/spacejam/sled/blob/main/CONTRIBUTING.md)!
-//! If your business has a need for particular items below, you can [fund development of particular
-//! features](https://opencollective.com/sled).
+//! Here's a look at where sled is at, and where it's going architecturally. The
+//! system is very much under active development, and we have a ways to go. If
+//! specific areas are interesting to you, I'd love to [work together](https://github.com/spacejam/sled/blob/main/CONTRIBUTING.md)!
+//! If your business has a need for particular items below, you can [fund
+//! development of particular features](https://opencollective.com/sled).
 //!
 //! People face unnecessary hardship when working with existing embedded
 //! databases. They tend to have sharp performance trade-offs, are difficult to

--- a/src/ebr/atomic.rs
+++ b/src/ebr/atomic.rs
@@ -11,8 +11,8 @@ use std::alloc;
 
 use super::Guard;
 
-/// Given ordering for the success case in a compare-exchange operation, returns the strongest
-/// appropriate ordering for the failure case.
+/// Given ordering for the success case in a compare-exchange operation, returns
+/// the strongest appropriate ordering for the failure case.
 pub(crate) const fn strongest_failure_ordering(ord: Ordering) -> Ordering {
     use self::Ordering::*;
     match ord {
@@ -44,23 +44,24 @@ impl<'g, T: 'g, P: Pointer<T> + fmt::Debug> fmt::Debug
 
 /// Memory orderings for compare-and-set operations.
 ///
-/// A compare-and-set operation can have different memory orderings depending on whether it
-/// succeeds or fails. This trait generalizes different ways of specifying memory orderings.
+/// A compare-and-set operation can have different memory orderings depending on
+/// whether it succeeds or fails. This trait generalizes different ways of
+/// specifying memory orderings.
 ///
 /// The two ways of specifying orderings for compare-and-set are:
 ///
-/// 1. Just one `Ordering` for the success case. In case of failure, the strongest appropriate
-///    ordering is chosen.
-/// 2. A pair of `Ordering`s. The first one is for the success case, while the second one is
-///    for the failure case.
+/// 1. Just one `Ordering` for the success case. In case of failure, the
+/// strongest appropriate    ordering is chosen.
+/// 2. A pair of `Ordering`s. The first one is for the success case, while the
+/// second one is    for the failure case.
 pub(crate) trait CompareAndSetOrdering: Copy {
     /// The ordering of the operation when it succeeds.
     fn success(self) -> Ordering;
 
     /// The ordering of the operation when it fails.
     ///
-    /// The failure ordering can't be `Release` or `AcqRel` and must be equivalent or weaker than
-    /// the success ordering.
+    /// The failure ordering can't be `Release` or `AcqRel` and must be
+    /// equivalent or weaker than the success ordering.
     fn failure(self) -> Ordering;
 }
 
@@ -88,7 +89,8 @@ impl CompareAndSetOrdering for (Ordering, Ordering) {
     }
 }
 
-/// Returns a bitmask containing the unused least significant bits of an aligned pointer to `T`.
+/// Returns a bitmask containing the unused least significant bits of an aligned
+/// pointer to `T`.
 #[inline]
 fn low_bits<T: ?Sized + Pointable>() -> usize {
     (1 << T::ALIGN.trailing_zeros()) - 1
@@ -100,7 +102,8 @@ fn ensure_aligned<T: ?Sized + Pointable>(raw: usize) {
     assert_eq!(raw & low_bits::<T>(), 0, "unaligned pointer");
 }
 
-/// Given a tagged pointer `data`, returns the same pointer, but tagged with `tag`.
+/// Given a tagged pointer `data`, returns the same pointer, but tagged with
+/// `tag`.
 ///
 /// `tag` is truncated to fit into the unused bits of the pointer to `T`.
 #[inline]
@@ -116,17 +119,19 @@ fn decompose_tag<T: ?Sized + Pointable>(data: usize) -> (usize, usize) {
 
 /// Types that are pointed to by a single word.
 ///
-/// In concurrent programming, it is necessary to represent an object within a word because atomic
-/// operations (e.g., reads, writes, read-modify-writes) support only single words.  This trait
-/// qualifies such types that are pointed to by a single word.
+/// In concurrent programming, it is necessary to represent an object within a
+/// word because atomic operations (e.g., reads, writes, read-modify-writes)
+/// support only single words.  This trait qualifies such types that are pointed
+/// to by a single word.
 ///
-/// The trait generalizes `Box<T>` for a sized type `T`.  In a box, an object of type `T` is
-/// allocated in heap and it is owned by a single-word pointer.  This trait is also implemented for
-/// `[MaybeUninit<T>]` by storing its size along with its elements and pointing to the pair of array
-/// size and elements.
+/// The trait generalizes `Box<T>` for a sized type `T`.  In a box, an object of
+/// type `T` is allocated in heap and it is owned by a single-word pointer.
+/// This trait is also implemented for `[MaybeUninit<T>]` by storing its size
+/// along with its elements and pointing to the pair of array size and elements.
 ///
-/// Pointers to `Pointable` types can be stored in [`Atomic`], [`Owned`], and [`Shared`].  In
-/// particular, Crossbeam supports dynamically sized slices as follows.
+/// Pointers to `Pointable` types can be stored in [`Atomic`], [`Owned`], and
+/// [`Shared`].  In particular, Crossbeam supports dynamically sized slices as
+/// follows.
 pub(crate) trait Pointable {
     /// The alignment of pointer.
     const ALIGN: usize;
@@ -147,7 +152,8 @@ pub(crate) trait Pointable {
     ///
     /// - The given `ptr` should have been initialized with [`Pointable::init`].
     /// - `ptr` should not have yet been dropped by [`Pointable::drop`].
-    /// - `ptr` should not be mutably dereferenced by [`Pointable::deref_mut`] concurrently.
+    /// - `ptr` should not be mutably dereferenced by [`Pointable::deref_mut`]
+    ///   concurrently.
     unsafe fn deref<'a>(ptr: usize) -> &'a Self;
 
     /// Mutably dereferences the given pointer.
@@ -156,8 +162,8 @@ pub(crate) trait Pointable {
     ///
     /// - The given `ptr` should have been initialized with [`Pointable::init`].
     /// - `ptr` should not have yet been dropped by [`Pointable::drop`].
-    /// - `ptr` should not be dereferenced by [`Pointable::deref`] or [`Pointable::deref_mut`]
-    ///   concurrently.
+    /// - `ptr` should not be dereferenced by [`Pointable::deref`] or
+    ///   [`Pointable::deref_mut`] concurrently.
     unsafe fn deref_mut<'a>(ptr: usize) -> &'a mut Self;
 
     /// Drops the object pointed to by the given pointer.
@@ -166,8 +172,8 @@ pub(crate) trait Pointable {
     ///
     /// - The given `ptr` should have been initialized with [`Pointable::init`].
     /// - `ptr` should not have yet been dropped by [`Pointable::drop`].
-    /// - `ptr` should not be dereferenced by [`Pointable::deref`] or [`Pointable::deref_mut`]
-    ///   concurrently.
+    /// - `ptr` should not be dereferenced by [`Pointable::deref`] or
+    ///   [`Pointable::deref_mut`] concurrently.
     unsafe fn drop(ptr: usize);
 }
 
@@ -208,14 +214,14 @@ impl<T> Pointable for T {
 /// ------------------------------------
 /// ```
 ///
-/// Its memory layout is different from that of `Box<[T]>` in that size is in the allocation (not
-/// along with pointer as in `Box<[T]>`).
+/// Its memory layout is different from that of `Box<[T]>` in that size is in
+/// the allocation (not along with pointer as in `Box<[T]>`).
 ///
 /// Elements are not present in the type, but they will be in the allocation.
 /// ```
 ///
-// TODO(@jeehoonkang): once we bump the minimum required Rust version to 1.44 or newer, use
-// [`alloc::alloc::Layout::extend`] instead.
+// TODO(@jeehoonkang): once we bump the minimum required Rust version to 1.44 or
+// newer, use [`alloc::alloc::Layout::extend`] instead.
 #[repr(C)]
 struct Array<T> {
     size: usize,
@@ -259,9 +265,10 @@ impl<T> Pointable for [MaybeUninit<T>] {
 
 /// An atomic pointer that can be safely shared between threads.
 ///
-/// The pointer must be properly aligned. Since it is aligned, a tag can be stored into the unused
-/// least significant bits of the address. For example, the tag for a pointer to a sized type `T`
-/// should be less than `(1 << mem::align_of::<T>().trailing_zeros())`.
+/// The pointer must be properly aligned. Since it is aligned, a tag can be
+/// stored into the unused least significant bits of the address. For example,
+/// the tag for a pointer to a sized type `T` should be less than `(1 <<
+/// mem::align_of::<T>().trailing_zeros())`.
 ///
 /// Any method that loads the pointer must be passed a reference to a [`Guard`].
 ///
@@ -275,14 +282,16 @@ unsafe impl<T: ?Sized + Pointable + Send + Sync> Send for Atomic<T> {}
 unsafe impl<T: ?Sized + Pointable + Send + Sync> Sync for Atomic<T> {}
 
 impl<T> Atomic<T> {
-    /// Allocates `value` on the heap and returns a new atomic pointer pointing to it.
+    /// Allocates `value` on the heap and returns a new atomic pointer pointing
+    /// to it.
     pub(crate) fn new(init: T) -> Atomic<T> {
         Self::init(init)
     }
 }
 
 impl<T: ?Sized + Pointable> Atomic<T> {
-    /// Allocates `value` on the heap and returns a new atomic pointer pointing to it.
+    /// Allocates `value` on the heap and returns a new atomic pointer pointing
+    /// to it.
     pub(crate) fn init(init: T::Init) -> Atomic<T> {
         Self::from(Owned::init(init))
     }
@@ -299,8 +308,8 @@ impl<T: ?Sized + Pointable> Atomic<T> {
 
     /// Loads a `Shared` from the atomic pointer.
     ///
-    /// This method takes an [`Ordering`] argument which describes the memory ordering of this
-    /// operation.
+    /// This method takes an [`Ordering`] argument which describes the memory
+    /// ordering of this operation.
     pub(crate) fn load<'g>(
         &self,
         ord: Ordering,
@@ -311,17 +320,17 @@ impl<T: ?Sized + Pointable> Atomic<T> {
 
     /// Stores a `Shared` or `Owned` pointer into the atomic pointer.
     ///
-    /// This method takes an [`Ordering`] argument which describes the memory ordering of this
-    /// operation.
+    /// This method takes an [`Ordering`] argument which describes the memory
+    /// ordering of this operation.
     pub(crate) fn store<P: Pointer<T>>(&self, new: P, ord: Ordering) {
         self.data.store(new.into_usize(), ord);
     }
 
-    /// Stores a `Shared` or `Owned` pointer into the atomic pointer, returning the previous
-    /// `Shared`.
+    /// Stores a `Shared` or `Owned` pointer into the atomic pointer, returning
+    /// the previous `Shared`.
     ///
-    /// This method takes an [`Ordering`] argument which describes the memory ordering of this
-    /// operation.
+    /// This method takes an [`Ordering`] argument which describes the memory
+    /// ordering of this operation.
     pub(crate) fn swap<'g, P: Pointer<T>>(
         &self,
         new: P,
@@ -331,16 +340,17 @@ impl<T: ?Sized + Pointable> Atomic<T> {
         unsafe { Shared::from_usize(self.data.swap(new.into_usize(), ord)) }
     }
 
-    /// Stores the pointer `new` (either `Shared` or `Owned`) into the atomic pointer if the current
-    /// value is the same as `current`. The tag is also taken into account, so two pointers to the
-    /// same object, but with different tags, will not be considered equal.
+    /// Stores the pointer `new` (either `Shared` or `Owned`) into the atomic
+    /// pointer if the current value is the same as `current`. The tag is
+    /// also taken into account, so two pointers to the same object, but
+    /// with different tags, will not be considered equal.
     ///
-    /// The return value is a result indicating whether the new pointer was written. On success the
-    /// pointer that was written is returned. On failure the actual current value and `new` are
-    /// returned.
+    /// The return value is a result indicating whether the new pointer was
+    /// written. On success the pointer that was written is returned. On
+    /// failure the actual current value and `new` are returned.
     ///
-    /// This method takes a [`CompareAndSetOrdering`] argument which describes the memory
-    /// ordering of this operation.
+    /// This method takes a [`CompareAndSetOrdering`] argument which describes
+    /// the memory ordering of this operation.
     pub(crate) fn compare_and_set<'g, O, P>(
         &self,
         current: Shared<'_, T>,
@@ -369,17 +379,20 @@ impl<T: ?Sized + Pointable> Atomic<T> {
             })
     }
 
-    /// Stores the pointer `new` (either `Shared` or `Owned`) into the atomic pointer if the current
-    /// value is the same as `current`. The tag is also taken into account, so two pointers to the
-    /// same object, but with different tags, will not be considered equal.
+    /// Stores the pointer `new` (either `Shared` or `Owned`) into the atomic
+    /// pointer if the current value is the same as `current`. The tag is
+    /// also taken into account, so two pointers to the same object, but
+    /// with different tags, will not be considered equal.
     ///
-    /// Unlike [`compare_and_set`], this method is allowed to spuriously fail even when comparison
-    /// succeeds, which can result in more efficient code on some platforms.  The return value is a
-    /// result indicating whether the new pointer was written. On success the pointer that was
-    /// written is returned. On failure the actual current value and `new` are returned.
+    /// Unlike [`compare_and_set`], this method is allowed to spuriously fail
+    /// even when comparison succeeds, which can result in more efficient
+    /// code on some platforms.  The return value is a result indicating
+    /// whether the new pointer was written. On success the pointer that was
+    /// written is returned. On failure the actual current value and `new` are
+    /// returned.
     ///
-    /// This method takes a [`CompareAndSetOrdering`] argument which describes the memory
-    /// ordering of this operation.
+    /// This method takes a [`CompareAndSetOrdering`] argument which describes
+    /// the memory ordering of this operation.
     ///
     /// [`compare_and_set`]: Atomic::compare_and_set
     pub(crate) fn compare_and_set_weak<'g, O, P>(
@@ -412,11 +425,12 @@ impl<T: ?Sized + Pointable> Atomic<T> {
 
     /// Bitwise "or" with the current tag.
     ///
-    /// Performs a bitwise "or" operation on the current tag and the argument `val`, and sets the
-    /// new tag to the result. Returns the previous pointer.
+    /// Performs a bitwise "or" operation on the current tag and the argument
+    /// `val`, and sets the new tag to the result. Returns the previous
+    /// pointer.
     ///
-    /// This method takes an [`Ordering`] argument which describes the memory ordering of this
-    /// operation.
+    /// This method takes an [`Ordering`] argument which describes the memory
+    /// ordering of this operation.
     pub(crate) fn fetch_or<'g>(
         &self,
         val: usize,
@@ -449,8 +463,8 @@ impl<T: ?Sized + Pointable> fmt::Pointer for Atomic<T> {
 impl<T: ?Sized + Pointable> Clone for Atomic<T> {
     /// Returns a copy of the atomic value.
     ///
-    /// Note that a `Relaxed` load is used here. If you need synchronization, use it with other
-    /// atomics or fences.
+    /// Note that a `Relaxed` load is used here. If you need synchronization,
+    /// use it with other atomics or fences.
     fn clone(&self) -> Self {
         let data = self.data.load(Ordering::Relaxed);
         Atomic::from_usize(data)
@@ -508,8 +522,9 @@ pub(crate) trait Pointer<T: ?Sized + Pointable> {
     ///
     /// # Safety
     ///
-    /// The given `data` should have been created by `Pointer::into_usize()`, and one `data` should
-    /// not be converted back by `Pointer::from_usize()` multiple times.
+    /// The given `data` should have been created by `Pointer::into_usize()`,
+    /// and one `data` should not be converted back by
+    /// `Pointer::from_usize()` multiple times.
     unsafe fn from_usize(data: usize) -> Self;
 }
 
@@ -517,8 +532,8 @@ pub(crate) trait Pointer<T: ?Sized + Pointable> {
 ///
 /// This type is very similar to `Box<T>`.
 ///
-/// The pointer must be properly aligned. Since it is aligned, a tag can be stored into the unused
-/// least significant bits of the address.
+/// The pointer must be properly aligned. Since it is aligned, a tag can be
+/// stored into the unused least significant bits of the address.
 pub(crate) struct Owned<T: ?Sized + Pointable> {
     data: usize,
     _marker: PhantomData<Box<T>>,
@@ -548,8 +563,9 @@ impl<T: ?Sized + Pointable> Pointer<T> for Owned<T> {
 impl<T> Owned<T> {
     /// Returns a new owned pointer pointing to `raw`.
     ///
-    /// This function is unsafe because improper use may lead to memory problems. Argument `raw`
-    /// must be a valid pointer. Also, a double-free may occur if the function is called twice on
+    /// This function is unsafe because improper use may lead to memory
+    /// problems. Argument `raw` must be a valid pointer. Also, a
+    /// double-free may occur if the function is called twice on
     /// the same raw pointer.
     ///
     /// # Panics
@@ -558,22 +574,24 @@ impl<T> Owned<T> {
     ///
     /// # Safety
     ///
-    /// The given `raw` should have been derived from `Owned`, and one `raw` should not be converted
-    /// back by `Owned::from_raw()` multiple times.
+    /// The given `raw` should have been derived from `Owned`, and one `raw`
+    /// should not be converted back by `Owned::from_raw()` multiple times.
     pub(crate) unsafe fn from_raw(raw_ptr: *mut T) -> Owned<T> {
         let raw = raw_ptr as usize;
         ensure_aligned::<T>(raw);
         Self::from_usize(raw)
     }
 
-    /// Allocates `value` on the heap and returns a new owned pointer pointing to it.
+    /// Allocates `value` on the heap and returns a new owned pointer pointing
+    /// to it.
     pub(crate) fn new(init: T) -> Owned<T> {
         Self::init(init)
     }
 }
 
 impl<T: ?Sized + Pointable> Owned<T> {
-    /// Allocates `value` on the heap and returns a new owned pointer pointing to it.
+    /// Allocates `value` on the heap and returns a new owned pointer pointing
+    /// to it.
     pub(crate) fn init(init: T::Init) -> Owned<T> {
         unsafe { Self::from_usize(T::init(init)) }
     }
@@ -590,8 +608,8 @@ impl<T: ?Sized + Pointable> Owned<T> {
         tag
     }
 
-    /// Returns the same pointer, but tagged with `tag`. `tag` is truncated to be fit into the
-    /// unused bits of the pointer to `T`.
+    /// Returns the same pointer, but tagged with `tag`. `tag` is truncated to
+    /// be fit into the unused bits of the pointer to `T`.
     pub(crate) fn with_tag(self, tag: usize) -> Owned<T> {
         let data = self.into_usize();
         unsafe { Self::from_usize(compose_tag::<T>(data, tag)) }
@@ -682,8 +700,8 @@ impl<T: ?Sized + Pointable> AsMut<T> for Owned<T> {
 ///
 /// The pointer is valid for use only during the lifetime `'g`.
 ///
-/// The pointer must be properly aligned. Since it is aligned, a tag can be stored into the unused
-/// least significant bits of the address.
+/// The pointer must be properly aligned. Since it is aligned, a tag can be
+/// stored into the unused least significant bits of the address.
 pub(crate) struct Shared<'g, T: 'g + ?Sized + Pointable> {
     data: usize,
     _marker: PhantomData<(&'g (), *const T)>,
@@ -733,21 +751,24 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
 
     /// Dereferences the pointer.
     ///
-    /// Returns a reference to the pointee that is valid during the lifetime `'g`.
+    /// Returns a reference to the pointee that is valid during the lifetime
+    /// `'g`.
     ///
     /// # Safety
     ///
-    /// Dereferencing a pointer is unsafe because it could be pointing to invalid memory.
+    /// Dereferencing a pointer is unsafe because it could be pointing to
+    /// invalid memory.
     ///
-    /// Another concern is the possibility of data races due to lack of proper synchronization.
-    /// For example, consider the following scenario:
+    /// Another concern is the possibility of data races due to lack of proper
+    /// synchronization. For example, consider the following scenario:
     ///
     /// 1. A thread creates a new object: `a.store(Owned::new(10), Relaxed)`
     /// 2. Another thread reads it: `*a.load(Relaxed, guard).as_ref().unwrap()`
     ///
-    /// The problem is that relaxed orderings don't synchronize initialization of the object with
-    /// the read from the second thread. This is a data race. A possible solution would be to use
-    /// `Release` and `Acquire` orderings.
+    /// The problem is that relaxed orderings don't synchronize initialization
+    /// of the object with the read from the second thread. This is a data
+    /// race. A possible solution would be to use `Release` and `Acquire`
+    /// orderings.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[allow(clippy::should_implement_trait)]
     pub(crate) unsafe fn deref(&self) -> &'g T {
@@ -757,29 +778,28 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
 
     /// Converts the pointer to a reference.
     ///
-    /// Returns `None` if the pointer is null, or else a reference to the object wrapped in `Some`.
+    /// Returns `None` if the pointer is null, or else a reference to the object
+    /// wrapped in `Some`.
     ///
     /// # Safety
     ///
-    /// Dereferencing a pointer is unsafe because it could be pointing to invalid memory.
+    /// Dereferencing a pointer is unsafe because it could be pointing to
+    /// invalid memory.
     ///
-    /// Another concern is the possibility of data races due to lack of proper synchronization.
-    /// For example, consider the following scenario:
+    /// Another concern is the possibility of data races due to lack of proper
+    /// synchronization. For example, consider the following scenario:
     ///
     /// 1. A thread creates a new object: `a.store(Owned::new(10), Relaxed)`
     /// 2. Another thread reads it: `*a.load(Relaxed, guard).as_ref().unwrap()`
     ///
-    /// The problem is that relaxed orderings don't synchronize initialization of the object with
-    /// the read from the second thread. This is a data race. A possible solution would be to use
-    /// `Release` and `Acquire` orderings.
+    /// The problem is that relaxed orderings don't synchronize initialization
+    /// of the object with the read from the second thread. This is a data
+    /// race. A possible solution would be to use `Release` and `Acquire`
+    /// orderings.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(crate) unsafe fn as_ref(&self) -> Option<&'g T> {
         let (raw, _) = decompose_tag::<T>(self.data);
-        if raw == 0 {
-            None
-        } else {
-            Some(T::deref(raw))
-        }
+        if raw == 0 { None } else { Some(T::deref(raw)) }
     }
 
     /// Takes ownership of the pointee.
@@ -790,8 +810,8 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     ///
     /// # Safety
     ///
-    /// This method may be called only if the pointer is valid and nobody else is holding a
-    /// reference to the same object.
+    /// This method may be called only if the pointer is valid and nobody else
+    /// is holding a reference to the same object.
     pub(crate) unsafe fn into_owned(self) -> Owned<T> {
         debug_assert!(
             !self.is_null(),
@@ -807,8 +827,8 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
         tag
     }
 
-    /// Returns the same pointer, but tagged with `tag`. `tag` is truncated to be fit into the
-    /// unused bits of the pointer to `T`.
+    /// Returns the same pointer, but tagged with `tag`. `tag` is truncated to
+    /// be fit into the unused bits of the pointer to `T`.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(crate) fn with_tag(&self, tag: usize) -> Shared<'g, T> {
         unsafe { Self::from_usize(compose_tag::<T>(self.data, tag)) }

--- a/src/ebr/deferred.rs
+++ b/src/ebr/deferred.rs
@@ -5,8 +5,9 @@ use core::ptr;
 
 /// Number of words a piece of `Data` can hold.
 ///
-/// Three words should be enough for the majority of cases. For example, you can fit inside it the
-/// function pointer together with a fat pointer representing an object that needs to be destroyed.
+/// Three words should be enough for the majority of cases. For example, you can
+/// fit inside it the function pointer together with a fat pointer representing
+/// an object that needs to be destroyed.
 const DATA_WORDS: usize = 3;
 
 /// Some space to keep a `FnOnce()` object on the stack.
@@ -14,7 +15,8 @@ type Data = [usize; DATA_WORDS];
 
 /// A `FnOnce()` that is stored inline if small, or otherwise boxed on the heap.
 ///
-/// This is a handy way of keeping an unsized `FnOnce()` within a sized structure.
+/// This is a handy way of keeping an unsized `FnOnce()` within a sized
+/// structure.
 pub(super) struct Deferred {
     call: unsafe fn(*mut u8),
     data: Data,

--- a/src/ebr/epoch.rs
+++ b/src/ebr/epoch.rs
@@ -1,21 +1,25 @@
 //! The global epoch
 //!
-//! The last bit in this number is unused and is always zero. Every so often the global epoch is
-//! incremented, i.e. we say it "advances". A pinned participant may advance the global epoch only
-//! if all currently pinned participants have been pinned in the current epoch.
+//! The last bit in this number is unused and is always zero. Every so often the
+//! global epoch is incremented, i.e. we say it "advances". A pinned participant
+//! may advance the global epoch only if all currently pinned participants have
+//! been pinned in the current epoch.
 //!
-//! If an object became garbage in some epoch, then we can be sure that after two advancements no
-//! participant will hold a reference to it. That is the crux of safe memory reclamation.
+//! If an object became garbage in some epoch, then we can be sure that after
+//! two advancements no participant will hold a reference to it. That is the
+//! crux of safe memory reclamation.
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// An epoch that can be marked as pinned or unpinned.
 ///
-/// Internally, the epoch is represented as an integer that wraps around at some unspecified point
-/// and a flag that represents whether it is pinned or unpinned.
+/// Internally, the epoch is represented as an integer that wraps around at some
+/// unspecified point and a flag that represents whether it is pinned or
+/// unpinned.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(super) struct Epoch {
-    /// The least significant bit is set if pinned. The rest of the bits hold the epoch.
+    /// The least significant bit is set if pinned. The rest of the bits hold
+    /// the epoch.
     data: usize,
 }
 
@@ -27,11 +31,13 @@ impl Epoch {
 
     /// Returns the number of epochs `self` is ahead of `rhs`.
     ///
-    /// Internally, epochs are represented as numbers in the range `(isize::MIN / 2) .. (isize::MAX
-    /// / 2)`, so the returned distance will be in the same interval.
+    /// Internally, epochs are represented as numbers in the range `(isize::MIN
+    /// / 2) .. (isize::MAX / 2)`, so the returned distance will be in the
+    /// same interval.
     pub(super) const fn wrapping_sub(self, rhs: Self) -> usize {
-        // The result is the same with `(self.data & !1).wrapping_sub(rhs.data & !1) as isize >> 1`,
-        // because the possible difference of LSB in `(self.data & !1).wrapping_sub(rhs.data & !1)`
+        // The result is the same with `(self.data & !1).wrapping_sub(rhs.data &
+        // !1) as isize >> 1`, because the possible difference of LSB in
+        // `(self.data & !1).wrapping_sub(rhs.data & !1)`
         // will be ignored in the shift operation.
         self.data.wrapping_sub(rhs.data & !1) >> 1
     }
@@ -53,7 +59,8 @@ impl Epoch {
 
     /// Returns the successor epoch.
     ///
-    /// The returned epoch will be marked as pinned only if the previous one was as well.
+    /// The returned epoch will be marked as pinned only if the previous one was
+    /// as well.
     pub(super) const fn successor(self) -> Epoch {
         Epoch { data: self.data.wrapping_add(2) }
     }
@@ -62,8 +69,8 @@ impl Epoch {
 /// An atomic value that holds an `Epoch`.
 #[derive(Default, Debug)]
 pub(super) struct AtomicEpoch {
-    /// Since `Epoch` is just a wrapper around `usize`, an `AtomicEpoch` is similarly represented
-    /// using an `AtomicUsize`.
+    /// Since `Epoch` is just a wrapper around `usize`, an `AtomicEpoch` is
+    /// similarly represented using an `AtomicUsize`.
     data: AtomicUsize,
 }
 
@@ -86,10 +93,11 @@ impl AtomicEpoch {
         self.data.store(epoch.data, ord);
     }
 
-    /// Stores a value into the atomic epoch if the current value is the same as `current`.
+    /// Stores a value into the atomic epoch if the current value is the same as
+    /// `current`.
     ///
-    /// The return value is always the previous value. If it is equal to `current`, then the value
-    /// is updated.
+    /// The return value is always the previous value. If it is equal to
+    /// `current`, then the value is updated.
     ///
     /// The `Ordering` argument describes the memory ordering of this operation.
     #[inline]

--- a/src/ebr/list.rs
+++ b/src/ebr/list.rs
@@ -1,7 +1,7 @@
 //! Lock-free intrusive linked list.
 //!
-//! Ideas from Michael.  High Performance Dynamic Lock-Free Hash Tables and List-Based Sets.  SPAA
-//! 2002.  `http://dl.acm.org/citation.cfm?id=564870.564881`
+//! Ideas from Michael.  High Performance Dynamic Lock-Free Hash Tables and
+//! List-Based Sets.  SPAA 2002.  `http://dl.acm.org/citation.cfm?id=564870.564881`
 
 use core::marker::PhantomData;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
@@ -10,8 +10,8 @@ use super::{pin, Atomic, Guard, Shared};
 
 /// An entry in a linked list.
 ///
-/// An Entry is accessed from multiple threads, so it would be beneficial to put it in a different
-/// cache-line than thread-local data in terms of performance.
+/// An Entry is accessed from multiple threads, so it would be beneficial to put
+/// it in a different cache-line than thread-local data in terms of performance.
 #[derive(Debug)]
 pub struct Entry {
     /// The next entry in the linked list.
@@ -19,19 +19,20 @@ pub struct Entry {
     next: Atomic<Entry>,
 }
 
-/// Implementing this trait asserts that the type `T` can be used as an element in the intrusive
-/// linked list defined in this module. `T` has to contain (or otherwise be linked to) an instance
-/// of `Entry`.
+/// Implementing this trait asserts that the type `T` can be used as an element
+/// in the intrusive linked list defined in this module. `T` has to contain (or
+/// otherwise be linked to) an instance of `Entry`.
 ///
 /// # Example
 ///
-/// This trait is implemented on a type separate from `T` (although it can be just `T`), because
-/// one type might be placeable into multiple lists, in which case it would require multiple
-/// implementations of `IsElement`. In such cases, each struct implementing `IsElement<T>`
-/// represents a distinct `Entry` in `T`.
+/// This trait is implemented on a type separate from `T` (although it can be
+/// just `T`), because one type might be placeable into multiple lists, in which
+/// case it would require multiple implementations of `IsElement`. In such
+/// cases, each struct implementing `IsElement<T>` represents a distinct `Entry`
+/// in `T`.
 ///
-/// For example, we can insert the following struct into two lists using `entry1` for one
-/// and `entry2` for the other:
+/// For example, we can insert the following struct into two lists using
+/// `entry1` for one and `entry2` for the other:
 pub trait IsElement<T> {
     /// Returns a reference to this element's `Entry`.
     fn entry_of(_: &T) -> &Entry;
@@ -40,16 +41,16 @@ pub trait IsElement<T> {
     ///
     /// # Safety
     ///
-    /// The caller has to guarantee that the `Entry` is called with was retrieved from an instance
-    /// of the element type (`T`).
+    /// The caller has to guarantee that the `Entry` is called with was
+    /// retrieved from an instance of the element type (`T`).
     unsafe fn element_of(_: &Entry) -> &T;
 
     /// The function that is called when an entry is unlinked from list.
     ///
     /// # Safety
     ///
-    /// The caller has to guarantee that the `Entry` is called with was retrieved from an instance
-    /// of the element type (`T`).
+    /// The caller has to guarantee that the `Entry` is called with was
+    /// retrieved from an instance of the element type (`T`).
     unsafe fn finalize(_: &Entry, _: &Guard);
 }
 
@@ -83,10 +84,11 @@ pub struct Iter<'g, T, C: IsElement<T>> {
 }
 
 /// An error that occurs during iteration over the list.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IterError {
-    /// A concurrent thread modified the state of the list at the same place that this iterator
-    /// was inspecting. Subsequent iteration will restart from the beginning of the list.
+    /// A concurrent thread modified the state of the list at the same place
+    /// that this iterator was inspecting. Subsequent iteration will
+    /// restart from the beginning of the list.
     Stalled,
 }
 
@@ -98,13 +100,15 @@ impl Default for Entry {
 }
 
 impl Entry {
-    /// Marks this entry as deleted, deferring the actual deallocation to a later iteration.
+    /// Marks this entry as deleted, deferring the actual deallocation to a
+    /// later iteration.
     ///
     /// # Safety
     ///
-    /// The entry should be a member of a linked list, and it should not have been deleted.
-    /// It should be safe to call `C::finalize` on the entry after the `guard` is dropped, where `C`
-    /// is the associated helper for the linked list.
+    /// The entry should be a member of a linked list, and it should not have
+    /// been deleted. It should be safe to call `C::finalize` on the entry
+    /// after the `guard` is dropped, where `C` is the associated helper for
+    /// the linked list.
     pub unsafe fn delete(&self, guard: &Guard) {
         self.next.fetch_or(1, Release, guard);
     }
@@ -142,13 +146,13 @@ impl<T, C: IsElement<T>> List<T, C> {
         let mut next = to.load(Relaxed, guard);
 
         loop {
-            // Set the Entry of the to-be-inserted element to point to the previous successor of
-            // `to`.
+            // Set the Entry of the to-be-inserted element to point to the
+            // previous successor of `to`.
             entry.next.store(next, Relaxed);
             match to.compare_and_set_weak(next, entry_ptr, Release, guard) {
                 Ok(_) => break,
-                // We lost the race or weak CAS failed spuriously. Update the successor and try
-                // again.
+                // We lost the race or weak CAS failed spuriously. Update the
+                // successor and try again.
                 Err(err) => next = err.current,
             }
         }
@@ -158,14 +162,16 @@ impl<T, C: IsElement<T>> List<T, C> {
     ///
     /// # Caveat
     ///
-    /// Every object that is inserted at the moment this function is called and persists at least
-    /// until the end of iteration will be returned. Since this iterator traverses a lock-free
-    /// linked list that may be concurrently modified, some additional caveats apply:
+    /// Every object that is inserted at the moment this function is called and
+    /// persists at least until the end of iteration will be returned. Since
+    /// this iterator traverses a lock-free linked list that may be
+    /// concurrently modified, some additional caveats apply:
     ///
-    /// 1. If a new object is inserted during iteration, it may or may not be returned.
-    /// 2. If an object is deleted during iteration, it may or may not be returned.
-    /// 3. The iteration may be aborted when it lost in a race condition. In this case, the winning
-    ///    thread will continue to iterate over the same list.
+    /// 1. If a new object is inserted during iteration, it may or may not be
+    /// returned. 2. If an object is deleted during iteration, it may or may
+    /// not be returned. 3. The iteration may be aborted when it lost in a
+    /// race condition. In this case, the winning    thread will continue to
+    /// iterate over the same list.
     pub fn iter<'g>(&'g self, guard: &'g Guard) -> Iter<'g, T, C> {
         Iter {
             guard,
@@ -205,19 +211,23 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
                 // This entry was removed. Try unlinking it from the list.
                 let succ = succ.with_tag(0);
 
-                // The tag should always be zero, because removing a node after a logically deleted
-                // node leaves the list in an invalid state.
+                // The tag should always be zero, because removing a node after
+                // a logically deleted node leaves the list in
+                // an invalid state.
                 debug_assert!(self.curr.tag() == 0);
 
-                // Try to unlink `curr` from the list, and get the new value of `self.pred`.
+                // Try to unlink `curr` from the list, and get the new value of
+                // `self.pred`.
                 let succ = match self
                     .pred
                     .compare_and_set(self.curr, succ, Acquire, self.guard)
                 {
                     Ok(_) => {
-                        // We succeeded in unlinking `curr`, so we have to schedule
-                        // deallocation. Deferred drop is okay, because `list.delete()` can only be
-                        // called if `T: 'static`.
+                        // We succeeded in unlinking `curr`, so we have to
+                        // schedule deallocation.
+                        // Deferred drop is okay, because `list.delete()` can
+                        // only be called if `T:
+                        // 'static`.
                         unsafe {
                             C::finalize(self.curr.deref(), self.guard);
                         }
@@ -231,8 +241,8 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
                     }
                 };
 
-                // If the predecessor node is already marked as deleted, we need to restart from
-                // `head`.
+                // If the predecessor node is already marked as deleted, we need
+                // to restart from `head`.
                 if succ.tag() != 0 {
                     self.pred = self.head;
                     self.curr = self.head.load(Acquire, self.guard);

--- a/src/ebr/mod.rs
+++ b/src/ebr/mod.rs
@@ -79,12 +79,14 @@ impl Drop for Guard {
 
 #[inline]
 unsafe fn unprotected() -> &'static Guard {
-    // HACK(stjepang): An unprotected guard is just a `Guard` with its field `local` set to null.
-    // Since this function returns a `'static` reference to a `Guard`, we must return a reference
-    // to a global guard. However, it's not possible to create a `static` `Guard` because it does
-    // not implement `Sync`. To get around the problem, we create a static `usize` initialized to
-    // zero and then transmute it into a `Guard`. This is safe because `usize` and `Guard`
-    // (consisting of a single pointer) have the same representation in memory.
+    // HACK(stjepang): An unprotected guard is just a `Guard` with its field
+    // `local` set to null. Since this function returns a `'static`
+    // reference to a `Guard`, we must return a reference to a global guard.
+    // However, it's not possible to create a `static` `Guard` because it does
+    // not implement `Sync`. To get around the problem, we create a static
+    // `usize` initialized to zero and then transmute it into a `Guard`.
+    // This is safe because `usize` and `Guard` (consisting of a single
+    // pointer) have the same representation in memory.
     static UNPROTECTED: &[usize] = &[0_usize; std::mem::size_of::<Guard>()];
     #[allow(trivial_casts)]
     &*(UNPROTECTED as *const _ as *const Guard)

--- a/src/fastlock.rs
+++ b/src/fastlock.rs
@@ -60,10 +60,6 @@ impl<T> FastLock<T> {
 
         let success = lock_result.is_ok();
 
-        if success {
-            Some(FastLockGuard { mu: self })
-        } else {
-            None
-        }
+        if success { Some(FastLockGuard { mu: self }) } else { None }
     }
 }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -95,7 +95,7 @@ impl Debug for Histogram {
         for p in &PS {
             let res = self.percentile(*p).round();
             let line = format!("({} -> {}) ", p, res);
-            f.write_str(&*line)?;
+            f.write_str(&line)?;
         }
 
         f.write_str("]")
@@ -255,7 +255,7 @@ fn multithreaded() {
         }));
     }
 
-    for t in threads.into_iter() {
+    for t in threads {
         t.join().unwrap();
     }
 

--- a/src/ivec.rs
+++ b/src/ivec.rs
@@ -327,9 +327,9 @@ mod qc {
     fn ivec_as_mut_identity() {
         let initial = &[1];
         let mut iv = IVec::from(initial);
-        assert_eq!(&*initial, &*iv);
-        assert_eq!(&*initial, &mut *iv);
-        assert_eq!(&*initial, iv.as_mut());
+        assert_eq!(initial, &*iv);
+        assert_eq!(initial, &mut *iv);
+        assert_eq!(initial, iv.as_mut());
     }
 
     fn prop_identity(ivec: &IVec) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@
 #![cfg_attr(
     feature = "testing",
     warn(
-        clippy::missing_const_for_fn,
+        // clippy::missing_const_for_fn,
         clippy::multiple_crate_versions,
         // clippy::wildcard_enum_match_arm,
     )

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -148,7 +148,7 @@ impl Drop for AccessQueue {
         debug_delay();
         let writing = self.writing.load(Ordering::Acquire);
         unsafe {
-            Box::from_raw(writing);
+            drop(Box::from_raw(writing));
         }
         debug_delay();
         let mut head = self.full_list.load(Ordering::Acquire);
@@ -157,7 +157,7 @@ impl Drop for AccessQueue {
                 debug_delay();
                 let next =
                     (*head).next.swap(std::ptr::null_mut(), Ordering::Release);
-                Box::from_raw(head);
+                drop(Box::from_raw(head));
                 head = next;
             }
         }

--- a/src/pagecache/disk_pointer.rs
+++ b/src/pagecache/disk_pointer.rs
@@ -4,7 +4,7 @@ use super::{HeapId, LogOffset};
 use crate::*;
 
 /// A pointer to a location on disk or an off-log heap item.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiskPtr {
     /// Points to a value stored in the single-file log.
     Inline(LogOffset),
@@ -30,11 +30,7 @@ impl DiskPtr {
     }
 
     pub(crate) const fn heap_id(&self) -> Option<HeapId> {
-        if let DiskPtr::Heap(_, heap_id) = self {
-            Some(*heap_id)
-        } else {
-            None
-        }
+        if let DiskPtr::Heap(_, heap_id) = self { Some(*heap_id) } else { None }
     }
 
     #[doc(hidden)]

--- a/src/pagecache/iobuf.rs
+++ b/src/pagecache/iobuf.rs
@@ -774,10 +774,10 @@ impl IoBufs {
                 );
 
                 let sync_completion = if iobuf.from_tip {
-                    self.io_uring.fsync(&*self.config.file)
+                    self.io_uring.fsync(&self.config.file)
                 } else {
                     self.io_uring.sync_file_range(
-                        &*self.config.file,
+                        &self.config.file,
                         offset,
                         to_write.len(),
                     )
@@ -1013,7 +1013,10 @@ pub(in crate::pagecache) fn make_stable_inner(
 
     while stable < lsn {
         if let Err(e) = iobufs.config.global_error() {
-            error!("bailing out of stabilization code due to detected IO error: {:?}", e);
+            error!(
+                "bailing out of stabilization code due to detected IO error: {:?}",
+                e
+            );
             let intervals = iobufs.intervals.lock();
 
             // having held the mutex makes this linearized

--- a/src/pagecache/iterator.rs
+++ b/src/pagecache/iterator.rs
@@ -318,13 +318,7 @@ fn scan_segment_headers_and_tail(
     let f = &config.file;
     let file_len = f.metadata()?.len();
     let segments = (file_len / segment_len)
-        + if file_len % segment_len
-            < LogOffset::try_from(SEG_HEADER_LEN).unwrap()
-        {
-            0
-        } else {
-            1
-        };
+        + u64::from(file_len % segment_len >= LogOffset::try_from(SEG_HEADER_LEN).unwrap());
 
     trace!(
         "file len: {} segment len {} segments: {}",

--- a/src/pagecache/logger.rs
+++ b/src/pagecache/logger.rs
@@ -534,7 +534,7 @@ impl Drop for Log {
 }
 
 /// All log messages are prepended with this header
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct MessageHeader {
     pub crc32: u32,
     pub kind: MessageKind,
@@ -544,7 +544,7 @@ pub struct MessageHeader {
 }
 
 /// A number representing a segment number.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(transparent)]
 pub struct SegmentNumber(pub u64);
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -105,10 +105,9 @@ impl From<Error> for io::Error {
         use std::io::ErrorKind;
         match error {
             Io(kind, reason) => io::Error::new(kind, reason),
-            CollectionNotFound => io::Error::new(
-                ErrorKind::NotFound,
-                "collection not found"
-            ),
+            CollectionNotFound => {
+                io::Error::new(ErrorKind::NotFound, "collection not found")
+            }
             Unsupported(why) => io::Error::new(
                 ErrorKind::InvalidInput,
                 format!("operation not supported: {:?}", why),

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -421,11 +421,7 @@ impl Serialize for Option<i64> {
 
 fn shift_i64_opt(value_opt: &Option<i64>) -> i64 {
     if let Some(value) = value_opt {
-        if *value < 0 {
-            *value
-        } else {
-            value + 1
-        }
+        if *value < 0 { *value } else { value + 1 }
     } else {
         0
     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -77,7 +77,7 @@ where
             if written {
                 formatter.write_str(", ")?;
             }
-            formatter.write_str(&*format!("({:?}) ", &node))?;
+            formatter.write_str(&format!("({:?}) ", &node))?;
             node.fmt(formatter)?;
             written = true;
         }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -174,7 +174,7 @@ impl Future for Subscriber {
                     Ok(future_rx) => future_rx,
                     Err(TryRecvError::Empty) => break,
                     Err(TryRecvError::Disconnected) => {
-                        return Poll::Ready(None)
+                        return Poll::Ready(None);
                     }
                 }
             };

--- a/src/sys_limits.rs
+++ b/src/sys_limits.rs
@@ -114,9 +114,5 @@ pub fn get_memory_limit() -> Option<usize> {
     }
 
     let ret = usize::try_from(max).expect("cache limit not representable");
-    if ret == 0 {
-        None
-    } else {
-        Some(ret)
-    }
+    if ret == 0 { None } else { Some(ret) }
 }

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -219,7 +219,8 @@ mod queue {
         R: Send + 'static,
     {
         // Polyfill for platforms other than those we explicitly trust to
-        // perform threaded work on. Just execute a task without involving threads.
+        // perform threaded work on. Just execute a task without involving
+        // threads.
         let (promise_filler, promise) = OneShot::pair();
         promise_filler.fill((work)());
         promise

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -99,7 +99,7 @@ pub struct TransactionalTree {
 
 /// An error type that is returned from the closure
 /// passed to the `transaction` method.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnabortableTransactionError {
     /// An internal conflict has occurred and the `transaction` method will
     /// retry the passed-in closure until it succeeds. This should never be
@@ -155,7 +155,7 @@ impl<E> From<UnabortableTransactionError> for ConflictableTransactionError<E> {
 
 /// An error type that is returned from the closure
 /// passed to the `transaction` method.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConflictableTransactionError<T = Error> {
     /// A user-provided error type that indicates the transaction should abort.
     /// This is passed into the return value of `transaction` as a direct Err
@@ -198,7 +198,7 @@ impl<E: std::error::Error> std::error::Error
 
 /// An error type that is returned from the closure
 /// passed to the `transaction` method.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransactionError<T = Error> {
     /// A user-provided error type that indicates the transaction should abort.
     /// This is passed into the return value of `transaction` as a direct Err
@@ -266,7 +266,7 @@ impl TransactionalTree {
     {
         let old = self.get(key.as_ref())?;
         let mut writes = self.writes.borrow_mut();
-        let _last_write = writes.insert(key, value.into());
+        writes.insert(key, value.into());
         Ok(old)
     }
 
@@ -280,7 +280,7 @@ impl TransactionalTree {
     {
         let old = self.get(key.as_ref());
         let mut writes = self.writes.borrow_mut();
-        let _last_write = writes.remove(key);
+        writes.remove(key);
         old
     }
 
@@ -510,7 +510,7 @@ impl<E> Transactional<E> for &&Tree {
 
     fn make_overlay(&self) -> Result<TransactionalTrees> {
         Ok(TransactionalTrees {
-            inner: vec![TransactionalTree::from_tree(*self)],
+            inner: vec![TransactionalTree::from_tree(self)],
         })
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -20,7 +20,7 @@ impl<'g> Deref for View<'g> {
     type Target = Node;
 
     fn deref(&self) -> &Node {
-        &*self.node_view
+        &self.node_view
     }
 }
 
@@ -42,7 +42,7 @@ const fn bounds_error() -> Result<()> {
     Err(Error::Unsupported(
         "Keys and values are limited to \
         128gb on 64-bit platforms and
-        512mb on 32-bit platforms."
+        512mb on 32-bit platforms.",
     ))
 }
 
@@ -198,7 +198,7 @@ impl Tree {
         let mut subscriber_reservation = if is_transactional {
             None
         } else {
-            Some(self.subscribers.reserve(&key))
+            Some(self.subscribers.reserve(key))
         };
 
         let (encoded_key, last_value) = node_view.node_kv_pair(key.as_ref());
@@ -948,7 +948,7 @@ impl Tree {
         } else {
             Err(Error::ReportableBug(
                 "threadpool failed to complete \
-                action before shutdown"
+                action before shutdown",
             ))
         }
     }
@@ -1163,7 +1163,7 @@ impl Tree {
             return Err(Error::Unsupported(
                 "must set a merge operator on this Tree \
                  before calling merge by calling \
-                 Tree::set_merge_operator"
+                 Tree::set_merge_operator",
             ));
         }
 
@@ -1184,7 +1184,7 @@ impl Tree {
                 return Ok(Ok(new_opt));
             }
 
-            let mut subscriber_reservation = self.subscribers.reserve(&key);
+            let mut subscriber_reservation = self.subscribers.reserve(key);
 
             let frag = if let Some(ref new) = new_opt {
                 Link::Set(encoded_key, new.clone())

--- a/tests/test_crash_recovery.rs
+++ b/tests/test_crash_recovery.rs
@@ -111,7 +111,7 @@ fn verify(tree: &sled::Tree) -> (u32, u32) {
     // it should never return, or go down again after that
     let mut iter = tree.iter();
     let highest = match iter.next() {
-        Some(Ok((_k, v))) => slice_to_u32(&*v),
+        Some(Ok((_k, v))) => slice_to_u32(&v),
         Some(Err(e)) => panic!("{:?}", e),
         None => return (0, 0),
     };
@@ -131,7 +131,7 @@ fn verify(tree: &sled::Tree) -> (u32, u32) {
             } else {
                 (highest - 1) % CYCLE as u32
             };
-            let actual = slice_to_u32(&*v);
+            let actual = slice_to_u32(&v);
             assert_eq!(expected, actual);
             lowest = actual;
             break;
@@ -144,12 +144,12 @@ fn verify(tree: &sled::Tree) -> (u32, u32) {
     for res in tree.range(&*low_beginning..) {
         let (k, v): (sled::IVec, _) = res.unwrap();
         assert_eq!(
-            slice_to_u32(&*v),
+            slice_to_u32(&v),
             lowest,
             "expected key {} to have value {}, instead it had value {} in db: {:?}",
-            slice_to_u32(&*k),
+            slice_to_u32(&k),
             lowest,
-            slice_to_u32(&*v),
+            slice_to_u32(&v),
             tree
         );
     }
@@ -220,7 +220,7 @@ fn run_inner(config: Config) {
 fn verify_batches(tree: &sled::Tree) -> u32 {
     let mut iter = tree.iter();
     let first_value = match iter.next() {
-        Some(Ok((_k, v))) => slice_to_u32(&*v),
+        Some(Ok((_k, v))) => slice_to_u32(&v),
         Some(Err(e)) => panic!("{:?}", e),
         None => return 0,
     };
@@ -234,7 +234,7 @@ fn verify_batches(tree: &sled::Tree) -> u32 {
                 key, tree
             ),
         };
-        let value = slice_to_u32(&*v);
+        let value = slice_to_u32(&v);
         assert_eq!(
             first_value, value,
             "expected key {} to have value {}, instead it had value {} in db: {:?}",
@@ -283,7 +283,7 @@ fn run_crash_recovery() {
     let config = Config::new()
         .cache_capacity(128 * 1024 * 1024)
         .flush_every_ms(Some(1))
-        .path(RECOVERY_DIR.to_string())
+        .path(RECOVERY_DIR)
         .segment_size(SEGMENT_SIZE);
 
     if let Err(e) = thread::spawn(|| run_inner(config)).join() {
@@ -302,7 +302,7 @@ fn run_crash_batches() {
     let config = Config::new()
         .cache_capacity(128 * 1024 * 1024)
         .flush_every_ms(Some(1))
-        .path(BATCHES_DIR.to_string())
+        .path(BATCHES_DIR)
         .segment_size(SEGMENT_SIZE);
 
     let db = config.open().unwrap();

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -90,7 +90,7 @@ fn fixed_stride_inserts() {
 
     let mut expected = std::collections::HashSet::new();
     for k in 0..4096_u16 {
-        db.insert(&k.to_be_bytes(), &[]).unwrap();
+        db.insert(k.to_be_bytes(), &[]).unwrap();
         expected.insert(k.to_be_bytes().to_vec());
     }
 
@@ -107,7 +107,7 @@ fn fixed_stride_inserts() {
     assert_eq!(count, 4096);
 
     for k in 0..4096_u16 {
-        db.insert(&k.to_be_bytes(), &[1]).unwrap();
+        db.insert(k.to_be_bytes(), &[1]).unwrap();
     }
 
     let count = db.iter().count();
@@ -118,7 +118,7 @@ fn fixed_stride_inserts() {
     assert_eq!(db.len(), 4096);
 
     for k in 0..4096_u16 {
-        db.remove(&k.to_be_bytes()).unwrap();
+        db.remove(k.to_be_bytes()).unwrap();
     }
 
     let count = db.iter().count();
@@ -139,7 +139,7 @@ fn sequential_inserts() {
 
     for len in [1, 16, 32, u16::MAX].iter() {
         for i in 0..*len {
-            db.insert(&i.to_le_bytes(), &[]).unwrap();
+            db.insert(i.to_le_bytes(), &[]).unwrap();
         }
 
         let count = db.iter().count();
@@ -160,7 +160,7 @@ fn reverse_inserts() {
     for len in [1, 16, 32, u16::MAX].iter() {
         for i in 0..*len {
             let i2 = u16::MAX - i;
-            db.insert(&i2.to_le_bytes(), &[]).unwrap();
+            db.insert(i2.to_le_bytes(), &[]).unwrap();
         }
 
         let count = db.iter().count();
@@ -428,7 +428,7 @@ fn concurrent_tree_iter() -> Result<()> {
     ];
 
     for item in &INDELIBLE {
-        t.insert(item.to_vec(), item.to_vec())?;
+        t.insert(item, item.to_vec())?;
     }
 
     let barrier = Arc::new(Barrier::new(N_FORWARD + N_REVERSE + 2));
@@ -764,7 +764,7 @@ fn tree_subdir() {
 
     let t = config.open().unwrap();
 
-    t.insert(&[1], vec![1]).unwrap();
+    t.insert([1], vec![1]).unwrap();
 
     drop(t);
 
@@ -876,11 +876,11 @@ fn tree_subscribers_and_keyspaces() -> Result<()> {
 
     let db = config.open().unwrap();
 
-    let t1 = db.open_tree(b"1".to_vec())?;
-    let mut s1 = t1.watch_prefix(b"".to_vec());
+    let t1 = db.open_tree(b"1")?;
+    let mut s1 = t1.watch_prefix(b"");
 
-    let t2 = db.open_tree(b"2".to_vec())?;
-    let mut s2 = t2.watch_prefix(b"".to_vec());
+    let t2 = db.open_tree(b"2")?;
+    let mut s2 = t2.watch_prefix(b"");
 
     t1.insert(b"t1_a", b"t1_a".to_vec())?;
     t2.insert(b"t2_a", b"t2_a".to_vec())?;
@@ -898,11 +898,11 @@ fn tree_subscribers_and_keyspaces() -> Result<()> {
 
     let db = config.open().unwrap();
 
-    let t1 = db.open_tree(b"1".to_vec())?;
-    let mut s1 = t1.watch_prefix(b"".to_vec());
+    let t1 = db.open_tree(b"1")?;
+    let mut s1 = t1.watch_prefix(b"");
 
-    let t2 = db.open_tree(b"2".to_vec())?;
-    let mut s2 = t2.watch_prefix(b"".to_vec());
+    let t2 = db.open_tree(b"2")?;
+    let mut s2 = t2.watch_prefix(b"");
 
     assert!(db.is_empty());
     assert_eq!(t1.len(), 1);
@@ -924,8 +924,8 @@ fn tree_subscribers_and_keyspaces() -> Result<()> {
 
     let db = config.open().unwrap();
 
-    let t1 = db.open_tree(b"1".to_vec())?;
-    let t2 = db.open_tree(b"2".to_vec())?;
+    let t1 = db.open_tree(b"1")?;
+    let t2 = db.open_tree(b"2")?;
 
     assert!(db.is_empty());
     assert_eq!(t1.len(), 2);
@@ -948,8 +948,8 @@ fn tree_subscribers_and_keyspaces() -> Result<()> {
 
     let db = config.open().unwrap();
 
-    let t1 = db.open_tree(b"1".to_vec())?;
-    let t2 = db.open_tree(b"2".to_vec())?;
+    let t1 = db.open_tree(b"1")?;
+    let t2 = db.open_tree(b"2")?;
 
     assert!(db.is_empty());
     assert_eq!(t1.len(), 0);

--- a/tests/test_tree_failpoints.rs
+++ b/tests/test_tree_failpoints.rs
@@ -395,7 +395,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 reference_entry.crash_epoch = crash_counter;
 
                 fp_crash!(tree.insert(
-                    &u16::to_be_bytes(set_counter),
+                    u16::to_be_bytes(set_counter),
                     value_factory(set_counter),
                 ));
 
@@ -485,9 +485,10 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                     if reference_entry.versions.len() > 1
                         && reference_entry.crash_epoch == crash_counter
                     {
-                        let last = std::mem::take(&mut reference_entry.versions)
-                        .pop()
-                        .unwrap();
+                        let last =
+                            std::mem::take(&mut reference_entry.versions)
+                                .pop()
+                                .unwrap();
                         reference_entry.versions.push(last);
                     }
                 }
@@ -496,7 +497,7 @@ fn run_tree_crashes_nicely(ops: Vec<Op>, flusher: bool) -> bool {
                 restart!();
             }
             FailPoint(fp, bitset) => {
-                sled::fail::set(&*fp, bitset);
+                sled::fail::set(fp, bitset);
             }
         }
     }

--- a/tests/tree/mod.rs
+++ b/tests/tree/mod.rs
@@ -15,7 +15,7 @@ impl fmt::Debug for Key {
             write!(
                 f,
                 "Key(vec![{}; {}])",
-                self.0.get(0).copied().unwrap_or(0),
+                self.0.first().copied().unwrap_or(0),
                 self.0.len()
             )
         } else {
@@ -59,7 +59,7 @@ impl RngCore for SledGen {
 pub fn fuzz_then_shrink(buf: &[u8]) {
     let use_compression = cfg!(feature = "compression")
         && !cfg!(miri)
-        && buf.get(0).unwrap_or(&0) % 2 == 0;
+        && buf.first().unwrap_or(&0) % 2 == 0;
 
     let ops: Vec<Op> = buf
         .chunks(2)
@@ -262,7 +262,7 @@ fn prop_tree_matches_btreemap_inner(
                 let old_actual = tree.insert(&k.0, vec![0, v]).unwrap();
                 let old_reference = reference.insert(k.clone(), u16::from(v));
                 assert_eq!(
-                    old_actual.map(|v| bytes_to_u16(&*v)),
+                    old_actual.map(|v| bytes_to_u16(&v)),
                     old_reference,
                     "when setting key {:?}, expected old returned value to be {:?}\n{:?}",
                     k,
@@ -276,7 +276,7 @@ fn prop_tree_matches_btreemap_inner(
                 *entry += u16::from(v);
             }
             Get(k) => {
-                let res1 = tree.get(&*k.0).unwrap().map(|v| bytes_to_u16(&*v));
+                let res1 = tree.get(&*k.0).unwrap().map(|v| bytes_to_u16(&v));
                 let res2 = reference.get(&k).cloned();
                 assert_eq!(res1, res2);
             }


### PR DESCRIPTION
Add clippy and formatting fixes to allow CI to pass (#1418).