### PR TITLE
Fix unused Box linter warning.

### DIFF
--- a/src/lru.rs
+++ b/src/lru.rs
@@ -148,7 +148,7 @@ impl Drop for AccessQueue {
         debug_delay();
         let writing = self.writing.load(Ordering::Acquire);
         unsafe {
-            Box::from_raw(writing);
+            drop(Box::from_raw(writing));
         }
         debug_delay();
         let mut head = self.full_list.load(Ordering::Acquire);
@@ -157,7 +157,7 @@ impl Drop for AccessQueue {
                 debug_delay();
                 let next =
                     (*head).next.swap(std::ptr::null_mut(), Ordering::Release);
-                Box::from_raw(head);
+                drop(Box::from_raw(head));
                 head = next;
             }
         }


### PR DESCRIPTION
`cargo check` is not happy with original code
```
    = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
151 |             let _ = Box::from_raw(writing);
    |             +++++++
```
and adding `drop` is not only recommended but also makes the intent explicit.