### PR TITLE
Remove implicit `Sized` bound on `Tree::range` and others

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1163,7 +1163,7 @@ impl<const LEAF_FANOUT: usize> Tree<LEAF_FANOUT> {
 
     pub fn range<K, R>(&self, range: R) -> Iter<LEAF_FANOUT>
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + ?Sized,
         R: RangeBounds<K>,
     {
         let start: Bound<InlineArray> =
@@ -1711,7 +1711,7 @@ impl<const LEAF_FANOUT: usize> Tree<LEAF_FANOUT> {
         range: R,
     ) -> io::Result<Option<(InlineArray, InlineArray)>>
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + ?Sized,
         R: Clone + RangeBounds<K>,
     {
         loop {
@@ -1820,7 +1820,7 @@ impl<const LEAF_FANOUT: usize> Tree<LEAF_FANOUT> {
         range: R,
     ) -> io::Result<Option<(InlineArray, InlineArray)>>
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + ?Sized,
         R: Clone + RangeBounds<K>,
     {
         loop {


### PR DESCRIPTION
See issue #1497.

The type parameter `K` on the method `Tree::range` has an implicit `Sized` constraint, but it unnecessarily constrains the flexibility of the API. For example, it's not currently possible to call `Tree::range` with a range of `RangeBounds<[u8]>` as `[u8]` is not sized.

Similar reasoning applies to the other two methods of `Tree` that this PR adjusts in a similar fashion.