### PR TITLE
Fix stale snapshot removal log message

### DIFF
--- a/src/metadata_store.rs
+++ b/src/metadata_store.rs
@@ -713,7 +713,7 @@ fn enumerate_logs_and_snapshot(
                 if let Some(snap_id) = snapshot {
                     if snap_id < id {
                         log::warn!(
-                            "removing stale snapshot {id} that is superceded by snapshot {id}"
+                            "removing stale snapshot {snap_id} that is superceded by snapshot {id}"
                         );
 
                         if let Err(e) = fs::remove_file(&file_name) {


### PR DESCRIPTION
## Summary

Corrects the warning when pruning a stale snapshot file: the message previously printed the same snapshot id twice because both placeholders used `{id}`. It now reports the removed stale snapshot (`snap_id`) and the superseding snapshot (`id`).

## Context

Small correctness fix for log output in `enumerate_logs_and_snapshot` (metadata store).