### PR TITLE
Update zerocopy to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ rand_distr = "0.3"
 quickcheck = "0.9"
 log = "0.4.14"
 env_logger = "0.9.0"
-zerocopy = "0.6.0"
+zerocopy = "0.7.0"
 byteorder = "1.4.3"
 
 [[test]]


### PR DESCRIPTION
This PR updates rand-distr to 0.7 in order to be able to get sled as a
rust package in Fedora

Signed-off-by: Daniel Mellado <dmellado@redhat.com>