### PR TITLE
Lossy signature for Tree::set_merge_operator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "rust-analyzer.cargo.features": [
-        "light_testing"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.features": [
+        "light_testing"
+    ]
+}

--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -53,7 +53,7 @@ fn merge_operator() -> Result<()> {
     let config = Config::new().temporary(true);
 
     let db = config.open()?;
-    db.set_merge_operator(concatenate_merge);
+    db.set_merge_operator(Box::new(concatenate_merge));
 
     let k = b"k".to_vec();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ use std::collections::{BTreeMap as Map, BTreeSet as Set};
 ///   .temporary(true);
 ///
 /// let tree = config.open()?;
-/// tree.set_merge_operator(concatenate_merge);
+/// tree.set_merge_operator(Box::new(concatenate_merge));
 ///
 /// let k = b"k1";
 ///

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1421,7 +1421,7 @@ impl Tree {
         while let Some(last) = upper.pop() {
             if last < u8::max_value() {
                 upper.push(last + 1);
-                return self.range(prefix_ref..&upper);
+                return self.range(prefix_ref..upper.as_ref());
             }
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1114,7 +1114,7 @@ impl Tree {
     ///   Some(ret)
     /// }
     ///
-    /// db.set_merge_operator(concatenate_merge);
+    /// db.set_merge_operator(Box::new(concatenate_merge));
     ///
     /// let k = b"k1";
     ///
@@ -1247,7 +1247,7 @@ impl Tree {
     ///   Some(ret)
     /// }
     ///
-    /// db.set_merge_operator(concatenate_merge);
+    /// db.set_merge_operator(Box::new(concatenate_merge));
     ///
     /// let k = b"k1";
     ///
@@ -1270,10 +1270,10 @@ impl Tree {
     /// ```
     pub fn set_merge_operator(
         &self,
-        merge_operator: impl MergeOperator + 'static,
+        merge_operator: Box<dyn MergeOperator>,
     ) {
         let mut mo_write = self.merge_operator.write();
-        *mo_write = Some(Box::new(merge_operator));
+        *mo_write = Some(merge_operator);
     }
 
     /// Create a double-ended iterator over the tuples of keys and

--- a/tests/tree/mod.rs
+++ b/tests/tree/mod.rs
@@ -252,7 +252,7 @@ fn prop_tree_matches_btreemap_inner(
         .segment_size(256 * (1 << (segment_size_bits as usize % 16)));
 
     let mut tree = config.open().unwrap();
-    tree.set_merge_operator(merge_operator);
+    tree.set_merge_operator(Box::new(merge_operator));
 
     let mut reference: BTreeMap<Key, u16> = BTreeMap::new();
 
@@ -380,7 +380,7 @@ fn prop_tree_matches_btreemap_inner(
             Restart => {
                 drop(tree);
                 tree = config.open().unwrap();
-                tree.set_merge_operator(merge_operator);
+                tree.set_merge_operator(Box::new(merge_operator));
             }
         }
         if let Err(e) = config.global_error() {


### PR DESCRIPTION
# Motivation

I am writting a double-index ecs component storage, by wrap the sled api. 

```rust
// Define a merge function trait like MergeOperator, let my lib user to write the function
pub trait MergeFn: Fn(EID, Option<Value>, Delta) -> Option<Value> + Send + Sync{} 
```
I found that it is not possible to  insert a trait-object(`Rc<dyn MergeFn>` in my case) into a Tree as its merge_operator. Because the set_merge_operator function's signature is strict to a static implement.

I design a trait to let my user write there own closure, an wrap them into a `Rc<>`. Function pointer is also a workround but use triat object is encouraged by the Book, see more in [here](https://doc.rust-lang.org/book/ch19-05-advanced-functions-and-closures.html#function-pointers).

# PR content

- Just change the signature to a Box<...>.   
- All test cases related are changed.  
- `cargo test --features light_testing` are passed.

# 1 more thing
(Not include in this pr)

In my scanery, merge function is considered as `stateless`, so it's a `Fn` trait, instead `FnMut`, also the merge function is init at the beginning of the program, and never changed after that. So I think the mutex to protect the function isn't needed.  The merge function should be passed at the init pharse of the Tree when the program begin, and not protected by a Mutex.

## Pros

- No cost when set or call the merge function during run-time.
 
## Cons

- One tree can only hold one immutable merge function during its lifetime.
- User must impl their own inner-mutable data in the merge function. 
