### PR TITLE
tempdir is deprecated, use tempfile instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ fnv = "1.0.7"
 fault-injection = "1.0.10"
 crossbeam-queue = "0.3.8"
 crossbeam-channel = "0.5.8"
-tempdir = "0.3.7"
+tempfile = "3"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fault_injection::{annotate, fallible};
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use crate::Db;
 
@@ -66,7 +66,8 @@ impl Config {
     /// temporary directory that will be deleted when this `Config`
     /// is dropped.
     pub fn tmp() -> io::Result<Config> {
-        let tempdir = fallible!(tempdir::TempDir::new("sled_tmp"));
+        let tempdir =
+            fallible!(tempfile::Builder::new().prefix("sled_tmp").tempdir());
 
         Ok(Config {
             path: tempdir.path().into(),


### PR DESCRIPTION
tempdir is deprecated, use tempfile instead. And its dependency remove_dir_all = "0.5" has vulnerability.

https://github.com/XAMPPRocky/remove_dir_all/security/advisories/GHSA-mc8h-8q98-g5hr