### PR TITLE
Rename "testing" feature to "for-internal-testing-only"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     - name: cargo test
       run: |
         rustup update --no-self-update
-        cargo test --release --no-default-features --features=testing -- --nocapture
+        cargo test --release --no-default-features --features=for-internal-testing-only -- --nocapture
     - uses: actions/upload-artifact@v2
       if: ${{ failure() && runner.os == 'linux' }}
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,7 @@ overflow-checks = true
 
 [features]
 default = []
-# Do not use the "testing" feature in your own testing code, this is for
-# internal testing use only. It injects many delays and performs several
-# test-only configurations that cause performance to drop significantly.
-# It will cause your tests to take much more time, and possibly time out etc...
-testing = ["event_log", "lock_free_delays", "light_testing"]
+for-internal-testing-only = ["event_log", "lock_free_delays", "light_testing"]
 light_testing = ["failpoints", "backtrace", "memshred"]
 lock_free_delays = []
 failpoints = []

--- a/scripts/cgtest.sh
+++ b/scripts/cgtest.sh
@@ -5,7 +5,7 @@ cgdelete memory:sledTest || true
 cgcreate -g memory:sledTest
 echo 100M > /sys/fs/cgroup/memory/sledTest/memory.limit_in_bytes
 
-su $SUDO_USER -c 'cargo build --release --features=testing'
+su $SUDO_USER -c 'cargo build --release --features=for-internal-testing-only'
 
 for test in target/release/deps/test*; do
   if [[ -x $test ]]

--- a/src/concurrency_control.rs
+++ b/src/concurrency_control.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "testing")]
+#[cfg(feature = "for-internal-testing-only")]
 use std::cell::RefCell;
 use std::sync::atomic::AtomicBool;
 
@@ -6,7 +6,7 @@ use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 
 use super::*;
 
-#[cfg(feature = "testing")]
+#[cfg(feature = "for-internal-testing-only")]
 thread_local! {
     pub static COUNT: RefCell<u32> = RefCell::new(0);
 }
@@ -42,7 +42,7 @@ impl<'a> Drop for Protector<'a> {
         if let Protector::None(active) = self {
             active.fetch_sub(1, Release);
         }
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         COUNT.with(|c| {
             let mut c = c.borrow_mut();
             *c -= 1;
@@ -73,7 +73,7 @@ impl ConcurrencyControl {
     }
 
     fn read(&self) -> Protector<'_> {
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         COUNT.with(|c| {
             let mut c = c.borrow_mut();
             *c += 1;
@@ -91,7 +91,7 @@ impl ConcurrencyControl {
     }
 
     fn write(&self) -> Protector<'_> {
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         COUNT.with(|c| {
             let mut c = c.borrow_mut();
             *c += 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -234,7 +234,7 @@ impl Default for Inner {
             segment_size: 512 * 1024, // 512kb in bytes
             flush_every_ms: Some(500),
             idgen_persist_interval: 1_000_000,
-            snapshot_after_ops: if cfg!(feature = "testing") {
+            snapshot_after_ops: if cfg!(feature = "for-internal-testing-only") {
                 10
             } else {
                 1_000_000
@@ -538,7 +538,7 @@ impl Config {
             use fs2::FileExt;
 
             let try_lock =
-                if cfg!(any(feature = "testing", feature = "light_testing")) {
+                if cfg!(any(feature = "for-internal-testing-only", feature = "light_testing")) {
                     // we block here because during testing
                     // there are many filesystem race condition
                     // that happen, causing locks to be held

--- a/src/ebr/internal.rs
+++ b/src/ebr/internal.rs
@@ -283,7 +283,7 @@ impl Global {
 
         let global_epoch = self.try_advance(guard);
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         let mut count = 0;
 
         for _ in 0..steps {
@@ -295,7 +295,7 @@ impl Global {
                 Some(sealed_bag) => {
                     drop(sealed_bag);
 
-                    #[cfg(feature = "testing")]
+                    #[cfg(feature = "for-internal-testing-only")]
                     {
                         count += 1;
                     }
@@ -303,7 +303,7 @@ impl Global {
             }
         }
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         {
             if count > 0 && SIZE_HINT.load(Ordering::Relaxed) > 5000 {
                 static O: std::sync::Once = std::sync::Once::new();
@@ -473,7 +473,7 @@ impl Local {
     pub(super) fn pin(&self) -> Guard {
         let guard = Guard {
             local: self,
-            #[cfg(feature = "testing")]
+            #[cfg(feature = "for-internal-testing-only")]
             began: std::time::Instant::now(),
         };
 

--- a/src/ebr/mod.rs
+++ b/src/ebr/mod.rs
@@ -25,7 +25,7 @@ use internal::Local;
 
 pub struct Guard {
     pub(super) local: *const Local,
-    #[cfg(feature = "testing")]
+    #[cfg(feature = "for-internal-testing-only")]
     pub(super) began: std::time::Instant,
 }
 
@@ -68,7 +68,7 @@ impl Drop for Guard {
             local.unpin();
         }
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         {
             if self.began.elapsed() > std::time::Duration::from_secs(1) {
                 log::warn!("guard lived longer than allowed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
     html_logo_url = "https://raw.githubusercontent.com/spacejam/sled/main/art/tree_face_anti-transphobia.png"
 )]
 #![cfg_attr(
-    feature = "testing",
+    feature = "for-internal-testing-only",
     deny(
         missing_docs,
         future_incompatible,
@@ -97,7 +97,7 @@
         unused_qualifications,
     )
 )]
-#![cfg_attr(feature = "testing", deny(
+#![cfg_attr(feature = "for-internal-testing-only", deny(
     // over time, consider enabling the commented-out lints below
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -153,7 +153,7 @@
     clippy::wildcard_dependencies,
 ))]
 #![cfg_attr(
-    feature = "testing",
+    feature = "for-internal-testing-only",
     warn(
         clippy::missing_const_for_fn,
         clippy::multiple_crate_versions,
@@ -177,7 +177,7 @@ macro_rules! io_fail {
 
 macro_rules! testing_assert {
     ($($e:expr),*) => {
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         assert!($($e),*)
     };
 }
@@ -401,28 +401,28 @@ pub(crate) enum Link {
 
 /// A fast map that is not resistant to collision attacks. Works
 /// on 8 bytes at a time.
-#[cfg(not(feature = "testing"))]
+#[cfg(not(feature = "for-internal-testing-only"))]
 pub(crate) type FastMap8<K, V> =
     std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fnv::Hasher>>;
 
-#[cfg(feature = "testing")]
+#[cfg(feature = "for-internal-testing-only")]
 pub(crate) type FastMap8<K, V> = BTreeMap<K, V>;
 
 /// A fast set that is not resistant to collision attacks. Works
 /// on 8 bytes at a time.
-#[cfg(not(feature = "testing"))]
+#[cfg(not(feature = "for-internal-testing-only"))]
 pub(crate) type FastSet8<V> =
     std::collections::HashSet<V, std::hash::BuildHasherDefault<fnv::Hasher>>;
 
-#[cfg(feature = "testing")]
+#[cfg(feature = "for-internal-testing-only")]
 pub(crate) type FastSet8<V> = std::collections::BTreeSet<V>;
 
-#[cfg(not(feature = "testing"))]
+#[cfg(not(feature = "for-internal-testing-only"))]
 use std::collections::HashMap as Map;
 
 // we avoid HashMap while testing because
 // it makes tests non-deterministic
-#[cfg(feature = "testing")]
+#[cfg(feature = "for-internal-testing-only")]
 use std::collections::{BTreeMap as Map, BTreeSet as Set};
 
 /// A function that may be configured on a particular shared `Tree`

--- a/src/node.rs
+++ b/src/node.rs
@@ -757,7 +757,7 @@ impl Node {
             &items,
         );
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         {
             let orig_ivec_pairs: Vec<_> = self
                 .iter()
@@ -813,7 +813,7 @@ impl Node {
             inner: Arc::new(left.receive_merge(&right)),
         };
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         {
             let orig_ivec_pairs: Vec<_> = self
                 .iter()
@@ -844,7 +844,7 @@ impl Node {
         let rhs =
             Node { inner: Arc::new(rhs_inner), overlay: Default::default() };
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         {
             let orig_ivec_pairs: Vec<_> = self
                 .iter()
@@ -1584,7 +1584,7 @@ impl Inner {
             fixed_key_stride
         );
 
-        #[cfg(feature = "testing")]
+        #[cfg(feature = "for-internal-testing-only")]
         {
             for i in 0..items.len() {
                 if fixed_key_length.is_none() || fixed_value_length.is_none() {
@@ -2450,7 +2450,7 @@ impl Inner {
         &self.lo()[..self.prefix_len as usize]
     }
 
-    #[cfg(feature = "testing")]
+    #[cfg(feature = "for-internal-testing-only")]
     fn is_sorted(&self) -> bool {
         if self.fixed_key_stride.is_some() {
             return true;

--- a/src/pagecache/heap.rs
+++ b/src/pagecache/heap.rs
@@ -18,10 +18,10 @@ use crate::{
     Error, Lsn, Result,
 };
 
-#[cfg(not(feature = "testing"))]
+#[cfg(not(feature = "for-internal-testing-only"))]
 pub(crate) const MIN_SZ: u64 = 32 * 1024;
 
-#[cfg(feature = "testing")]
+#[cfg(feature = "for-internal-testing-only")]
 pub(crate) const MIN_SZ: u64 = 128;
 
 const MIN_TRAILING_ZEROS: u64 = MIN_SZ.trailing_zeros() as u64;


### PR DESCRIPTION
Rather than having a feature named "testing" that external users might
be tempted to incorrectly use (and a detailed comment discouraging them,
which people may or may not see), rename the feature to
"for-internal-testing-only" so that nobody gets any wrong ideas about
whether it's meant for them.
