### PR TITLE
Update rand-distr to v0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ fs2 = "0.4.3"
 [dev-dependencies]
 rand = "0.7"
 rand_chacha = "0.3.1"
-rand_distr = "0.3"
+rand_distr = "0.4.3"
 quickcheck = "0.9"
 log = "0.4.14"
 env_logger = "0.9.0"


### PR DESCRIPTION
This PR updates rand-distr to 0.4.3 in order to be able to get sled as a
rust package in Fedora

Signed-off-by: Daniel Mellado <dmellado@redhat.com>