### PR TITLE
sled 1.0 alpha merges and storage refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ opt-level = 3
 overflow-checks = true
 panic = "abort"
 
+[profile.test]
+debug = true
+overflow-checks = true
+panic = "abort"
+
 [dependencies]
 bincode = "1.3.3"
 cache-advisor = "1.0.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,13 @@
-// TODO change dirty to work with NodeId or Node, to account for
-//      split/merge/split within flush epochs
+// TODO put aborts behind feature flags for hard crashes
 // TODO implement tree node merges when batches remove items
 // TODO heap maintenance w/ speculative write followed by CAS in pt
 //      maybe with global writer lock that controls flushers too
-// TODO allow waiting flusher to start collecting dirty pages
+// TODO allow waiting flusher to start collecting dirty pages as soon
+//      as it is evacuated - just wait until last flush is done before
+//      we persist the batch
 // TODO serialize flush batch in parallel
 // TODO add failpoints to writepath
-// TODO better formalize the need to only insert into dirty if we have a valid
-//      flush epoch guard for the dirty epoch, and only use CAS otherwise
-//      to avoid inserting bytes for already-serialized data
 // TODO re-enable transaction tests in test_tree.rs
-// TODO free empty leaves with try_lock on left sibling, set hi key, remove from indexes, store deletion in metadata_store
 // TODO set explicit max key and value sizes w/ corresponding heap
 // TODO skim inlining output of RUSTFLAGS="-Cremark=all -Cdebuginfo=1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// TODO change dirty to work with NodeId or Node, to account for
+//      split/merge/split within flush epochs
+// TODO implement tree node merges when batches remove items
 // TODO heap maintenance w/ speculative write followed by CAS in pt
 //      maybe with global writer lock that controls flushers too
 // TODO allow waiting flusher to start collecting dirty pages
@@ -9,6 +12,7 @@
 // TODO re-enable transaction tests in test_tree.rs
 // TODO free empty leaves with try_lock on left sibling, set hi key, remove from indexes, store deletion in metadata_store
 // TODO set explicit max key and value sizes w/ corresponding heap
+// TODO skim inlining output of RUSTFLAGS="-Cremark=all -Cdebuginfo=1"
 
 // NB: this macro must appear before the following mod statements
 // for it to be usable within them. One of the few places where
@@ -56,7 +60,7 @@ pub fn open<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Db> {
     Config::new().path(path).open()
 }
 
-use crate::flush_epoch::{FlushEpoch, FlushEpochGuard};
+use crate::flush_epoch::{FlushEpoch, FlushEpochGuard, FlushEpochTracker};
 
 /// Compare and swap result.
 ///
@@ -106,8 +110,13 @@ impl std::error::Error for CompareAndSwapError {}
     Ord,
     PartialEq,
     Eq,
+    Hash,
 )]
 struct NodeId(u64);
+
+impl concurrent_map::Minimum for NodeId {
+    const MIN: NodeId = NodeId(u64::MIN);
+}
 
 const fn _assert_public_types_send_sync() {
     use std::fmt::Debug;

--- a/src/metadata_store.rs
+++ b/src/metadata_store.rs
@@ -715,13 +715,13 @@ fn read_snapshot_and_apply_logs(
     let mut recovered: FnvHashMap<NodeId, (NonZeroU64, InlineArray)> =
         snapshot_rx.recv().unwrap()?;
 
-    println!("recovered snapshot contains {recovered:?}");
+    log::trace!("recovered snapshot contains {recovered:?}");
 
     for (log_id, log_datum) in log_data_res? {
         max_log_id = max_log_id.max(log_id);
 
         for (k, (v, user_data)) in log_datum {
-            println!("recovery of log contained location {v:?} for object id {k:?} user_data {user_data:?}");
+            log::trace!("recovery of log contained location {v:?} for object id {k:?} user_data {user_data:?}");
             if v == 0 {
                 recovered.remove(&k);
             } else {

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -1096,10 +1096,16 @@ fn recover_tree() {
     }
     drop(t);
 
+    println!("---------------- recovering a (hopefully) empty db ----------------------");
+
     let t: sled::Db<7> = config.open().unwrap();
     for i in 0..N_PER_THREAD {
         let k = kv(i as usize);
-        assert!(t.get(&*k).unwrap().is_none());
+        assert!(
+            t.get(&*k).unwrap().is_none(),
+            "expected key {:?} to have been deleted",
+            i
+        );
     }
 }
 


### PR DESCRIPTION
This starts freeing empty tree nodes to allow their memory to be reclaimed and fixes a number of race conditions related to the previous way that dirty pages were being tracked. A separate PR will add reclamation for the heap-based on-disk storage system.