### PR TITLE
bloodstone: A few nits

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -615,7 +615,7 @@ impl<
         let to_evict = ca.accessed_reuse_buffer(node_id.0, size);
         for (node_to_evict, _rough_size) in to_evict {
             let low_key =
-                self.node_id_to_low_key_index.get(&node_to_evict).unwrap();
+                self.node_id_to_low_key_index.get(node_to_evict).unwrap();
             let node = self.index.get(&low_key).unwrap();
             let mut write = node.inner.write();
             if write.is_none() {
@@ -1203,14 +1203,14 @@ impl<
                 let leaf = w.as_ref().unwrap();
                 assert!(&leaf.lo <= key);
                 if let Some(hi) = &leaf.hi {
-                    if hi <= &key {
+                    if hi <= key {
                         let (lo, w, id) = last.take().unwrap();
                         acquired_locks.insert(lo, (w, id));
                     }
                 }
             }
             if last.is_none() {
-                last = Some(self.page_in(&key)?);
+                last = Some(self.page_in(key)?);
             }
         }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1190,7 +1190,7 @@ impl<
             NodeId,
         )> = None;
 
-        for (key, _value) in &batch.writes {
+        for key in batch.writes.keys() {
             if let Some((_lo, w, _id)) = &last {
                 let leaf = w.as_ref().unwrap();
                 assert!(&leaf.lo <= key);
@@ -1218,7 +1218,7 @@ impl<
 
         // Flush any leaves that are dirty from a previous flush epoch
         // before performing operations.
-        for (_, (write, node_id)) in &mut acquired_locks {
+        for (write, node_id) in acquired_locks.values_mut() {
             let leaf = write.as_mut().unwrap();
             if let Some(old_flush_epoch) = leaf.dirty_flush_epoch {
                 if old_flush_epoch != new_epoch {
@@ -1771,8 +1771,7 @@ impl<
     /// for the duration of the entire scan.
     pub fn checksum(&self) -> io::Result<u32> {
         let mut hasher = crc32fast::Hasher::new();
-        let mut iter = self.iter();
-        while let Some(kv_res) = iter.next() {
+        for kv_res in self.iter() {
             let (k, v) = kv_res?;
             hasher.update(&k);
             hasher.update(&v);

--- a/src/db.rs
+++ b/src/db.rs
@@ -1483,7 +1483,7 @@ impl<
         let mut upper = prefix_ref.to_vec();
 
         while let Some(last) = upper.pop() {
-            if last < u8::max_value() {
+            if last < u8::MAX {
                 upper.push(last + 1);
                 return self.range(prefix_ref..&upper);
             }

--- a/src/db.rs
+++ b/src/db.rs
@@ -431,9 +431,9 @@ impl<
 
             let leaf = read.as_ref().unwrap();
 
-            assert!(&*leaf.lo <= key.as_ref());
+            assert!(&*leaf.lo <= key);
             if let Some(ref hi) = leaf.hi {
-                if &**hi < key.as_ref() {
+                if &**hi < key {
                     log::trace!("key overshoot on leaf_for_key");
                     continue;
                 }
@@ -534,9 +534,9 @@ impl<
             }
             let leaf = write.as_mut().unwrap();
 
-            assert!(&*leaf.lo <= key.as_ref());
+            assert!(&*leaf.lo <= key);
             if let Some(ref hi) = leaf.hi {
-                if &**hi < key.as_ref() {
+                if &**hi < key {
                     let size = leaf.in_memory_size;
                     drop(write);
                     log::trace!("key overshoot in leaf_for_key_mut_inner");
@@ -560,9 +560,9 @@ impl<
         let flush_epoch_guard = self.flush_epoch.check_in();
 
         let leaf = write.as_mut().unwrap();
-        assert!(&*leaf.lo <= key.as_ref());
+        assert!(&*leaf.lo <= key);
         if let Some(ref hi) = leaf.hi {
-            assert!(&**hi > key.as_ref());
+            assert!(&**hi > key);
         }
 
         if let Some(old_flush_epoch) = leaf.dirty_flush_epoch {

--- a/src/db.rs
+++ b/src/db.rs
@@ -702,7 +702,7 @@ impl<
         let mut leaf_guard = self.leaf_for_key_mut(key_ref)?;
         let new_epoch = leaf_guard.flush_epoch_guard.epoch();
 
-        let leaf = &mut leaf_guard.leaf_write.as_mut().unwrap();
+        let leaf = leaf_guard.leaf_write.as_mut().unwrap();
 
         // TODO handle prefix encoding
 
@@ -759,7 +759,7 @@ impl<
         let mut leaf_guard = self.leaf_for_key_mut(key_ref)?;
         let new_epoch = leaf_guard.flush_epoch_guard.epoch();
 
-        let leaf = &mut leaf_guard.leaf_write.as_mut().unwrap();
+        let leaf = leaf_guard.leaf_write.as_mut().unwrap();
 
         // TODO handle prefix encoding
 
@@ -936,7 +936,7 @@ impl<
 
         let proposed: Option<InlineArray> = new.map(Into::into);
 
-        let leaf = &mut leaf_guard.leaf_write.as_mut().unwrap();
+        let leaf = leaf_guard.leaf_write.as_mut().unwrap();
 
         // TODO handle prefix encoding
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -361,7 +361,7 @@ impl Slab {
             crc32fast::hash(&data[..self.slot_size - 4]).to_le_bytes();
         let hash_expected = &data[self.slot_size - 4..];
 
-        if hash_expected != &hash_actual {
+        if hash_expected != hash_actual {
             return Err(annotate!(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "crc mismatch - data corruption detected"

--- a/src/metadata_store.rs
+++ b/src/metadata_store.rs
@@ -238,9 +238,9 @@ impl MetadataStore {
         let path = storage_directory.as_ref();
 
         // initialize directories if not present
-        if let Err(e) = fs::read_dir(&path) {
+        if let Err(e) = fs::read_dir(path) {
             if e.kind() == io::ErrorKind::NotFound {
-                fallible!(fs::create_dir_all(&path));
+                fallible!(fs::create_dir_all(path));
             }
         }
 
@@ -293,7 +293,7 @@ impl MetadataStore {
 
         log::debug!("opening MetadataStore at {:?}", path);
 
-        let (log_ids, snapshot_id_opt) = enumerate_logs_and_snapshot(&path)?;
+        let (log_ids, snapshot_id_opt) = enumerate_logs_and_snapshot(path)?;
 
         read_snapshot_and_apply_logs(
             path,
@@ -660,7 +660,7 @@ fn read_snapshot_and_apply_logs(
                 assert!(*log_id > snapshot_id);
             }
 
-            let log_datum = read_log(&path, *log_id)?;
+            let log_datum = read_log(path, *log_id)?;
 
             Ok((*log_id, log_datum))
         })

--- a/src/metadata_store.rs
+++ b/src/metadata_store.rs
@@ -517,7 +517,7 @@ fn read_log(
     let mut reusable_frame_buffer: Vec<u8> = vec![];
 
     while let Ok(frame) = read_frame(&mut file, &mut reusable_frame_buffer) {
-        for (k, v) in frame.into_iter() {
+        for (k, v) in frame {
             ret.insert(k, v);
         }
     }

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -829,7 +829,7 @@ fn tree_big_keys_iterator() {
     fn kv(i: usize) -> Vec<u8> {
         let k = [(i >> 16) as u8, (i >> 8) as u8, i as u8];
 
-        let mut base = vec![0; u8::max_value() as usize];
+        let mut base = vec![0; u8::MAX as usize];
         base.extend_from_slice(&k);
         base
     }


### PR DESCRIPTION
Fixes a few clippy lints and makes it so that `as_ref` is only called once on keys (out of concern for impure `AsRef` implementations).