### PR TITLE
Wrong atomic ordering in clone

### DIFF
--- a/src/ivec.rs
+++ b/src/ivec.rs
@@ -23,7 +23,7 @@ pub struct IVec([u8; SZ]);
 impl Clone for IVec {
     fn clone(&self) -> IVec {
         if !self.is_inline() {
-            self.deref_header().rc.fetch_add(1, Ordering::Relaxed);
+            self.deref_header().rc.fetch_add(1, Ordering::Acquire);
         }
         IVec(self.0)
     }


### PR DESCRIPTION
https://github.com/spacejam/sled/blob/69294e59c718289ab3cb6bd03ac3b9e1e072a1e7/src/ivec.rs#L24-L29
https://github.com/spacejam/sled/blob/69294e59c718289ab3cb6bd03ac3b9e1e072a1e7/src/ivec.rs#L33-L50
https://github.com/spacejam/sled/blob/69294e59c718289ab3cb6bd03ac3b9e1e072a1e7/src/ivec.rs#L26
Use of Ordering::Relaxed is incorrect. The compiler is free to reorder, which may cause the result of the IVec(self.0) in thread 1 to be stored in hardware before the execution rc.fetch_add(suppose the clone function is executed in thread 1), if rc is 1 and the drop function is executed in thread 2, rc is judged to be 0 (at this point there is no execution rc.fetch_add in thread 1), which will cause the IVec (self.0) returned by thread 1 to have been freed . It should be Ordering::Acquire instead.