### PR TITLE
Added xtensa architecture to cfg for atomic_shim

### DIFF
--- a/src/atomic_shim.rs
+++ b/src/atomic_shim.rs
@@ -3,10 +3,16 @@
 #[cfg(not(any(
     target_arch = "mips",
     target_arch = "powerpc",
+    target_arch = "xtensa",
     feature = "mutex"
 )))]
 pub use std::sync::atomic::{AtomicI64, AtomicU64};
-#[cfg(any(target_arch = "mips", target_arch = "powerpc", feature = "mutex"))]
+#[cfg(any(
+    target_arch = "mips",
+    target_arch = "powerpc",
+    target_arch = "xtensa",
+    feature = "mutex"
+))]
 mod shim {
     use parking_lot::{const_rwlock, RwLock};
     use std::sync::atomic::Ordering;


### PR DESCRIPTION
I am building an ereader project based on an xtensa board. I would like to use sled as a db, but it doesn't compile with the stable version 0.34.7.

xtensa architecture doesn't have 64bit atomics, so adjusted config to bring the shim versions of those types